### PR TITLE
Update .gitignore to leave out .vscode and .cursor folders for personalization

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@ helix-importer-ui
 .DS_Store
 *.bak
 .idea
+.vscode
+.cursor


### PR DESCRIPTION
Just updating .gitignore so that when I personalize cursor settings locally they don't persist up to github for everyone. I prefer using different cursor themes per project to just visually set them apart. 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://git-ignore--idfc--aemsites.aem.page/
