### PR TITLE
Initial desktop header/nav functionality and styling

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -468,7 +468,7 @@ header nav .nav-sections ul>li>ul>li {
     align-items: center;
     margin: 0 auto;
     width: 100%;
-    max-width: 1440px;
+    max-width: 1140px;
   }
 
   .nav-tools .default-content-wrapper>p:first-child {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -38,10 +38,8 @@ header nav[aria-expanded="true"] {
 
 .header nav .nav-sections .default-content-wrapper>ul>li:first-child p {
   min-width: 70px;
-  height: 30px;
-  padding: 0 14px;
-  padding-left: 0;
-  padding-top: 6px;
+  height: 38px;
+  padding-right: 12px;
   font-weight: 400;
   font-size: 14px;
   line-height: 20px;
@@ -64,6 +62,18 @@ header nav[aria-expanded="true"] {
   padding: 9px 12px;
   display: inline-block;
   color: #0b0b0b;
+}
+
+.header nav .nav-sections .default-content-wrapper>ul>li:first-child a {
+  border-radius: 20px;
+  background: #FFF;
+  font-size: 14px;
+  line-height: 120%;
+  font-weight: normal;
+  padding: 12px;
+  display: inline-block;
+  color: #0b0b0b;
+  box-shadow: unset;
 }
 
 @media (width >=900px) {
@@ -271,14 +281,13 @@ header nav .nav-sections ul>li>ul>li {
     content: '';
     display: inline-block;
     position: absolute;
-    top: 35%;
+    top: 45%;
     right: 8px;
     transform: translateX(-50%);
     width: 8px;
     height: 8px;
     color: #da3442;
     border: 2px solid currentcolor;
-    border-radius: 0 1px 0 0;
     border-width: 2px 2px 0 0;
     rotate: 135deg;
   }
@@ -324,14 +333,28 @@ header nav .nav-sections ul>li>ul>li {
     display: block;
     position: absolute;
     width: 260px;
-    margin-top: 16px;
     padding: 12px 11px;
     white-space: initial;
     z-index: 99;
-    top: 20px;
+    top: 30px;
+    left: 5px;
     border-radius: 0 4px 8px 8px;
     background: #fff;
     box-shadow: 0 0 6.8px 0 rgb(0 0 0 / 25%);
+  }
+
+  header nav .nav-sections .default-content-wrapper>ul>li:first-child:hover>ul {
+    display: block;
+    position: absolute;
+    width: 180px;
+    padding: 12px 11px;
+    white-space: initial;
+    z-index: 99;
+    top: 38px;
+    left: 0;
+    border-radius: 10px;
+    background: #fff;
+    box-shadow: 0 0 2px 0 rgb(0 0 0 / 50%);
   }
 
   header nav .nav-sections .default-content-wrapper>ul>li:hover p a {
@@ -353,7 +376,8 @@ header nav .nav-sections ul>li>ul>li {
     height: 0;
     border-left: 8px solid transparent;
     border-right: 8px solid transparent;
-    border-bottom: 8px solid #f7f7f7;
+
+    /* border-bottom: 8px solid #f7f7f7; */
   }
 
   header nav .nav-sections .default-content-wrapper>ul>li>ul>li {
@@ -364,22 +388,32 @@ header nav .nav-sections ul>li>ul>li {
     border-bottom: 1px solid #f1f1f1;
   }
 
-  header nav .nav-sections .default-content-wrapper>ul>li>ul>li a:hover {
+  .header nav .nav-sections .default-content-wrapper>ul>li>ul>li:hover a {
     color: #9d1d27;
     font-weight: 700;
+    font-family: "Inter-bold";
     background: #f1f1f1;
     border-radius: 4px;
     display: block;
-    padding: 8px 12px;
+    padding: 12px;
   }
 
-  header nav .nav-sections .default-content-wrapper>ul>li:first-child>ul>li:first-child a {
+  /* header nav .nav-sections .default-content-wrapper>ul>li:first-child>ul>li:first-child a {
     color: #9d1d27;
     font-weight: 700;
     background: #f1f1f1;
     border-radius: 4px;
     display: block;
-    padding: 8px 12px;
+    padding: 12px;
+  } */
+
+  header nav .nav-sections .default-content-wrapper>ul>li:first-child>ul>li:first-child:hover a {
+    color: #9d1d27;
+    font-weight: 700;
+    background: #f1f1f1;
+    border-radius: 4px;
+    display: block;
+    padding: 12px;
   }
 
   /* Nav Tools Desktop */

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -3,21 +3,25 @@
 
 /* header and nav layout */
 header .nav-wrapper {
-  background-color: var(--background-color);
+  background-color: #fff;
   width: 100%;
   z-index: 2;
   position: fixed;
+  box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
+  top: 0;
+  left: 0;
 }
 
 header nav {
   box-sizing: border-box;
   display: grid;
   grid-template:
-    'brand cust-service hamburger' var(--nav-height) 'tools tools tools' 1fr / auto 1fr auto;
-  grid-template-columns: 1fr 1fr 0.3fr;
+    'hamburger brand' var(--nav-height)
+    'sections sections' 0fr
+    'tools tools' 0fr / auto 1fr;
   align-items: center;
   margin: auto;
-  max-width: 1248px;
+  max-width: 1440px;
   height: var(--nav-height);
   padding: 0 24px;
   font-family: var(--body-font-family);
@@ -25,11 +29,11 @@ header nav {
 
 header nav[aria-expanded="true"] {
   grid-template:
-    'hamburger brand' var(--nav-height) 'sections sections' 1fr
+    'hamburger brand' var(--nav-height)
+    'sections sections' 1fr
     'tools tools' var(--nav-height) / auto 1fr;
-  /* overflow-y: auto;
-  min-height: 100dvh; */
-  height: 160px;
+  overflow-y: auto;
+  min-height: 100dvh;
 }
 
 .header nav .nav-sections .default-content-wrapper>ul>li:first-child p {
@@ -63,43 +67,37 @@ header nav[aria-expanded="true"] {
 }
 
 @media (width >=900px) {
+  header .nav-wrapper {
+    position: relative;
+    height: auto;
+  }
+
   header nav {
     display: flex;
+    flex-wrap: wrap;
     justify-content: space-between;
-    gap: 0;
-    max-width: 1430px;
+    align-items: center;
+    gap: 16px;
+    max-width: 1440px;
     margin: 0 auto;
-    padding: 0 32px;
+    padding: 12px 32px;
+    height: auto;
+    min-height: auto;
+    overflow-y: visible;
   }
 
-  .sectionlast::after {
-    content: "";
-    position: absolute;
-    width: 152px;
-    height: 50px;
-    left: -149px;
-    background-color: #f5f5f5;
-    z-index: 0;
-    box-shadow: 0px 6px 6px -4px rgba(37, 36, 59, 0.1);
+  header nav[aria-expanded="true"] {
+    display: flex;
+    flex-wrap: wrap;
+    min-height: auto;
+    overflow-y: visible;
   }
-
-  .sectionlast::before {
-    content: "";
-    position: absolute;
-    width: 152px;
-    height: 50px;
-    right: -149px;
-    background-color: #f5f5f5;
-    z-index: 0;
-    box-shadow: 0px 6px 6px -4px rgba(37, 36, 59, 0.1);
-  }
-
 }
 
 header nav p {
   margin: 0;
   line-height: 1;
-  padding: 0px 4px;
+  padding: 0 4px;
 }
 
 header nav a:any-link {
@@ -194,14 +192,21 @@ header .nav-brand {
   font-size: var(--heading-font-size-s);
   font-weight: 700;
   line-height: 1;
+  flex-shrink: 0;
 }
 
 header nav .nav-brand img {
   width: 128px;
   height: auto;
+  display: block;
 }
 
 @media (width >=900px) {
+  header .nav-brand {
+    flex-basis: auto;
+    order: 1;
+  }
+
   header nav .nav-brand img {
     width: 101px;
     height: 36px;
@@ -241,14 +246,12 @@ header nav .nav-sections ul>li>ul>li {
 }
 
 @media (width >=900px) {
-  .nav-wrapper nav {
-    flex-wrap: wrap;
-  }
-
   header nav .nav-sections {
     display: block;
     visibility: visible;
     white-space: nowrap;
+    flex: 1 1 auto;
+    order: 2;
   }
 
   header nav[aria-expanded='true'] .nav-sections {
@@ -257,26 +260,14 @@ header nav .nav-sections ul>li>ul>li {
 
   header nav .nav-sections .nav-drop {
     position: relative;
-    /* padding-right: 16px; */
     cursor: pointer;
   }
 
   header nav .nav-sections .nav-drop:hover>p>a {
-    color: #0056b3;
+    color: #9d1d27;
   }
 
-  header nav .nav-sections .default-content-wrapper>ul>li.nav-drop:first-child:after {
-    /* content: '';
-    display: inline-block;
-    position: absolute;
-    top: 0.5em;
-    right: 2px;
-    transform: rotate(135deg);
-    width: 6px;
-    height: 6px;
-    border: 2px solid currentcolor;
-    border-radius: 0 1px 0 0;
-    border-width: 2px 2px 0 0; */
+  header nav .nav-sections .default-content-wrapper>ul>li.nav-drop:first-child::after {
     content: '';
     display: inline-block;
     position: absolute;
@@ -295,13 +286,12 @@ header nav .nav-sections ul>li>ul>li {
   header nav .nav-sections .nav-drop:hover::after {
     top: unset;
     bottom: 0.5em;
-    /* transform: rotate(315deg); */
     color: #981a1d;
   }
 
   header nav .nav-sections ul {
     display: flex;
-    gap: 24px;
+    gap: 16px;
     margin: 0;
     align-items: center;
   }
@@ -314,18 +304,9 @@ header nav .nav-sections ul>li>ul>li {
     color: #353535;
   }
 
-  header nav .nav-sections .default-content-wrapper>ul>li:nth-child(2) {
-    margin-left: auto;
-  }
-
   header nav .nav-sections .default-content-wrapper>ul>li>ul {
     display: none;
     position: absolute;
-  }
-
-  header nav .nav-sections .default-content-wrapper>ul>li:not(:first-child):hover>ul {
-    display: block;
-    top: 32px;
   }
 
   header nav .nav-sections .default-content-wrapper>ul>li:hover>ul {
@@ -333,49 +314,23 @@ header nav .nav-sections ul>li>ul>li {
     position: absolute;
     width: 260px;
     margin-top: 16px;
-    padding: 16px;
     padding: 12px 11px;
-    /* background-color: var(--light-color); */
     white-space: initial;
     z-index: 99;
     top: 20px;
-
+    border-radius: 0 4px 8px 8px;
+    background: #fff;
+    box-shadow: 0 0 6.8px 0 rgb(0 0 0 / 25%);
   }
 
   header nav .nav-sections .default-content-wrapper>ul>li:hover p a {
-    border-radius: 8px 8px 0px 0px;
+    border-radius: 8px 8px 0 0;
     background: #f7f7f7;
     height: 28px;
-    box-shadow: 0px -2px 3.1px 0px rgba(0, 0, 0, .25);
+    box-shadow: 0 -2px 3.1px 0 rgb(0 0 0 / 25%);
     color: #661213;
     font-weight: bold;
     cursor: pointer;
-  }
-
-  header nav .nav-sections .default-content-wrapper>ul>li:nth-child(4):hover p {
-    border-radius: 8px 8px 0px 0px;
-    background: #f7f7f7;
-    height: 28px;
-    box-shadow: 0px -2px 3.1px 0px rgba(0, 0, 0, .25);
-    color: #661213;
-    font-weight: bold;
-    cursor: pointer;
-  }
-
-  header nav .nav-sections .default-content-wrapper>ul>li:nth-child(5):hover p {
-    border-radius: 8px 8px 0px 0px;
-    background: #f7f7f7;
-    height: 28px;
-    box-shadow: 0px -2px 3.1px 0px rgba(0, 0, 0, .25);
-    color: #661213;
-    font-weight: bold;
-    cursor: pointer;
-  }
-
-  header nav .nav-sections .default-content-wrapper>ul>li>ul {
-    border-radius: 0px 4px 8px 8px;
-    background: #fff;
-    box-shadow: 0px 0px 6.8px 0px rgba(0, 0, 0, .25);
   }
 
   header nav .nav-sections .default-content-wrapper>ul>li>ul::before {
@@ -387,12 +342,10 @@ header nav .nav-sections ul>li>ul>li {
     height: 0;
     border-left: 8px solid transparent;
     border-right: 8px solid transparent;
-    border-bottom: 8px solid var(--light-color);
+    border-bottom: 8px solid #f7f7f7;
   }
 
   header nav .nav-sections .default-content-wrapper>ul>li>ul>li {
-    /* padding: 4px 0; */
-    /* padding: 12px 11px; */
     color: #353535;
     font-size: 14px;
     font-weight: 400;
@@ -400,12 +353,13 @@ header nav .nav-sections ul>li>ul>li {
     border-bottom: 1px solid #f1f1f1;
   }
 
-  header nav .nav-sections .default-content-wrapper>ul>li>ul>li :hover {
+  header nav .nav-sections .default-content-wrapper>ul>li>ul>li a:hover {
     color: #9d1d27;
     font-weight: 700;
     background: #f1f1f1;
     border-radius: 4px;
-    width: 100%;
+    display: block;
+    padding: 8px 12px;
   }
 
   header nav .nav-sections .default-content-wrapper>ul>li:first-child>ul>li:first-child a {
@@ -413,35 +367,48 @@ header nav .nav-sections ul>li>ul>li {
     font-weight: 700;
     background: #f1f1f1;
     border-radius: 4px;
-    width: 100%;
+    display: block;
+    padding: 8px 12px;
   }
 
-  .nav-tools {
-    flex-grow: 1;
-    flex-basis: 100%;
-  }
-
-  .sectionlast {
-    align-items: none;
-  }
-
-  .nav-tools>div>p:first-child {
+  /* Nav Tools Desktop */
+  header nav .nav-tools {
+    flex: 0 0 100%;
     display: flex;
     align-items: center;
-    border-radius: 19.5px;
+    order: 10;
+    padding-top: 12px;
+    margin-top: 12px;
+    border-top: 1px solid #e5e5e5;
+  }
+
+  .nav-tools .default-content-wrapper {
+    display: flex;
+    gap: 12px;
+    align-items: center;
+    margin: 0;
+    width: 100%;
+  }
+
+  .nav-tools .default-content-wrapper>p:first-child {
+    display: flex;
+    align-items: center;
+    border-radius: 20px;
     border: 1px solid #353535;
     background: #fff;
-    padding: 9px 10px 9px 23px;
-    width: 100%;
+    padding: 8px 16px;
     color: #3a3a3a;
-    font-size: 16px;
+    font-size: 14px;
     font-weight: 400;
     line-height: normal;
     box-sizing: border-box;
-    height: 40px;
+    min-width: 200px;
+    flex-grow: 1;
+    max-width: 400px;
+    margin-right: auto;
   }
 
-  .nav-tools>div>p:first-child>strong {
+  .nav-tools .default-content-wrapper>p:first-child>strong {
     margin-left: 8px;
     color: #3a3a3a;
     font-weight: 400;
@@ -449,22 +416,14 @@ header nav .nav-sections ul>li>ul>li {
   }
 
   .nav-tools .default-content-wrapper .icon-search {
-    width: 22px;
-    height: 22px;
+    width: 20px;
+    height: 20px;
   }
 
-  .nav-tools>div {
-    display: flex;
-    gap: 15px;
-    align-items: center;
-    margin: unset;
-  }
-
-  .nav-tools>div>p:nth-child(2) {
+  .nav-tools .default-content-wrapper>p:nth-child(2) {
     display: flex;
     align-items: center;
-    min-width: 70px;
-    padding: 7px 16px;
+    padding: 8px 16px;
     font-weight: 400;
     font-size: 13px;
     line-height: 20px;
@@ -472,85 +431,50 @@ header nav .nav-sections ul>li>ul>li {
     color: #353535;
     border: 1px solid #353535;
     border-radius: 50px;
-    background: rgba(0, 0, 0, 0);
-    margin-left: 15px;
-    width: 25%;
+    background: transparent;
+    white-space: nowrap;
   }
 
-  .nav-tools>div>p:nth-child(2) .icon-special {
+  .nav-tools .default-content-wrapper>p:nth-child(2) .icon-special {
     width: 17px;
     height: 17px;
-    margin-right: 0.5rem;
+    margin-right: 8px;
   }
 
-  .nav-tools>div>ul {
+  .nav-tools .default-content-wrapper>ul {
     display: flex;
-    gap: 15px;
-    padding: unset;
+    gap: 12px;
+    padding: 0;
+    margin: 0;
     list-style: none;
     align-items: center;
   }
 
-  .nav-tools>div>ul>li>ul {
-    list-style: none;
-    padding: unset;
-  }
-
-  .nav-tools>div>ul>li>ul {
-    list-style: none;
-    padding: unset;
-    display: none;
-    position: absolute;
-  }
-
-  .nav-tools>div>ul>li {
-    position: relative;
-
-  }
-
-  .nav-tools>div>ul>li:hover>ul {
-    display: block;
-    margin-top: 20px;
-    border-radius: 6px;
-    overflow: hidden;
-    box-shadow: 0 0 5px rgba(0, 0, 0, .2);
-    border: none;
-    left: auto;
-    background: #fff;
-    border: 1px solid #d9d9d9;
-    width: 500px;
-  }
-
-  .nav-tools>div>ul>li>p.button-container>a {
-    margin: unset;
-    min-width: 70px;
-    padding: 7px 16px;
+  .nav-tools .default-content-wrapper>ul>li {
+    padding: 8px 16px;
     font-weight: 400;
-    font-size: 14px;
+    font-size: 13px;
     line-height: 20px;
     letter-spacing: -0.6px;
     color: #353535;
     border: 1px solid #353535;
     border-radius: 50px;
-    background: rgba(0, 0, 0, 0);
+    background: transparent;
+    white-space: nowrap;
+    cursor: pointer;
   }
 
-  .nav-tools>div>ul>li:not(:first-child)>p {
-    min-width: 92px;
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-    padding: 8px 16px;
-    font-weight: 500;
-    font-size: 14px;
+  .nav-tools .default-content-wrapper>ul>li:last-child {
     color: #fff;
     background-color: #902a2c;
-    margin-left: 12px;
-    border-radius: 25px;
+    border-color: #902a2c;
+    display: flex;
+    align-items: center;
+    gap: 8px;
   }
 
-  .nav-tools>div>ul>li:not(:first-child)>p .icon-login_header {
-    width: 15px;
+  .nav-tools .default-content-wrapper .icon-login_header {
+    width: 14px;
     height: 14px;
   }
 }
@@ -718,9 +642,13 @@ header nav .nav-sections ul>li>ul>li {
 /* tools */
 header nav .nav-tools {
   grid-area: tools;
-  max-width: 1230px;
-  margin: 0 auto;
-  padding-bottom: 0.5rem;
+}
+
+@media (width < 900px) {
+  header nav .nav-tools {
+    display: none;
+    visibility: hidden;
+  }
 }
 
 .login-bx .login-top .tab-pane {
@@ -762,98 +690,4 @@ header nav .nav-tools {
   .login-bx .login-top .tab-pane .btn-box .btn-white {
     line-height: 46px
   }
-}
-
-.sectionlast {
-  position: relative;
-  background: #f5f5f5;
-  padding: 0 70px;
-  height: 50px;
-  align-items: center;
-  width: 100%;
-  box-shadow: 0px 4px 8px rgba(37, 36, 59, .1);
-  display: flex;
-  justify-content: space-between;
-}
-
-.nav-tools>div>ul>li:first-child {
-  border: 1px solid #353535;
-  border-radius: 50px;
-  background: rgba(0, 0, 0, 0);
-  margin-left: 3px;
-  align-items: center;
-  min-width: 150px;
-  padding: 0px 40px;
-  font-weight: 400;
-  font-size: 13px;
-  line-height: 19px;
-  letter-spacing: -0.6px;
-  padding: 7px 22px;
-  height: fit-content;
-}
-
-.nav-tools>div>ul>li:last-child {
-  display: flex;
-  min-width: 101px;
-  padding: 7px 22px;
-  font-weight: 500;
-  font-size: 14px;
-  color: #fff;
-  background-color: #902a2c;
-  border-radius: 50px;
-  justify-content: space-between;
-  align-items: center;
-}
-
-.icon-login_header {
-  height: 15px;
-  width: 14px;
-}
-
-.all-drop-down .grdiantCard a .title span {
-  width: 18px;
-  height: 18px;
-  -ms-flex-negative: 0;
-  flex-shrink: 0;
-  border-radius: 20px;
-  box-shadow: 0px 1px 2.5px rgba(145, 42, 44, .24);
-  top: 0;
-  position: relative;
-}
-
-.grdiantCard a span {
-  background: #fff;
-  border-radius: 50%;
-  height: 30px;
-  width: 30px;
-  display: -ms-flexbox;
-  display: flex;
-  -ms-flex-align: center;
-  align-items: center;
-  -ms-flex-pack: center;
-  justify-content: center;
-}
-
-.grdiantCard .title {
-  display: flex;
-  justify-content: space-between;
-  width: 100%;
-}
-
-.header nav .nav-sections .default-content-wrapper>ul>li:nth-child(6)>ul {
-  top: 28px;
-  right: 0px;
-  /* width: 300px; */
-}
-
-.header nav .nav-sections .default-content-wrapper>ul>li:nth-child(6)>ul::before {
-  content: '';
-  position: absolute;
-  top: -5px;
-  left: 140px;
-  width: 20px;
-  height: 0;
-  border-left: 8px solid transparent;
-  border-right: 8px solid transparent;
-  border-bottom: 8px solid var(--light-color);
 }

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -77,23 +77,30 @@ header nav[aria-expanded="true"] {
 }
 
 @media (width >=900px) {
+  /* Header wrapper is now a container for both nav and secondary navbar */
   header .nav-wrapper {
-    position: relative;
+    position: fixed;
+    top: 0;
+    left: 0;
+    width: 100%;
     height: auto;
+    z-index: 1000;
+    transition: all 0.3s ease;
+    background-color: #fff;
   }
 
   header nav {
     display: flex;
     flex-wrap: wrap;
-    justify-content: space-between;
     align-items: center;
     gap: 16px;
-    max-width: 1440px;
+    max-width: unset;
     margin: 0 auto;
-    padding: 12px 32px;
+    padding: 12px 70px;
     height: auto;
     min-height: auto;
     overflow-y: visible;
+    transition: padding 0.3s ease;
   }
 
   header nav[aria-expanded="true"] {
@@ -101,6 +108,38 @@ header nav[aria-expanded="true"] {
     flex-wrap: wrap;
     min-height: auto;
     overflow-y: visible;
+  }
+
+  /* Scrolled state - collapsed header */
+  header .nav-wrapper.scrolled nav {
+    padding: 8px 70px;
+    flex-wrap: nowrap;
+    gap: 24px;
+  }
+
+  /* Hide nav-sections menu items when scrolled (but keep the brand) */
+  header .nav-wrapper.scrolled .nav-sections {
+    display: none !important;
+    visibility: hidden !important;
+  }
+
+  /* Adjust nav-tools to take full width minus logo when scrolled */
+  header .nav-wrapper.scrolled .nav-tools {
+    flex: 1 1 auto;
+    order: 2;
+    padding-top: 0;
+    margin-top: 0;
+    border-top: none;
+  }
+
+  /* Adjust brand positioning when scrolled */
+  header .nav-wrapper.scrolled .nav-brand {
+    order: 1;
+  }
+
+  /* Secondary navbar inside header wrapper */
+  header .nav-wrapper .secondary-navbar-wrapper {
+    width: 100%;
   }
 }
 
@@ -262,6 +301,7 @@ header nav .nav-sections ul>li>ul>li {
     white-space: nowrap;
     flex: 1 1 auto;
     order: 2;
+    max-width: 100%;
   }
 
   header nav[aria-expanded='true'] .nav-sections {
@@ -306,12 +346,7 @@ header nav .nav-sections ul>li>ul>li {
     width: 100%;
   }
 
-  /* First nav item (Personal) stays on left */
-  header nav .nav-sections .default-content-wrapper>ul>li:first-child {
-    margin-right: auto;
-  }
-
-  /* Second nav item starts the right-aligned group */
+  /* Second nav item (Explore Personal Banking) starts the right-aligned group */
   header nav .nav-sections .default-content-wrapper>ul>li:nth-child(2) {
     margin-left: auto;
   }
@@ -424,15 +459,16 @@ header nav .nav-sections ul>li>ul>li {
     order: 10;
     padding-top: 12px;
     margin-top: 12px;
-    border-top: 1px solid #e5e5e5;
+    width: 100%;
   }
 
   .nav-tools .default-content-wrapper {
     display: flex;
     gap: 12px;
     align-items: center;
-    margin: 0;
+    margin: 0 auto;
     width: 100%;
+    max-width: 1440px;
   }
 
   .nav-tools .default-content-wrapper>p:first-child {

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -203,7 +203,7 @@ header nav .nav-brand img {
 
 @media (width >=900px) {
   header .nav-brand {
-    flex-basis: auto;
+    flex: 0 0 auto;
     order: 1;
   }
 
@@ -294,6 +294,17 @@ header nav .nav-sections ul>li>ul>li {
     gap: 16px;
     margin: 0;
     align-items: center;
+    width: 100%;
+  }
+
+  /* First nav item (Personal) stays on left */
+  header nav .nav-sections .default-content-wrapper>ul>li:first-child {
+    margin-right: auto;
+  }
+
+  /* Second nav item starts the right-aligned group */
+  header nav .nav-sections .default-content-wrapper>ul>li:nth-child(2) {
+    margin-left: auto;
   }
 
   header nav .nav-sections .default-content-wrapper>ul>li {

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -302,4 +302,38 @@ export default async function decorate(block) {
   navWrapper.className = 'nav-wrapper';
   navWrapper.append(nav);
   block.append(navWrapper);
+
+  // Add scroll behavior for collapsing header
+  let lastScrollTop = 0;
+  const scrollThreshold = 50; // Pixels to scroll before collapsing
+
+  function handleScroll() {
+    const scrollTop = window.pageYOffset || document.documentElement.scrollTop;
+    
+    if (scrollTop > scrollThreshold) {
+      navWrapper.classList.add('scrolled');
+    } else {
+      navWrapper.classList.remove('scrolled');
+    }
+    
+    lastScrollTop = scrollTop;
+  }
+
+  // Only apply scroll behavior on desktop
+  if (isDesktop.matches) {
+    window.addEventListener('scroll', handleScroll, { passive: true });
+    // Initial call to set proper position
+    handleScroll();
+  }
+
+  // Handle resize to add/remove scroll listener
+  isDesktop.addEventListener('change', () => {
+    if (isDesktop.matches) {
+      window.addEventListener('scroll', handleScroll, { passive: true });
+      handleScroll(); // Call immediately on resize to desktop
+    } else {
+      window.removeEventListener('scroll', handleScroll);
+      navWrapper.classList.remove('scrolled');
+    }
+  });
 }

--- a/blocks/header/nav-pane.css
+++ b/blocks/header/nav-pane.css
@@ -1268,7 +1268,9 @@ header.d-lg-none .top-nav-right ul li:last-child {
 }
 
 .top-nav.bg-light-white {
-    padding: 0 70px
+    padding: 0 70px;
+    background-color: #F5F5F5;
+
 }
 
 @media(max-width: 1024px) {

--- a/blocks/header/nav-pane.css
+++ b/blocks/header/nav-pane.css
@@ -1263,12 +1263,13 @@ header.d-lg-none .top-nav-right ul li:last-child {
     display: flex;
     -ms-flex-align: center;
     align-items: center;
-    padding: 9px 65px;
+    
+    /* padding: 9px 65px; */
     background: #fff
 }
 
 .top-nav.bg-light-white {
-    padding: 0 70px;
+    /* padding: 0 70px; */
     background-color: #F5F5F5;
 
 }
@@ -1364,7 +1365,7 @@ header.d-lg-none .top-nav-right ul li:last-child {
 
 .top-nav .top-nav-left .dropdown-content {
     left: 0;
-    top: 45px
+    top: 51px
 }
 
 .top-nav .top-nav-left .dropdown-content.menu-cardList-cnt {

--- a/blocks/secondary-navbar/secondary-navbar.css
+++ b/blocks/secondary-navbar/secondary-navbar.css
@@ -18,8 +18,8 @@
 /* Inner container - matches header nav exactly */
 .tabs-pane-js {
   max-width: 1440px;
-  margin: 0 auto;
-  padding: 0 32px;
+  position: relative;
+  left: 70px;
   box-sizing: border-box;
 }
 
@@ -73,9 +73,10 @@
   position: absolute;
   top: 100%;
   left: 50%;
-  transform: translateX(-50%);
+
+  /* transform: translateX(-50%); */
   margin-top: 8px;
-  border-radius: 8px;
+  border-radius: 0 8px 8px;
   box-shadow: 0 4px 16px rgb(0 0 0 / 12%);
   background: #fff;
   border: 1px solid #e0e0e0;

--- a/blocks/secondary-navbar/secondary-navbar.css
+++ b/blocks/secondary-navbar/secondary-navbar.css
@@ -1,125 +1,282 @@
-/* stylelint-disable */
-.secondary-navbar {
-  position: sticky;
-  top: 0;
-  z-index: 2;
-  background-color: #fff;
+/* Top Navigation (L2 Nav) - Third row */
+.top-nav {
+  background: #f5f5f5;
+  box-shadow: 0 4px 8px rgb(37 36 59 / 10%);
+  position: relative;
+  width: 100%;
+}
+
+.tabs-pane-js {
+  max-width: 1440px;
+  margin: 0 auto;
+  padding: 0 32px;
+}
+
+.tab-pane {
+  display: none;
+}
+
+.tab-pane.active {
+  display: block;
+}
+
+.top-nav-left {
+  display: flex;
+  gap: 40px;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  align-items: center;
+}
+
+.top-nav-left > li {
+  position: relative;
+  padding: 16px 0;
+}
+
+.top-nav-left > li > a {
+  color: #353535;
+  font-size: 14px;
+  font-weight: 400;
+  line-height: 20px;
+  text-decoration: none;
+  cursor: pointer;
+  white-space: nowrap;
+}
+
+.top-nav-left > li > a:hover {
+  color: #9d1d27;
+  font-weight: 500;
+}
+
+/* Dropdown Styles */
+.drop-down {
+  cursor: pointer;
+}
+
+.dropdown-content {
+  display: none;
+  position: absolute;
+  top: 100%;
+  left: 0;
+  margin-top: 20px;
+  border-radius: 6px;
+  overflow: hidden;
+  box-shadow: 0 0 5px rgb(0 0 0 / 20%);
+  background: #fff;
+  border: 1px solid #d9d9d9;
+  min-width: 760px;
+  max-height: 290px;
+  overflow-y: auto;
+  z-index: 1000;
+}
+
+.drop-down:hover > .dropdown-content {
+  display: block;
+}
+
+/* Header Box */
+.hd-bx {
+  padding: 20px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  gap: 1rem;
-  overflow-x: auto;
-  background: #FFFFFF;
-  padding: 0 1rem;
+  border-bottom: 1px solid #f1f1f1;
 }
 
-.secondary-nav-links {
-  flex: 1 1 auto;
-  display: flex;
-  flex-wrap: nowrap;
-  overflow-x: auto;
-  gap: 3.5rem;
-  scrollbar-width: none;
+.hd-bx-h4 {
+  margin: 0;
+  font-size: 16px;
+  font-weight: 600;
+  color: #353535;
 }
-.secondary-nav-links::-webkit-scrollbar {
-  display: none;
-}
-.secondary-nav-cta-wrapper {
-  flex-shrink: 0;
-  margin-left: auto;
-}
-/* Base nav item */
-.secondary-nav-item {
-  font-weight: 400;
-  color: #25243B !important;
-  font-size: 17px;
-  line-height: 20px;
-  letter-spacing: -0.5px;
-  padding: 25px 0px 20px;
-  text-decoration: none;
-  position: relative;
-  display: inline-block;
-  white-space: nowrap;
-  transition: font-weight 0.2s ease;
-}
-.secondary-nav-item:hover {
+
+.hd-bx .link {
+  color: #9d1d27;
+  font-size: 14px;
   text-decoration: none;
   font-weight: 500;
 }
-.secondary-nav-item:hover::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  height: 3px;
-  width: 100%;
-  background-color: #9D1D27;
-  transition: all 0.3s ease;
-}
-/* CTA Button */
-.secondary-nav-cta {
-  display: inline-block;
-    color: rgb(255, 255, 255) !important;
-    text-align: center;
-    font-size: 16px;
-    font-weight: 500;
-    letter-spacing: -0.5px;
-    line-height: 22px;
-    padding: 12px 30px;
-    border-radius: 25px;
-    background: rgb(157, 29, 39);
-    white-space: nowrap;
-}
-.secondary-nav-cta:hover {
-  background-color: #A01313;
-  text-decoration: none !important;
-  border: none;
-}
-.secondary-nav-item.secondary-nav-cta:hover::after {
-  display: none;
-}
-/* Responsive for mobile */
-@media (max-width: 768px) {
-  .secondary-navbar {
-    flex-wrap: nowrap;
-    justify-content: flex-start;
-    overflow-x: auto;
-  }
-  .secondary-nav-links {
-    flex: 1 1 100%;
-    gap: 2rem;
-    scroll-behavior: smooth;
-    -webkit-overflow-scrolling: touch;
-  }
-  .secondary-nav-cta-wrapper {
-    display: none; /* Hide CTA on mobile */
-  }
-}
-/* .secondary-nav-item.active::after {
-  content: "";
-  position: absolute;
-  bottom: 0;
-  left: 0;
-  height: 3px;
-  width: 100%;
-  background-color: #9D1D27;
-  transition: all 0.3s ease;
-} */
-.secondary-nav-links {
-  position: relative; /* For the sliding indicator */
+
+.hd-bx .link:hover {
+  text-decoration: underline;
 }
 
-.nav-indicator {
-  position: absolute;
-  bottom: 0;
-  height: 3px;
-  background-color: #9D1D27;
-  transition: transform 0.3s ease, width 0.3s ease;
-  will-change: transform, width;
-  z-index: 1;
+/* Menu Card List */
+.menu-cardList {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 12px;
+  padding: 20px;
 }
 
-.secondary-nav-item::after,
-.secondary-nav-item.active::after {
-  content: none !important; /* Disable built-in underline */
+.menu-cardList.MT15 {
+  margin-top: 0;
+}
+
+/* Gradient Cards */
+.grdiantCard {
+  flex: 0 0 calc(50% - 6px);
+  min-width: 0;
+}
+
+.grdiantCard a {
+  display: block;
+  padding: 16px;
+  border-radius: 8px;
+  background: linear-gradient(135deg, #f8f8f8 0%, #fff 100%);
+  border: 1px solid #e5e5e5;
+  text-decoration: none;
+  transition: all 0.3s ease;
+}
+
+.grdiantCard a:hover {
+  border-color: #9d1d27;
+  box-shadow: 0 4px 12px rgb(157 29 39 / 15%);
+  transform: translateY(-2px);
+}
+
+/* Card Tags */
+.tags {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 12px;
+  flex-wrap: wrap;
+}
+
+.tag {
+  padding: 4px 8px;
+  border-radius: 4px;
+  font-size: 11px;
+  font-weight: 500;
+  color: #fff;
+}
+
+.tag.tgclr1 { background-color: #9d1d27; }
+.tag.tgclr2 { background-color: #4caf50; }
+.tag.tgclr3 { background-color: #ff9800; }
+.tag.tgclr4 { background-color: #2196f3; }
+.tag.tgclr5 { background-color: #9c27b0; }
+.tag.tgclr6 { background-color: #00bcd4; }
+.tag.tgclr7 { background-color: #8bc34a; }
+.tag.tgclr8 { background-color: #ff5722; }
+
+/* Card Title */
+.grdiantCard .title {
+  display: flex;
+  justify-content: space-between;
+  align-items: center;
+  color: #353535;
+  font-size: 14px;
+  font-weight: 500;
+  line-height: 1.4;
+}
+
+.grdiantCard a:hover .title {
+  color: #9d1d27;
+}
+
+/* Icon Right Arrow */
+.icon-Right {
+  width: 18px;
+  height: 18px;
+  flex-shrink: 0;
+  border-radius: 50%;
+  background: #fff;
+  box-shadow: 0 1px 2.5px rgb(145 42 44 / 24%);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  position: relative;
+}
+
+.icon-Right::after {
+  content: '';
+  display: block;
+  width: 6px;
+  height: 6px;
+  border-right: 2px solid #9d1d27;
+  border-bottom: 2px solid #9d1d27;
+  transform: rotate(-45deg);
+}
+
+/* Gradient Card Variants */
+.grdiantCard.grdP1 a {
+  background: linear-gradient(135deg, #fff5f5 0%, #fff 100%);
+}
+
+.grdiantCard.grdP2 a {
+  background: linear-gradient(135deg, #fff8e1 0%, #fff 100%);
+}
+
+.grdiantCard.grdP3 a {
+  background: linear-gradient(135deg, #f3e5f5 0%, #fff 100%);
+}
+
+.grdiantCard.grdP4 a {
+  background: linear-gradient(135deg, #e8f5e9 0%, #fff 100%);
+}
+
+.grdiantCard.grdSelect a {
+  background: linear-gradient(135deg, #e3f2fd 0%, #fff 100%);
+}
+
+.grdiantCard.grdWealth a {
+  background: linear-gradient(135deg, #fff3e0 0%, #fff 100%);
+}
+
+.grdiantCard.grdPrivate a {
+  background: linear-gradient(135deg, #fce4ec 0%, #fff 100%);
+}
+
+/* Mobile Responsiveness */
+@media (width < 900px) {
+  .top-nav {
+    display: none;
+  }
+}
+
+@media (width >= 900px) and (width < 1200px) {
+  .dropdown-content {
+    min-width: 550px;
+  }
+  
+  .top-nav-left {
+    gap: 24px;
+  }
+}
+
+/* Animation */
+.animated.fadeIn {
+  animation: fade-in 0.3s ease-in-out;
+}
+
+@keyframes fade-in {
+  from {
+    opacity: 0;
+    transform: translateY(-10px);
+  }
+
+  to {
+    opacity: 1;
+    transform: translateY(0);
+  }
+}
+
+/* Scrollbar for dropdown */
+.dropdown-content::-webkit-scrollbar {
+  width: 6px;
+}
+
+.dropdown-content::-webkit-scrollbar-track {
+  background: #f1f1f1;
+}
+
+.dropdown-content::-webkit-scrollbar-thumb {
+  background: #9d1d27;
+  border-radius: 3px;
+}
+
+.dropdown-content::-webkit-scrollbar-thumb:hover {
+  background: #7a1620;
 }

--- a/blocks/secondary-navbar/secondary-navbar.css
+++ b/blocks/secondary-navbar/secondary-navbar.css
@@ -1,15 +1,27 @@
+/* stylelint-disable selector-class-pattern, no-descending-specificity */
+
+/* Secondary Navbar Wrapper - full width gray background */
+.secondary-navbar-wrapper {
+  width: 100%;
+  position: relative;
+  z-index: 99;
+  background: #f7f7f7;
+  border-top: 1px solid #e5e5e5;
+}
+
 /* Top Navigation (L2 Nav) - Third row */
 .top-nav {
-  background: #f5f5f5;
-  box-shadow: 0 4px 8px rgb(37 36 59 / 10%);
+  background: transparent;
   position: relative;
   width: 100%;
 }
 
+/* Inner container - matches header nav exactly */
 .tabs-pane-js {
   max-width: 1440px;
   margin: 0 auto;
   padding: 0 32px;
+  box-sizing: border-box;
 }
 
 .tab-pane {
@@ -20,33 +32,36 @@
   display: block;
 }
 
+/* Navigation list */
 .top-nav-left {
   display: flex;
-  gap: 40px;
+  gap: 48px;
   list-style: none;
   margin: 0;
   padding: 0;
   align-items: center;
+  justify-content: flex-start;
+  box-sizing: border-box;
 }
 
 .top-nav-left > li {
   position: relative;
-  padding: 16px 0;
+  padding: 14px 0;
 }
 
 .top-nav-left > li > a {
-  color: #353535;
-  font-size: 14px;
+  color: #333;
+  font-size: 13px;
   font-weight: 400;
-  line-height: 20px;
+  line-height: 18px;
   text-decoration: none;
   cursor: pointer;
   white-space: nowrap;
+  transition: color 0.2s ease;
 }
 
 .top-nav-left > li > a:hover {
   color: #9d1d27;
-  font-weight: 500;
 }
 
 /* Dropdown Styles */
@@ -58,15 +73,15 @@
   display: none;
   position: absolute;
   top: 100%;
-  left: 0;
-  margin-top: 20px;
-  border-radius: 6px;
-  overflow: hidden;
-  box-shadow: 0 0 5px rgb(0 0 0 / 20%);
+  left: 50%;
+  transform: translateX(-50%);
+  margin-top: 8px;
+  border-radius: 8px;
+  box-shadow: 0 4px 16px rgb(0 0 0 / 12%);
   background: #fff;
-  border: 1px solid #d9d9d9;
-  min-width: 760px;
-  max-height: 290px;
+  border: 1px solid #e0e0e0;
+  min-width: 720px;
+  max-height: 320px;
   overflow-y: auto;
   z-index: 1000;
 }
@@ -77,23 +92,24 @@
 
 /* Header Box */
 .hd-bx {
-  padding: 20px;
+  padding: 18px 24px;
   display: flex;
   justify-content: space-between;
   align-items: center;
-  border-bottom: 1px solid #f1f1f1;
+  border-bottom: 1px solid #f0f0f0;
+  background: #fafafa;
 }
 
 .hd-bx-h4 {
   margin: 0;
-  font-size: 16px;
+  font-size: 15px;
   font-weight: 600;
-  color: #353535;
+  color: #333;
 }
 
 .hd-bx .link {
   color: #9d1d27;
-  font-size: 14px;
+  font-size: 13px;
   text-decoration: none;
   font-weight: 500;
 }
@@ -106,8 +122,8 @@
 .menu-cardList {
   display: flex;
   flex-wrap: wrap;
-  gap: 12px;
-  padding: 20px;
+  gap: 10px;
+  padding: 20px 24px;
 }
 
 .menu-cardList.MT15 {
@@ -116,24 +132,24 @@
 
 /* Gradient Cards */
 .grdiantCard {
-  flex: 0 0 calc(50% - 6px);
+  flex: 0 0 calc(50% - 5px);
   min-width: 0;
 }
 
 .grdiantCard a {
   display: block;
-  padding: 16px;
-  border-radius: 8px;
-  background: linear-gradient(135deg, #f8f8f8 0%, #fff 100%);
-  border: 1px solid #e5e5e5;
+  padding: 14px 16px;
+  border-radius: 6px;
+  background: #fff;
+  border: 1px solid #e8e8e8;
   text-decoration: none;
-  transition: all 0.3s ease;
+  transition: all 0.2s ease;
 }
 
 .grdiantCard a:hover {
   border-color: #9d1d27;
-  box-shadow: 0 4px 12px rgb(157 29 39 / 15%);
-  transform: translateY(-2px);
+  box-shadow: 0 2px 8px rgb(157 29 39 / 10%);
+  transform: translateY(-1px);
 }
 
 /* Card Tags */
@@ -166,95 +182,93 @@
   display: flex;
   justify-content: space-between;
   align-items: center;
-  color: #353535;
-  font-size: 14px;
-  font-weight: 500;
-  line-height: 1.4;
+  color: #333;
+  font-size: 13px;
+  font-weight: 400;
+  line-height: 1.5;
 }
 
 .grdiantCard a:hover .title {
   color: #9d1d27;
+  font-weight: 500;
 }
 
 /* Icon Right Arrow */
 .icon-Right {
-  width: 18px;
-  height: 18px;
+  width: 16px;
+  height: 16px;
   flex-shrink: 0;
   border-radius: 50%;
-  background: #fff;
-  box-shadow: 0 1px 2.5px rgb(145 42 44 / 24%);
+  background: #f5f5f5;
+  box-shadow: 0 1px 3px rgb(0 0 0 / 8%);
   display: flex;
   align-items: center;
   justify-content: center;
   position: relative;
+  transition: all 0.2s ease;
+}
+
+.grdiantCard a:hover .icon-Right {
+  background: #9d1d27;
+  box-shadow: 0 2px 4px rgb(157 29 39 / 20%);
 }
 
 .icon-Right::after {
   content: '';
   display: block;
-  width: 6px;
-  height: 6px;
-  border-right: 2px solid #9d1d27;
-  border-bottom: 2px solid #9d1d27;
+  width: 5px;
+  height: 5px;
+  border-right: 1.5px solid #666;
+  border-bottom: 1.5px solid #666;
   transform: rotate(-45deg);
+  transition: border-color 0.2s ease;
 }
 
-/* Gradient Card Variants */
-.grdiantCard.grdP1 a {
-  background: linear-gradient(135deg, #fff5f5 0%, #fff 100%);
+.grdiantCard a:hover .icon-Right::after {
+  border-color: #fff;
 }
 
-.grdiantCard.grdP2 a {
-  background: linear-gradient(135deg, #fff8e1 0%, #fff 100%);
-}
-
-.grdiantCard.grdP3 a {
-  background: linear-gradient(135deg, #f3e5f5 0%, #fff 100%);
-}
-
-.grdiantCard.grdP4 a {
-  background: linear-gradient(135deg, #e8f5e9 0%, #fff 100%);
-}
-
-.grdiantCard.grdSelect a {
-  background: linear-gradient(135deg, #e3f2fd 0%, #fff 100%);
-}
-
-.grdiantCard.grdWealth a {
-  background: linear-gradient(135deg, #fff3e0 0%, #fff 100%);
-}
-
+/* Gradient Card Variants - subtle backgrounds */
+.grdiantCard.grdP1 a,
+.grdiantCard.grdP2 a,
+.grdiantCard.grdP3 a,
+.grdiantCard.grdP4 a,
+.grdiantCard.grdSelect a,
+.grdiantCard.grdWealth a,
 .grdiantCard.grdPrivate a {
-  background: linear-gradient(135deg, #fce4ec 0%, #fff 100%);
+  background: #fff;
 }
 
 /* Mobile Responsiveness */
 @media (width < 900px) {
-  .top-nav {
+  .secondary-navbar-wrapper {
     display: none;
   }
 }
 
 @media (width >= 900px) and (width < 1200px) {
   .dropdown-content {
-    min-width: 550px;
+    min-width: 600px;
   }
-  
+
   .top-nav-left {
-    gap: 24px;
+    gap: 32px;
+  }
+
+  .tabs-pane-js {
+    padding: 0 24px;
   }
 }
 
 /* Animation */
 .animated.fadeIn {
-  animation: fade-in 0.3s ease-in-out;
+  animation: fade-in 0.25s ease-out;
 }
 
 @keyframes fade-in {
   from {
     opacity: 0;
-    transform: translateY(-10px);
+    transform: translateY(-8px);
   }
 
   to {
@@ -265,18 +279,19 @@
 
 /* Scrollbar for dropdown */
 .dropdown-content::-webkit-scrollbar {
-  width: 6px;
+  width: 5px;
 }
 
 .dropdown-content::-webkit-scrollbar-track {
-  background: #f1f1f1;
+  background: #f5f5f5;
+  border-radius: 3px;
 }
 
 .dropdown-content::-webkit-scrollbar-thumb {
-  background: #9d1d27;
+  background: #ccc;
   border-radius: 3px;
 }
 
 .dropdown-content::-webkit-scrollbar-thumb:hover {
-  background: #7a1620;
+  background: #9d1d27;
 }

--- a/blocks/secondary-navbar/secondary-navbar.css
+++ b/blocks/secondary-navbar/secondary-navbar.css
@@ -4,7 +4,6 @@
 .secondary-navbar-wrapper {
   width: 100%;
   position: relative;
-  z-index: 99;
   background: #f7f7f7;
   border-top: 1px solid #e5e5e5;
 }

--- a/blocks/secondary-navbar/secondary-navbar.js
+++ b/blocks/secondary-navbar/secondary-navbar.js
@@ -1,85 +1,207 @@
-export default function decorate(block) {
-  const items = [...block.children];
-  const navWrapper = document.createElement('div');
-  navWrapper.classList.add('secondary-nav-links');
-  navWrapper.style.position = 'relative'; // Ensure indicator positions properly
+/**
+ * Top Navigation (L2 Nav) - Third row navigation with dropdowns
+ * Extracts content from page section with class "mid-banner"
+ */
 
-  const ctaWrapper = document.createElement('div');
-  ctaWrapper.classList.add('secondary-nav-cta-wrapper');
+/**
+ * Build a card from a list item
+ */
+function buildCard(item) {
+  const card = document.createElement('div');
+  card.classList.add('grdiantCard', 'grdP1');
 
-  const sectionLinks = [];
+  const link = item.querySelector('a');
+  if (!link) {
+    // Handle items without links (plain text)
+    const cardText = document.createElement('div');
+    cardText.classList.add('title');
+    cardText.textContent = item.textContent.trim();
+    card.appendChild(cardText);
+    return card;
+  }
 
-  // Create shared underline indicator
-  const indicator = document.createElement('div');
-  indicator.classList.add('nav-indicator');
-  navWrapper.appendChild(indicator);
+  const cardLink = document.createElement('a');
+  cardLink.href = link.getAttribute('href') || '#';
+  cardLink.setAttribute('data-gtm-desk-l3cards-click', '');
 
-  items.forEach((row) => {
-    const href = row.querySelector('.button-container a')?.getAttribute('href') || '#';
-    const linkTitle = row.querySelectorAll('div')[1]?.textContent?.trim() || '';
-    const linkType = row.querySelectorAll('div')[2]?.textContent?.trim();
+  // Tags container (hidden by default for this structure)
+  const tagsContainer = document.createElement('div');
+  tagsContainer.classList.add('tags');
+  tagsContainer.style.display = 'none';
+  cardLink.appendChild(tagsContainer);
 
-    if (href && linkTitle) {
-      const a = document.createElement('a');
-      a.href = href;
-      a.textContent = linkTitle;
-      a.classList.add('secondary-nav-item');
+  // Card title
+  const title = document.createElement('div');
+  title.classList.add('title');
+  title.textContent = link.textContent.trim();
 
-      if (href.startsWith('#')) {
-        sectionLinks.push({ id: href.slice(1), linkEl: a });
-      }
+  const iconSpan = document.createElement('span');
+  iconSpan.classList.add('icon-Right');
+  title.appendChild(iconSpan);
 
-      a.addEventListener('click', (e) => {
-        if (href.startsWith('#')) {
-          e.preventDefault();
-          const targetId = href.slice(1);
-          const targetElement = document.getElementById(targetId);
-          if (targetElement) {
-            const yOffset = -250;
-            const y = targetElement.getBoundingClientRect().top + window.pageYOffset + yOffset;
-            window.scrollTo({ top: y, behavior: 'smooth' });
-          }
+  cardLink.appendChild(title);
+  card.appendChild(cardLink);
+
+  return card;
+}
+
+/**
+ * Build dropdown content from heading and following elements
+ */
+function buildDropdownContent(headerText, elements) {
+  const dropdown = document.createElement('div');
+  dropdown.classList.add('dropdown-content', 'animated', 'fadeIn', 'menu-cardList-cnt');
+
+  // Header box
+  const hdBx = document.createElement('div');
+  hdBx.classList.add('hd-bx');
+
+  const h4 = document.createElement('p');
+  h4.classList.add('hd-bx-h4');
+  h4.textContent = headerText;
+  hdBx.appendChild(h4);
+
+  dropdown.appendChild(hdBx);
+
+  // Build card list from all ul elements
+  const menuCardList = document.createElement('div');
+  menuCardList.classList.add('menu-cardList', 'MT15');
+
+  elements.forEach((element) => {
+    if (element.tagName === 'UL') {
+      const listItems = element.querySelectorAll(':scope > li');
+      listItems.forEach((item) => {
+        const card = buildCard(item);
+        if (card) {
+          menuCardList.appendChild(card);
         }
       });
-
-      if (linkType === 'true') {
-        a.classList.add('secondary-nav-cta');
-        ctaWrapper.appendChild(a);
-      } else {
-        navWrapper.appendChild(a);
-      }
     }
   });
 
-  block.innerHTML = '';
-  block.classList.add('secondary-navbar');
-  block.appendChild(navWrapper);
-  block.appendChild(ctaWrapper);
+  dropdown.appendChild(menuCardList);
+  return dropdown;
+}
 
-  // === Active section tracking + sliding indicator ===
-  window.addEventListener('scroll', () => {
-    const scrollPos = window.scrollY + 260; // match yOffset
+/**
+ * Parse mid-banner section content
+ */
+function parseMidBannerContent(midBannerSection) {
+  const navItems = [];
+  const contentWrapper = midBannerSection.querySelector('.default-content-wrapper');
 
-    sectionLinks.forEach(({ id, linkEl }) => {
-      const section = document.getElementById(id);
-      if (section) {
-        const top = section.offsetTop;
-        const bottom = top + section.offsetHeight;
+  if (!contentWrapper) return navItems;
 
-        if (scrollPos >= top && scrollPos < bottom) {
-          // Add active class
-          linkEl.classList.add('active');
-          linkEl.scrollIntoView({ behavior: 'smooth', inline: 'center', block: 'nearest' });
+  const children = Array.from(contentWrapper.children);
+  let currentGroup = null;
 
-          // Move indicator
-          const linkRect = linkEl.getBoundingClientRect();
-          const navRect = navWrapper.getBoundingClientRect();
-          indicator.style.width = `${linkRect.width}px`;
-          indicator.style.transform = `translateX(${linkRect.left - navRect.left}px)`;
-        } else {
-          linkEl.classList.remove('active');
-        }
+  children.forEach((child) => {
+    if (child.tagName === 'H1') {
+      // Start a new group
+      if (currentGroup) {
+        navItems.push(currentGroup);
+      }
+
+      currentGroup = {
+        title: child.textContent.trim().replace(/^&nbsp;/, ''),
+        id: child.id || child.textContent.trim().toLowerCase().replace(/\s+/g, '-'),
+        elements: [],
+      };
+    } else if (currentGroup) {
+      // Add element to current group
+      currentGroup.elements.push(child);
+    }
+  });
+
+  // Add last group
+  if (currentGroup) {
+    navItems.push(currentGroup);
+  }
+
+  return navItems;
+}
+
+/**
+ * Build navigation from parsed content
+ */
+function buildNavigation(navItems) {
+  const topNav = document.createElement('div');
+  topNav.classList.add('top-nav', 'bg-light-white');
+
+  const tabsPane = document.createElement('div');
+  tabsPane.classList.add('tabs-pane-js');
+
+  const tabPane = document.createElement('div');
+  tabPane.classList.add('tab-pane', 'top-second-nav-js', 'active');
+
+  const navList = document.createElement('ul');
+  navList.classList.add('top-nav-left');
+
+  navItems.forEach((item) => {
+    const li = document.createElement('li');
+    li.classList.add('drop-down', 'all-drop-down');
+    li.setAttribute('data-header-gtm', item.title);
+
+    const link = document.createElement('a');
+    link.textContent = item.title;
+    link.href = `#${item.id}`;
+    link.addEventListener('click', (e) => {
+      e.preventDefault();
+      const target = document.getElementById(item.id);
+      if (target) {
+        const yOffset = -200;
+        const y = target.getBoundingClientRect().top + window.pageYOffset + yOffset;
+        window.scrollTo({ top: y, behavior: 'smooth' });
       }
     });
+    li.appendChild(link);
+
+    // Find header text from first p element
+    const firstP = item.elements.find((el) => el.tagName === 'P' && !el.classList.contains('button-container'));
+    const headerText = firstP ? firstP.textContent.trim() : item.title;
+
+    // Build dropdown
+    const dropdown = buildDropdownContent(headerText, item.elements);
+    if (dropdown) {
+      li.appendChild(dropdown);
+    }
+
+    navList.appendChild(li);
   });
+
+  tabPane.appendChild(navList);
+  tabsPane.appendChild(tabPane);
+  topNav.appendChild(tabsPane);
+
+  return topNav;
+}
+
+export default function decorate(block) {
+  // Find the mid-banner section on the page
+  const midBannerSection = document.querySelector('.section.mid-banner');
+
+  if (!midBannerSection) {
+    // No mid-banner section found, hide the block
+    block.style.display = 'none';
+    return;
+  }
+
+  // Parse content from mid-banner section
+  const navItems = parseMidBannerContent(midBannerSection);
+
+  if (navItems.length === 0) {
+    // No navigation items found
+    block.style.display = 'none';
+    return;
+  }
+
+  // Build navigation
+  const topNav = buildNavigation(navItems);
+
+  // Replace block content
+  block.innerHTML = '';
+  block.appendChild(topNav);
+
+  // Optionally hide the mid-banner section since we've extracted its content
+  // midBannerSection.style.display = 'none';
 }

--- a/blocks/secondary-navbar/secondary-navbar.js
+++ b/blocks/secondary-navbar/secondary-navbar.js
@@ -202,6 +202,19 @@ export default function decorate(block) {
   block.innerHTML = '';
   block.appendChild(topNav);
 
+  // Move the secondary navbar to the header section
+  // Note: Header is guaranteed to be loaded first (see loadLazy in scripts.js)
+  const secondaryNavbarWrapper = block.closest('.secondary-navbar-wrapper');
+  const navWrapper = document.querySelector('header.header-wrapper .nav-wrapper');
+
+  if (secondaryNavbarWrapper && navWrapper) {
+    // Move the wrapper from main to inside nav-wrapper (as sibling of <nav>)
+    navWrapper.appendChild(secondaryNavbarWrapper);
+
+    // Add a class to identify it as part of the header
+    secondaryNavbarWrapper.classList.add('header-secondary-nav');
+  }
+
   // Optionally hide the mid-banner section since we've extracted its content
   // midBannerSection.style.display = 'none';
 }

--- a/component-models.json
+++ b/component-models.json
@@ -144,6 +144,10 @@
           {
             "name": "Banner Breadcrumb",
             "value": "banner-breadcrumb"
+          },
+          {
+            "name": "Top Nav Menu (special section)",
+            "value": "top-nav"
           }
         ]
       }

--- a/models/_section.json
+++ b/models/_section.json
@@ -65,6 +65,10 @@
             {
               "name": "Banner Breadcrumb",
               "value": "banner-breadcrumb"
+            },
+            {
+              "name": "Top Nav Menu (special section)",
+              "value": "top-nav"
             }
           ]
         }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -564,14 +564,17 @@ async function loadLazy(doc) {
   const main = doc.querySelector('main');
   await loadSections(main);
 
-  // Auto-inject secondary navbar if mid-banner section exists
-  await loadSecondaryNav(main);
-
   const { hash } = window.location;
   const element = hash ? doc.getElementById(hash.substring(1)) : false;
   if (hash && element) element.scrollIntoView();
 
-  loadHeader(doc.querySelector('header'));
+  // Load header first so nav-wrapper is available for secondary navbar
+  await loadHeader(doc.querySelector('header'));
+
+  // Auto-inject secondary navbar if mid-banner section exists
+  // Must load after header so it can move itself into the header structure
+  await loadSecondaryNav(main);
+
   loadFooter(doc.querySelector('footer'));
 
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -290,13 +290,18 @@ main .section.highlight {
 
 /* IDFC */
 
+/* Secondary navbar is now part of header, so simpler styling */
+.secondary-navbar-wrapper {
+  width: 100%;
+  background-color: #fff;
+  border-top: 1px solid #E0E0E0;
+  border-bottom: 1px solid #E0E0E0;
+  box-shadow: 0 2px 4px rgba(37, 36, 59, 0.1);
+}
+
 .section.secondary-navbar-container {
   margin: 0;
-  position: sticky;
-  top: 159px;
-  z-index: 2;
   background-color: #fff;
-  border-bottom: 1px solid #E0E0E0;
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -306,22 +311,20 @@ main .section.highlight {
   /* Firefox */
   -ms-overflow-style: none;
   /* IE 10+ */
-  background: #FFFFFF;
-  box-shadow: 0 4px 8px rgba(37, 36, 59, 0.1);
   padding: 0 1rem;
 }
 
-.secondary-navbar-wrapper {
-  width: 100%;
+/* Desktop: secondary navbar is part of fixed header */
+@media (width >= 900px) {
+  /* Add padding to main content to account for fixed header + secondary nav */
+  main {
+    padding-top: 210px; /* Approximate: 160px header + 50px secondary nav */
+  }
 }
 
-@media (max-width:767px) {
-  .section.secondary-navbar-container {
-    top: 115px;
-  }
-
+@media (max-width: 767px) {
   .secondary-navbar-wrapper {
-    width: auto;
+    display: none; /* Hide on mobile as per original design */
   }
 }
 


### PR DESCRIPTION
Fix #4

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://4-header--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

@helms-charity, they have a "secondary nav" functionality that can vary per page (each CC page is different, and the home page is different). I authored this into the page in a section with a particular class applied (currently `mid-banner` but after updating _sections.json in main I'll change it to `top-nav`) and then parsing that into the top of main just under the primary nav. Is this a good method (in terms of best practice, code management, etc.) to do something like this that can vary per-page? Would love to discuss it with you before I finish this. There's still more styling and functionality work on this of course. 