### PR TITLE
add moveInstrumentation and fixed some linting

### DIFF
--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,3 +1,5 @@
+import { moveInstrumentation } from '../../scripts/scripts.js';
+
 export default function decorate(block) {
   // const isMobile = window.matchMedia('(max-width: 767px)').matches;
   // if (!isMobile) return; // Skip accordion transformation on desktop
@@ -12,6 +14,7 @@ export default function decorate(block) {
       const body = children[1];
       body.className = 'accordion-item-body';
       const details = document.createElement('details');
+      moveInstrumentation(row, details);
       details.className = 'accordion-item';
       details.append(summary, body);
       row.replaceWith(details);
@@ -21,14 +24,16 @@ export default function decorate(block) {
     }
   });
   // Optional: Only one open at a time
-  const footerAccordion = document.querySelector(".footer-accordion")
-  block.querySelectorAll('details').forEach((detail) => {
-    detail.addEventListener('toggle', () => {
+  const footerAccordion = document.querySelector('.footer-accordion');
+  if (footerAccordion) {
+    block.querySelectorAll('details').forEach((detail) => {
+      detail.addEventListener('toggle', () => {
       // if (detail.open) {
       //   block.querySelectorAll('details').forEach((el) => {
       //     if (el !== detail) el.removeAttribute('open');
       //   });
       // }
+      });
     });
-  });
+  }
 }


### PR DESCRIPTION
I am not sure how this every worked without the moveInstrumentation, but it is there now.

Fix #32 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://32-accordion--idfc--aemsites.aem.page/

It is showing now in my ref branch:
<img width="1379" height="487" alt="image" src="https://github.com/user-attachments/assets/6ce037c2-9497-4550-a9c8-8173c28fb81f" />
