### PR TITLE
fix bad footer-accordion name

### DIFF
--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -24,7 +24,7 @@ export default function decorate(block) {
     }
   });
   // Optional: Only one open at a time
-  const footerAccordion = document.querySelector('.footer-accordion');
+  const footerAccordion = document.querySelector('footer .section.accordion-container:first-of-type');
   if (footerAccordion) {
     block.querySelectorAll('details').forEach((detail) => {
       detail.addEventListener('toggle', () => {

--- a/blocks/faq-accordion/faq-accordion.js
+++ b/blocks/faq-accordion/faq-accordion.js
@@ -1,4 +1,4 @@
-import "../accordion/accordion.js"
+import '../accordion/accordion.js';
 
 export default function decorate(block) {
   block.id = 'faqs';
@@ -72,9 +72,10 @@ export default function decorate(block) {
         item.classList.add('open');
         answer.style.maxHeight = 'none'; // temporarily unset
         // const height = answer.scrollHeight + 'px';
-        answer.style.maxHeight = '0';     // reset before transition
-        void answer.offsetHeight;         // force reflow
-        answer.style.maxHeight = "fit-content";  // animate to actual height
+        answer.style.maxHeight = '0'; // reset before transition
+        // eslint-disable-next-line no-void
+        void answer.offsetHeight; // force reflow
+        answer.style.maxHeight = 'fit-content'; // animate to actual height
       }
     });
   });

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -280,11 +280,11 @@ footer .footer>div .section:nth-child(4)>div p a {
   height: 100%;
 }
 
-.section.accordion-container:first-of-type .accordion details summary {
+.footer .section.accordion-container:first-of-type .accordion details summary {
   pointer-events: none;
 }
 
-.section.accordion-container:first-of-type .accordion details summary::after,
+.footer .section.accordion-container:first-of-type .accordion details summary::after,
 .footer .section.accordion-container:first-of-type .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label::after {
   display: none;
 }
@@ -296,11 +296,11 @@ footer .footer>div .section:nth-child(4)>div p a {
     padding-top: 14px;
   }
 
-  .section.accordion-container:first-of-type .accordion details summary {
+  .footer .section.accordion-container:first-of-type .accordion details summary {
     pointer-events: all;
   }
 
-  .section.accordion-container:first-of-type .accordion details summary::after,
+  .footer .section.accordion-container:first-of-type .accordion details summary::after,
   .footer .section.accordion-container:first-of-type .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label::after {
     display: block;
   }

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -91,7 +91,7 @@ footer .footer ul {
   border: unset;
 }
 
-.footer .footer-accordion .accordion-wrapper .accordion .accordion-item-label {
+.footer .section.accordion-container:first-of-type .accordion-wrapper .accordion .accordion-item-label {
   border-bottom: 1px solid rgba(255, 255, 255, 0.21);
 }
 
@@ -280,12 +280,12 @@ footer .footer>div .section:nth-child(4)>div p a {
   height: 100%;
 }
 
-.footer-accordion .accordion details summary {
+.section.accordion-container:first-of-type .accordion details summary {
   pointer-events: none;
 }
 
-.footer-accordion .accordion details summary::after,
-.footer .footer-accordion .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label::after {
+.section.accordion-container:first-of-type .accordion details summary::after,
+.footer .section.accordion-container:first-of-type .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label::after {
   display: none;
 }
 
@@ -296,12 +296,12 @@ footer .footer>div .section:nth-child(4)>div p a {
     padding-top: 14px;
   }
 
-  .footer-accordion .accordion details summary {
+  .section.accordion-container:first-of-type .accordion details summary {
     pointer-events: all;
   }
 
-  .footer-accordion .accordion details summary::after,
-  .footer .footer-accordion .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label::after {
+  .section.accordion-container:first-of-type .accordion details summary::after,
+  .footer .section.accordion-container:first-of-type .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label::after {
     display: block;
   }
 
@@ -469,7 +469,7 @@ footer .footer>div .section:nth-child(4)>div p a {
     display: none;
   }
 
-  .footer .footer-accordion .accordion-wrapper .accordion .accordion-item-label {
+  .footer .section.accordion-container:first-of-type .accordion-wrapper .accordion .accordion-item-label {
     border-bottom: unset;
   }
 

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -17,12 +17,10 @@ export default async function decorate(block) {
 
   block.append(footer);
 
-  const details = block.querySelectorAll(".footer-accordion details");
+  const details = block.querySelectorAll('footer .section.accordion-container:first-of-type details');
   if (window.innerWidth > 768) {
-    details.forEach(detail => {
+    details.forEach((detail) => {
       detail.open = true;
     });
   }
-
 }
-


### PR DESCRIPTION
Now that the accordion works, I added the footer accordion-item conent, and now I can see the footer one was expecting a specific section class. We don't need the author to choose a section style so I'm using a generic "first-of-type" to capture those styles instead.

Fix #32 
Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/accordion
- After: https://32-accordion--idfc--aemsites.aem.page/library/accordion
