### PR TITLE
[UE] Add 1 accordion item with block for easier authoring

### DIFF
--- a/blocks/accordion/_accordion.json
+++ b/blocks/accordion/_accordion.json
@@ -10,7 +10,14 @@
             "template": {
               "name": "Accordion",
               "model": "accordion",
-              "filter": "accordion"
+              "filter": "accordion",
+              "item1": {
+                "sling:resourceType": "blocks/accordion/accordion-item",
+                "name": "Accordion Item",
+                "model": "accordion-item",
+                "col_head": "Lorem Ipsum",
+                "col1_body": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur volutpat consequat dui, sit amet ...</p>"
+              }
             }
           }
         }
@@ -25,9 +32,7 @@
             "resourceType": "core/franklin/components/block/v1/block/item",
             "template": {
               "name": "Accordion Item",
-              "model": "accordion-item",
-              "col_head": "",
-              "col1_body": ""
+              "model": "accordion-item"
             }
           }
         }

--- a/component-definition.json
+++ b/component-definition.json
@@ -92,7 +92,14 @@
                 "template": {
                   "name": "Accordion",
                   "model": "accordion",
-                  "filter": "accordion"
+                  "filter": "accordion",
+                  "item1": {
+                    "sling:resourceType": "blocks/accordion/accordion-item",
+                    "name": "Accordion Item",
+                    "model": "accordion-item",
+                    "col_head": "Lorem Ipsum",
+                    "col1_body": "<p>Lorem ipsum dolor sit amet, consectetur adipiscing elit. Curabitur volutpat consequat dui, sit amet ...</p>"
+                  }
                 }
               }
             }


### PR DESCRIPTION
I was able to see this working in the UE using ?ref. 
The first accordion item will be added by default when the block is added, with "Lorem Ipsum". This makes authoring a little faster/easier.
<img width="1324" height="519" alt="image" src="https://github.com/user-attachments/assets/324be562-6863-4219-bcc4-71f9365dfb04" />

Subsequent accordion items will not have Lorem Ipsum.

Fix #32 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/accordion
- After: https://32-accordion--idfc--aemsites.aem.page/library/accordion
