### PR TITLE
Add banner block styles and functionality with mobile-first CSS. Apply semantic classes to banner elements.

### DIFF
--- a/blocks/banner/banner.css
+++ b/blocks/banner/banner.css
@@ -1,1 +1,265 @@
-/* will be added wih issue 20 banner block */
+/* Banner Block Styles - Mobile First */
+
+/* Base styles for Mobile */
+
+.banner-container {
+  background-color: #000;
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+.banner-wrapper {
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.banner.block {
+  background-color: #000;
+  color: var(--background-color);
+  font-family: var(--body-font-family);
+  position: relative;
+  min-height: 600px;
+  overflow: hidden;
+}
+
+/* Main content container */
+.banner-content {
+  display: grid;
+  grid-template-columns: 1fr;
+  grid-template-rows: auto auto 1fr auto;
+  position: relative;
+  min-height: 600px;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 30px 20px;
+  z-index: 2;
+}
+
+/* Banner Heading */
+.banner-heading {
+  grid-row: 1;
+  margin-bottom: 20px;
+}
+
+.banner-heading-text {
+  font-size: 28px;
+  font-family: var(--heading-font-family);
+  font-weight: bold;
+  line-height: 1.2;
+  margin: 0;
+  color: var(--background-color);
+  max-width: 100%;
+}
+
+/* CTA Containers */
+.banner-cta {
+  grid-row: 2;
+  margin-bottom: 15px;
+}
+
+/* Hide hr separators from composite multi-field */
+.cta-separator {
+  display: none;
+}
+
+/* CTA Headings */
+.cta-heading {
+  font-size: 16px;
+  font-weight: normal;
+  margin: 0 0 10px;
+  color: var(--background-color);
+}
+
+/* CTA Buttons - Base styles */
+.cta-button {
+  display: block;
+  text-align: center;
+  width: 100%;
+  max-width: 300px;
+  padding: 12px 30px;
+  border-radius: 25px;
+  text-decoration: none;
+  font-family: var(--body-font-family);
+  font-weight: 600;
+  font-size: 14px;
+  transition: all 0.3s ease;
+  border: 2px solid var(--background-color);
+  margin-bottom: 15px;
+}
+
+/* CTA Button - Outlined style */
+.cta-button-outlined {
+  background-color: transparent;
+  color: var(--background-color);
+  border-color: var(--background-color);
+}
+
+.cta-button-outlined:hover {
+  background-color: var(--background-color);
+  color: #000;
+}
+
+/* CTA Button - Filled style (red/accent) */
+.cta-button-filled {
+  background-color: var(--red-color);
+  color: var(--background-color);
+  border-color: var(--red-color);
+}
+
+.cta-button-filled:hover {
+  background-color: var(--dark-red-color);
+  border-color: var(--dark-red-color);
+}
+
+/* Bottom Text - Sticks to bottom */
+.banner-bottom-text {
+  grid-row: 4;
+  align-self: end;
+  margin-top: 20px;
+}
+
+.banner-bottom-text-content {
+  font-size: 13px;
+  line-height: 1.6;
+  margin: 0;
+  color: var(--background-color);
+  max-width: 100%;
+}
+
+/* Desktop Image - Hidden on mobile */
+.banner-image-desktop {
+  display: none;
+}
+
+/* Mobile Image - Shows as background on mobile */
+.banner-image-mobile {
+  display: block;
+  position: absolute;
+  inset: 0;
+  z-index: 0;
+}
+
+.banner-image-mobile .banner-picture {
+  display: block;
+  width: 100%;
+  height: 100%;
+}
+
+.banner-image-mobile .banner-img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+  opacity: 0.4;
+}
+
+/* Ensure content is above background image */
+.banner-heading,
+.banner-cta,
+.banner-bottom-text {
+  position: relative;
+  z-index: 3;
+}
+
+/* Tablet Styles */
+@media (width >= 601px) {
+  .banner.block {
+    min-height: 400px;
+  }
+
+  .banner-content {
+    padding: 40px 30px;
+    min-height: 400px;
+  }
+
+  .banner-heading {
+    margin-bottom: 30px;
+  }
+
+  .banner-heading-text {
+    font-size: 32px;
+    max-width: 500px;
+  }
+
+  .banner-cta {
+    margin-bottom: 20px;
+  }
+
+  .banner-bottom-text-content {
+    font-size: 14px;
+    max-width: 600px;
+  }
+
+  .cta-button {
+    display: inline-block;
+    text-align: left;
+    width: auto;
+    max-width: none;
+  }
+
+  /* Show desktop image on tablet with reduced opacity */
+  .banner-image-desktop {
+    display: flex;
+    position: absolute;
+    inset: 0 0 0 auto;
+    width: 45%;
+    z-index: 1;
+    align-items: center;
+    justify-content: flex-end;
+    opacity: 0.8;
+  }
+
+  .banner-image-desktop .banner-picture {
+    display: block;
+    width: 100%;
+    height: 100%;
+  }
+
+  .banner-image-desktop .banner-img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    object-position: center;
+  }
+
+  /* Hide mobile image on tablet */
+  .banner-image-mobile {
+    display: none;
+  }
+
+  /* Content can be static on tablet/desktop */
+  .banner-heading,
+  .banner-cta,
+  .banner-bottom-text {
+    position: static;
+    z-index: auto;
+  }
+}
+
+/* Desktop Styles */
+@media (width >= 901px) {
+  .section.banner-container:has(.banner) {
+    margin-top: 32px;
+  }
+  
+  .banner.block {
+    min-height: 500px;
+  }
+
+  .banner-content {
+    padding: 60px 40px;
+    min-height: 500px;
+  }
+
+  .banner-heading-text {
+    font-size: 42px;
+    max-width: 600px;
+  }
+
+  /* Desktop image takes full 50% width with full opacity */
+  .banner-image-desktop {
+    width: 50%;
+    opacity: 1;
+  }
+}

--- a/blocks/banner/banner.js
+++ b/blocks/banner/banner.js
@@ -1,1 +1,72 @@
-// will be added wih issue 20 banner block
+export default function decorate(block) {
+  // Get the main container div
+  const container = block.querySelector(':scope > div');
+
+  if (!container) return;
+
+  // Add semantic class to container
+  container.classList.add('banner-content');
+
+  // Get all child divs
+  const children = Array.from(container.children);
+
+  // Banner Heading
+  if (children[0]) {
+    children[0].classList.add('banner-heading');
+    const headingText = children[0].querySelector('p');
+    if (headingText) headingText.classList.add('banner-heading-text');
+  }
+
+  // CTA 1
+  if (children[1]) {
+    children[1].classList.add('banner-cta-1', 'banner-cta');
+    const ctaHeading = children[1].querySelector('p:first-of-type');
+    const ctaLink = children[1].querySelector('p:last-of-type a');
+    const ctaHr = children[1].querySelectorAll('hr');
+    if (ctaHeading) ctaHeading.classList.add('cta-heading');
+    if (ctaLink) ctaLink.classList.add('cta-button', 'cta-button-outlined');
+    ctaHr.forEach((hr) => hr.classList.add('cta-separator'));
+  }
+
+  // CTA 2
+  if (children[2]) {
+    children[2].classList.add('banner-cta-2', 'banner-cta');
+    const ctaHeading = children[2].querySelector('p:first-of-type');
+    const ctaLink = children[2].querySelector('p:last-of-type a');
+    const ctaHr = children[2].querySelectorAll('hr');
+    if (ctaHeading) ctaHeading.classList.add('cta-heading');
+    if (ctaLink) ctaLink.classList.add('cta-button', 'cta-button-filled');
+    ctaHr.forEach((hr) => hr.classList.add('cta-separator'));
+  }
+
+  // Bottom Text
+  if (children[3]) {
+    children[3].classList.add('banner-bottom-text');
+    const bottomText = children[3].querySelector('p');
+    if (bottomText) bottomText.classList.add('banner-bottom-text-content');
+  }
+
+  // Desktop Image
+  if (children[4]) {
+    children[4].classList.add('banner-image-desktop', 'banner-image');
+    const picture = children[4].querySelector('picture');
+    const img = children[4].querySelector('img');
+    if (picture) picture.classList.add('banner-picture');
+    if (img) {
+      img.classList.add('banner-img');
+      img.loading = 'eager';
+    }
+  }
+
+  // Mobile Image
+  if (children[5]) {
+    children[5].classList.add('banner-image-mobile', 'banner-image');
+    const picture = children[5].querySelector('picture');
+    const img = children[5].querySelector('img');
+    if (picture) picture.classList.add('banner-picture');
+    if (img) {
+      img.classList.add('banner-img');
+      img.loading = 'lazy';
+    }
+  }
+}

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -596,10 +596,6 @@ section.faq-accordion-container h4 {
     height: 160px;
   }
 
-    /* Add padding to main content to account for fixed header + secondary nav */
-    main {
-      padding-top: 210px; /* Approximate: 160px header + 50px secondary nav */
-    }
 }
 
 /* ANIMATIONS */


### PR DESCRIPTION
Fix #20 

Waiting on new UE Crosswalk feature support for composite multi-fields as noted in https://www.aem.live/developer/component-model-definitions#multi-fields-and-composite-multi-fields. The UE portion seems to work, and sub-items added via the UE UI are created and written into the JCR, however the UE editing window doesn't read these children and render them into the page (plain, html, nor markdown) yet. We probably need a side-port of this feature from AEMaaCS or DA, wherever it's currently functional. 

<img width="846" height="443" alt="image" src="https://github.com/user-attachments/assets/af27c932-dc72-4828-b7be-e0b48c391e24" />


Supports tablet and mobile breakpoints, swaps image at mobile (smallest) breakpoint size. 

HTML structure looks good, CTA div placeholders are in place until we get proper crosswalk support, after which they'll probably need a bit more styling/targeting to match the customer page component style. 

<img width="1538" height="1255" alt="image" src="https://github.com/user-attachments/assets/57383cd8-05be-4007-9e70-44919455cb8e" />


Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://20-banner--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
