### PR TITLE
Add Sticky CTA block with mobile-first styles, JSON UE config, and js semantic tagging

### DIFF
--- a/blocks/sticky-cta/_sticky-cta.json
+++ b/blocks/sticky-cta/_sticky-cta.json
@@ -1,0 +1,60 @@
+{
+  "definitions": [
+    {
+      "title": "Sticky CTA",
+      "id": "sticky-cta",
+      "plugins": {
+        "xwalk": {
+          "page": {
+            "resourceType": "core/franklin/components/block/v1/block",
+            "template": {
+              "name": "Sticky CTA",
+              "model": "sticky-cta"
+            }
+          }
+        }
+      }
+    }
+  ],
+  "models": [
+    {
+      "id": "sticky-cta",
+      "fields": [
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "ctaUrl",
+          "label": "CTA URL",
+          "multi": false
+        },
+        {
+          "component": "text",
+          "valueType": "string",
+          "name": "ctaText",
+          "label": "CTA Text"
+        },
+        {
+          "component": "text",
+          "valueType": "string",
+          "name": "ctaId",
+          "label": "CTA ID"
+        },
+        {
+          "component": "text",
+          "valueType": "string",
+          "name": "ctaMobileText",
+          "label": "CTA Mobile Text"
+        },
+        {
+          "component": "richtext",
+          "valueType": "string",
+          "name": "ctaSubtitle",
+          "label": "CTA Subtitle",
+          "value": ""
+        }
+      ]
+    }
+  ],
+  "filters": []
+}
+

--- a/blocks/sticky-cta/sticky-cta.css
+++ b/blocks/sticky-cta/sticky-cta.css
@@ -1,0 +1,155 @@
+/* Sticky CTA Block Styles - Mobile First */
+
+/* Base styles for Mobile */
+
+.sticky-cta-container {
+  width: 100%;
+  padding: 0;
+  margin: 0;
+}
+
+.sticky-cta-wrapper {
+  max-width: 100%;
+  margin: 0 auto;
+}
+
+.sticky-cta.block {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  background-color: var(--background-color);
+  box-shadow: 0 -2px 10px rgba(0 0 0 / 10%);
+  z-index: 1000;
+  font-family: var(--body-font-family);
+}
+
+/* Main content container */
+.sticky-cta-content {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  max-width: 1200px;
+  margin: 0 auto;
+  padding: 15px 20px;
+  gap: 15px;
+}
+
+/* CTA Link Button */
+.sticky-cta-link {
+  display: inline-block;
+  padding: 12px 30px;
+  background-color: var(--red-color);
+  color: var(--background-color);
+  text-decoration: none;
+  border-radius: 25px;
+  font-weight: 600;
+  font-size: 14px;
+  text-align: center;
+  white-space: nowrap;
+  transition: background-color 0.3s ease;
+  border: 2px solid var(--red-color);
+}
+
+.sticky-cta-link:hover {
+  background-color: var(--dark-red-color);
+  border-color: var(--dark-red-color);
+}
+
+/* CTA Text */
+.sticky-cta-text {
+  flex: 1;
+  display: none; /* Hidden on mobile by default */
+}
+
+.sticky-cta-text-content {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+/* CTA Mobile Text - Shows on mobile */
+.sticky-cta-mobile-text {
+  flex: 1;
+}
+
+.sticky-cta-mobile-text-content {
+  margin: 0;
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--text-color);
+}
+
+/* CTA Subtitle */
+.sticky-cta-subtitle {
+  display: none; /* Hidden on mobile */
+}
+
+.sticky-cta-subtitle-content {
+  margin: 0;
+  font-size: 12px;
+  color: var(--text-color);
+  opacity: 0.8;
+}
+
+/* Tablet Styles */
+@media (width >= 601px) {
+  .sticky-cta-content {
+    padding: 15px 30px;
+    gap: 20px;
+  }
+
+  .sticky-cta-link {
+    padding: 14px 40px;
+    font-size: 16px;
+  }
+
+  .sticky-cta-text-content {
+    font-size: 16px;
+  }
+
+  .sticky-cta-mobile-text-content {
+    font-size: 16px;
+  }
+
+  .sticky-cta-subtitle {
+    display: block;
+  }
+
+  .sticky-cta-subtitle-content {
+    font-size: 13px;
+  }
+}
+
+/* Desktop Styles */
+@media (width >= 901px) {
+  .sticky-cta-content {
+    padding: 20px 40px;
+    gap: 30px;
+  }
+
+  /* Hide mobile text on desktop */
+  .sticky-cta-mobile-text {
+    display: none;
+  }
+
+  /* Show desktop text on desktop */
+  .sticky-cta-text {
+    display: block;
+  }
+
+  .sticky-cta-link {
+    padding: 15px 50px;
+    font-size: 16px;
+  }
+
+  .sticky-cta-text-content {
+    font-size: 18px;
+  }
+
+  .sticky-cta-subtitle-content {
+    font-size: 14px;
+  }
+}
+

--- a/blocks/sticky-cta/sticky-cta.js
+++ b/blocks/sticky-cta/sticky-cta.js
@@ -1,0 +1,50 @@
+export default function decorate(block) {
+  // Get the main container div
+  const container = block.querySelector(':scope > div');
+
+  if (!container) return;
+
+  // Add semantic class to container
+  container.classList.add('sticky-cta-content');
+
+  // Get all child divs
+  const children = Array.from(container.children);
+
+  // CTA URL
+  if (children[0]) {
+    const ctaLink = children[0].querySelector('a');
+    if (ctaLink) {
+      ctaLink.classList.add('sticky-cta-link');
+    }
+  }
+
+  // CTA Text
+  if (children[1]) {
+    children[1].classList.add('sticky-cta-text');
+    const textContent = children[1].querySelector('p');
+    if (textContent) textContent.classList.add('sticky-cta-text-content');
+  }
+
+  // CTA ID
+  if (children[2]) {
+    const ctaId = children[2].textContent.trim();
+    if (ctaId) {
+      block.setAttribute('data-cta-id', ctaId);
+    }
+    children[2].style.display = 'none'; // Hide the ID field from display
+  }
+
+  // CTA Mobile Text
+  if (children[3]) {
+    children[3].classList.add('sticky-cta-mobile-text');
+    const mobileTextContent = children[3].querySelector('p');
+    if (mobileTextContent) mobileTextContent.classList.add('sticky-cta-mobile-text-content');
+  }
+
+  // CTA Subtitle
+  if (children[4]) {
+    children[4].classList.add('sticky-cta-subtitle');
+    const subtitleContent = children[4].querySelector('p');
+    if (subtitleContent) subtitleContent.classList.add('sticky-cta-subtitle-content');
+  }
+}

--- a/component-definition.json
+++ b/component-definition.json
@@ -565,6 +565,21 @@
           }
         },
         {
+          "title": "Sticky CTA",
+          "id": "sticky-cta",
+          "plugins": {
+            "xwalk": {
+              "page": {
+                "resourceType": "core/franklin/components/block/v1/block",
+                "template": {
+                  "name": "Sticky CTA",
+                  "model": "sticky-cta"
+                }
+              }
+            }
+          }
+        },
+        {
           "title": "Swipper Card",
           "id": "swipper-card",
           "plugins": {

--- a/component-models.json
+++ b/component-models.json
@@ -593,6 +593,43 @@
     "fields": []
   },
   {
+    "id": "sticky-cta",
+    "fields": [
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "ctaUrl",
+        "label": "CTA URL",
+        "multi": false
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "ctaText",
+        "label": "CTA Text"
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "ctaId",
+        "label": "CTA ID"
+      },
+      {
+        "component": "text",
+        "valueType": "string",
+        "name": "ctaMobileText",
+        "label": "CTA Mobile Text"
+      },
+      {
+        "component": "richtext",
+        "valueType": "string",
+        "name": "ctaSubtitle",
+        "label": "CTA Subtitle",
+        "value": ""
+      }
+    ]
+  },
+  {
     "id": "swipper-card-item",
     "fields": [
       {


### PR DESCRIPTION
Fix #<gh-issue-id>

This one was primarily a Cursor one-shot prompt, I'll drop it here for future learnings and copy-pastability for popping out net new blocks quickly:

<pre>
create a new set of base files (js, css, json) for the brand new sticky-cta component in the blocks folder. Look at the format of other blocks. I want the _sticky-cta.json file to be properly instrumented for Adobe AEM Universal Editor, and I'd like the fields of the model to allow for the following 5 fields:

1. CTA URL (reference) 
2. CTA Text (text)
3. CTA id (text)
4. CTA Mobile Text (text)
5. CTA Subtitle (richtext)
</pre>

<img width="496" height="725" alt="image" src="https://github.com/user-attachments/assets/db934d09-1f40-485c-b0e8-e43505188874" />


Will need a bit more styling but that will be handled in #22 once I can drop a component into my test page. 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://23-stickyctaUE--idfc--aemsites.aem.page/
