### PR TITLE
Adding sticky-cta to _section.json

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,2 +1,3 @@
 helix-importer-ui
 tools/*
+blocks/swipper/swipper-bundle.min.js

--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,6 @@
 coverage/*
 logs/*
 node_modules/*
-blocks/swipper/swipper-bundle.min.js
 
 helix-importer-ui
 .DS_Store

--- a/component-filters.json
+++ b/component-filters.json
@@ -32,7 +32,8 @@
       "overview-rte",
       "cf-fragment",
       "library-metadata",
-      "banner"
+      "banner",
+      "sticky-cta"
     ]
   },
   {

--- a/models/_section.json
+++ b/models/_section.json
@@ -103,7 +103,8 @@
         "overview-rte",
         "cf-fragment",
         "library-metadata",
-        "banner"
+        "banner",
+        "sticky-cta"
       ]
     }
   ]


### PR DESCRIPTION
Forgot to add it to the sections filter for UE visibility on PR 52. 

Fix #23 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://23-stickyctaUE--idfc--aemsites.aem.page/
