### PR TITLE
Update sticky-CTA CSS styles and JS functionality

### DIFF
--- a/blocks/sticky-cta/sticky-cta.css
+++ b/blocks/sticky-cta/sticky-cta.css
@@ -37,7 +37,7 @@
 /* Button container */
 .sticky-cta-content {
   order: 1;
-  padding-top: 6px;
+  padding-top: 4px;
 }
 
 .sticky-cta-content .button-container {
@@ -49,7 +49,7 @@
 .sticky-cta-content a.button {
   display: inline;
   height: 57px;
-  padding: 11px 54px;
+  padding: 10px 54px;
   min-width: 234px;
   background-color: var(--red-color);
   color: var(--background-color);
@@ -91,23 +91,31 @@
   margin: 0;
   font-size: 11px;
   color: #fff;
+  text-shadow: 0 0 20px rgb(0 0 0 / 25%);
+  font-family: var(--body-font-family-semibold);
   line-height: 1.4;
+  padding-bottom: 6px;
 }
 
 /* Tablet Styles */
 @media (width >= 601px) {
   .sticky-cta.block {
     padding: 20px 30px;
-    gap: 15px;
+    gap: 10px;
+  }
+
+  .sticky-cta-content {
+    padding-top: 8px;
   }
 
   .sticky-cta-link,
   .sticky-cta-content a.button {
-    padding: 11px 54px;
+    padding: 10px 54px;
   }
 
   .sticky-cta-subtitle-content {
     font-size: 12px;
+    padding-bottom: 10px;
   }
 }
 
@@ -115,7 +123,7 @@
 @media (width >= 901px) {
   .sticky-cta.block {
     padding: 25px 40px;
-    gap: 24px;
+    gap: 20px;
     height: 120px;
   }
 
@@ -126,11 +134,12 @@
   .sticky-cta-link,
   .sticky-cta-content a.button {
     font-size: 16px;
-    padding: 20px 28px;
+    padding: 16px 28px;
   }
 
   .sticky-cta-subtitle-content {
     font-size: 14px;
     max-width: 900px;
+    padding-bottom: 10px;
   }
 }

--- a/blocks/sticky-cta/sticky-cta.css
+++ b/blocks/sticky-cta/sticky-cta.css
@@ -9,8 +9,9 @@
 }
 
 .sticky-cta-wrapper {
-  max-width: 100%;
-  margin: 0 auto;
+  width: 100%;
+  margin: 0;
+  padding: 0;
 }
 
 .sticky-cta.block {
@@ -18,138 +19,118 @@
   bottom: 0;
   left: 0;
   right: 0;
-  background-color: var(--background-color);
-  box-shadow: 0 -2px 10px rgba(0 0 0 / 10%);
+  width: 100%;
+  height: 96px;
+  background-color: rgb(0 0 0 / 50%);
+  backdrop-filter: blur(3.5px);
   z-index: 1000;
   font-family: var(--body-font-family);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  padding: 20px;
+  gap: 12px;
+  text-align: center;
 }
 
-/* Main content container */
+/* Button container */
 .sticky-cta-content {
-  display: flex;
-  align-items: center;
-  justify-content: space-between;
-  max-width: 1200px;
-  margin: 0 auto;
-  padding: 15px 20px;
-  gap: 15px;
+  order: 1;
+  padding-top: 6px;
+}
+
+.sticky-cta-content .button-container {
+  margin: 0;
 }
 
 /* CTA Link Button */
-.sticky-cta-link {
-  display: inline-block;
-  padding: 12px 30px;
+.sticky-cta-link,
+.sticky-cta-content a.button {
+  display: inline;
+  height: 57px;
+  padding: 11px 54px;
+  min-width: 234px;
   background-color: var(--red-color);
   color: var(--background-color);
   text-decoration: none;
-  border-radius: 25px;
+  border-radius: 32px;
+  font-family: var(--heading-font-family);
   font-weight: 600;
   font-size: 14px;
   text-align: center;
   white-space: nowrap;
-  transition: background-color 0.3s ease;
+  transition: background-color 0.2s ease;
   border: 2px solid var(--red-color);
+  box-shadow: 0 0 20px 0 rgb(0 0 0 / 25%);
 }
 
-.sticky-cta-link:hover {
+.sticky-cta-link:hover,
+.sticky-cta-content a.button:hover {
   background-color: var(--dark-red-color);
   border-color: var(--dark-red-color);
 }
 
-/* CTA Text */
-.sticky-cta-text {
-  flex: 1;
-  display: none; /* Hidden on mobile by default */
+/* Tracking ID - hidden */
+.sticky-cta-tracking-id {
+  display: none;
 }
 
-.sticky-cta-text-content {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-color);
-}
-
-/* CTA Mobile Text - Shows on mobile */
+/* Mobile text - hidden as it's used for button text */
 .sticky-cta-mobile-text {
-  flex: 1;
+  display: none;
 }
 
-.sticky-cta-mobile-text-content {
-  margin: 0;
-  font-size: 14px;
-  font-weight: 600;
-  color: var(--text-color);
-}
-
-/* CTA Subtitle */
+/* Subtitle */
 .sticky-cta-subtitle {
-  display: none; /* Hidden on mobile */
+  order: 2;
+  display: block;
 }
 
 .sticky-cta-subtitle-content {
   margin: 0;
-  font-size: 12px;
-  color: var(--text-color);
-  opacity: 0.8;
+  font-size: 11px;
+  color: #fff;
+  line-height: 1.4;
 }
 
 /* Tablet Styles */
 @media (width >= 601px) {
-  .sticky-cta-content {
-    padding: 15px 30px;
-    gap: 20px;
+  .sticky-cta.block {
+    padding: 20px 30px;
+    gap: 15px;
   }
 
-  .sticky-cta-link {
-    padding: 14px 40px;
-    font-size: 16px;
-  }
-
-  .sticky-cta-text-content {
-    font-size: 16px;
-  }
-
-  .sticky-cta-mobile-text-content {
-    font-size: 16px;
-  }
-
-  .sticky-cta-subtitle {
-    display: block;
+  .sticky-cta-link,
+  .sticky-cta-content a.button {
+    padding: 11px 54px;
   }
 
   .sticky-cta-subtitle-content {
-    font-size: 13px;
+    font-size: 12px;
   }
 }
 
 /* Desktop Styles */
 @media (width >= 901px) {
+  .sticky-cta.block {
+    padding: 25px 40px;
+    gap: 24px;
+    height: 120px;
+  }
+
   .sticky-cta-content {
-    padding: 20px 40px;
-    gap: 30px;
+    padding-top: 24px;
   }
 
-  /* Hide mobile text on desktop */
-  .sticky-cta-mobile-text {
-    display: none;
-  }
-
-  /* Show desktop text on desktop */
-  .sticky-cta-text {
-    display: block;
-  }
-
-  .sticky-cta-link {
-    padding: 15px 50px;
+  .sticky-cta-link,
+  .sticky-cta-content a.button {
     font-size: 16px;
-  }
-
-  .sticky-cta-text-content {
-    font-size: 18px;
+    padding: 20px 28px;
   }
 
   .sticky-cta-subtitle-content {
     font-size: 14px;
+    max-width: 900px;
   }
 }
-

--- a/blocks/sticky-cta/sticky-cta.js
+++ b/blocks/sticky-cta/sticky-cta.js
@@ -1,50 +1,64 @@
+function updateButtonText(button) {
+  const desktopText = button.getAttribute('data-desktop-text');
+  const mobileText = button.getAttribute('data-mobile-text');
+  const isMobile = window.innerWidth < 901;
+
+  if (isMobile && mobileText) {
+    button.textContent = mobileText;
+  } else if (desktopText) {
+    button.textContent = desktopText;
+  }
+}
+
 export default function decorate(block) {
-  // Get the main container div
-  const container = block.querySelector(':scope > div');
+  // Get all direct child divs of the block
+  const children = Array.from(block.children);
 
-  if (!container) return;
-
-  // Add semantic class to container
-  container.classList.add('sticky-cta-content');
-
-  // Get all child divs
-  const children = Array.from(container.children);
-
-  // CTA URL
+  // First child: CTA Button Container
   if (children[0]) {
+    children[0].classList.add('sticky-cta-content');
     const ctaLink = children[0].querySelector('a');
     if (ctaLink) {
       ctaLink.classList.add('sticky-cta-link');
+      // Store the original button text as desktop text
+      const desktopText = ctaLink.textContent.trim();
+      ctaLink.setAttribute('data-desktop-text', desktopText);
     }
   }
 
-  // CTA Text
+  // Second child: CTA Tracking ID (hidden)
   if (children[1]) {
-    children[1].classList.add('sticky-cta-text');
-    const textContent = children[1].querySelector('p');
-    if (textContent) textContent.classList.add('sticky-cta-text-content');
-  }
-
-  // CTA ID
-  if (children[2]) {
-    const ctaId = children[2].textContent.trim();
+    children[1].classList.add('sticky-cta-tracking-id');
+    const ctaId = children[1].textContent.trim();
     if (ctaId) {
       block.setAttribute('data-cta-id', ctaId);
     }
-    children[2].style.display = 'none'; // Hide the ID field from display
   }
 
-  // CTA Mobile Text
+  // Third child: CTA Mobile Text (used for button text on mobile)
+  if (children[2]) {
+    children[2].classList.add('sticky-cta-mobile-text');
+    const mobileTextContent = children[2].querySelector('p');
+    if (mobileTextContent) {
+      mobileTextContent.classList.add('sticky-cta-mobile-text-content');
+      // Store mobile text for button
+      const mobileText = mobileTextContent.textContent.trim();
+      const ctaLink = children[0]?.querySelector('a');
+      if (ctaLink && mobileText) {
+        ctaLink.setAttribute('data-mobile-text', mobileText);
+        // Update button text based on viewport
+        updateButtonText(ctaLink);
+        window.addEventListener('resize', () => updateButtonText(ctaLink));
+      }
+    }
+  }
+
+  // Fourth child: CTA Subtitle
   if (children[3]) {
-    children[3].classList.add('sticky-cta-mobile-text');
-    const mobileTextContent = children[3].querySelector('p');
-    if (mobileTextContent) mobileTextContent.classList.add('sticky-cta-mobile-text-content');
-  }
-
-  // CTA Subtitle
-  if (children[4]) {
-    children[4].classList.add('sticky-cta-subtitle');
-    const subtitleContent = children[4].querySelector('p');
-    if (subtitleContent) subtitleContent.classList.add('sticky-cta-subtitle-content');
+    children[3].classList.add('sticky-cta-subtitle');
+    const subtitleContent = children[3].querySelector('p');
+    if (subtitleContent) {
+      subtitleContent.classList.add('sticky-cta-subtitle-content');
+    }
   }
 }

--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,22 +1,24 @@
 /* stylelint-disable max-line-length */
 @font-face {
-  font-family: 'Inter';
+  font-family: Inter;
   font-style: normal;
   font-weight: 400;
   font-display: swap;
   src: url('../fonts/inter-v8-latin-300.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
+
 @font-face {
-  font-family: 'Inter-semiBold';
+  font-family: Inter-semiBold;
   font-style: normal;
   font-weight: 500;
   font-display: swap;
   src: url('../fonts/inter-v8-latin-500.woff2') format('woff2');
   unicode-range: U+0000-00FF, U+0131, U+0152-0153, U+02BB-02BC, U+02C6, U+02DA, U+02DC, U+2000-206F, U+2074, U+20AC, U+2122, U+2191, U+2193, U+2212, U+2215, U+FEFF, U+FFFD;
 }
+
 @font-face {
-  font-family: 'Inter-bold';
+  font-family: Inter-bold;
   font-style: bold;
   font-weight: 700;
   font-display: swap;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -27,6 +27,7 @@
   --gradient-pewter: linear-gradient(270deg, #332B28 0%, #514A44 21.11%, #8B837D 50.14%, #625A50 71.74%, #7A766D 90.18%, #433C32 100%);
   --gradient-silver: linear-gradient(208deg, #C8C6C6 0%, #F1F0F0 53.5%, #C8C6C6 100%);
 
+  /* bootstrap colors */
   --blue: #007bff;
   --indigo: #6610f2;
   --purple: #6f42c1;
@@ -50,7 +51,8 @@
   --dark: #343a40;
 
   /* fonts */
-  --body-font-family: 'Inter', sans-serif;
+  --body-font-family: 'Inter', sans-serif; 
+  --body-font-family-semibold: 'Inter-semiBold', sans-serif;
   --heading-font-family: 'Inter-bold', sans-serif;
 
   /* body sizes */


### PR DESCRIPTION
Update button text handling for mobile and desktop views as well.

Fix #22 

Desktop view: 
<img width="2932" height="1015" alt="image" src="https://github.com/user-attachments/assets/2bb81e38-066b-493f-8d58-5fac57163974" />

Mobile View: 
<img width="1204" height="976" alt="image" src="https://github.com/user-attachments/assets/7348814f-580a-4dc6-8f3b-7b902707a70c" />

UE Authoring:
<img width="488" height="678" alt="image" src="https://github.com/user-attachments/assets/f4c04dcc-f8a9-421a-a652-bfc2e16d948b" />


Test URLs:
- Before: https://main--idfc--aemsites.aem.page/drafts/test
- After: https://22-stickycta--idfc--aemsites.aem.page/drafts/test
