### PR TITLE
Finalize Category-Nav authoring and styling

### DIFF
--- a/blocks/category-nav/_category-nav.json
+++ b/blocks/category-nav/_category-nav.json
@@ -112,6 +112,10 @@
           "description": "Background color of the 1st tag of the category navigation card item.",
           "options": [
             {
+              "name": "None",
+              "value": "tg-clr-none"
+            },
+            {
               "name": "Pale Yellow",
               "value": "tg-clr-pale-yellow"
             },
@@ -158,6 +162,10 @@
           "description": "Background color of the 2nd tag of the category navigation card item.",
           "options": [
             {
+              "name": "None",
+              "value": "tg-clr-none"
+            },
+            {
               "name": "Pale Yellow",
               "value": "tg-clr-pale-yellow"
             },
@@ -203,6 +211,10 @@
           "label": "Tag 3 Background Color",
           "description": "Background color of the 3rd tag of the category navigation card item.",
           "options": [
+            {
+              "name": "None",
+              "value": "tg-clr-none"
+            },
             {
               "name": "Pale Yellow",
               "value": "tg-clr-pale-yellow"

--- a/blocks/category-nav/category-nav.css
+++ b/blocks/category-nav/category-nav.css
@@ -120,7 +120,7 @@
 }
 
 .category-nav-dropdown .category-nav-explore-link {
-  color: var(--dark-red-color);
+  color: var(--dark-red-link-color);
   font-size: 12px;
   text-decoration: none;
   font-weight: 500;
@@ -129,9 +129,10 @@
   gap: 6px;
 }
 
-.category-nav-explore-link > a:hover {
+.category-nav-dropdown .category-nav-explore-link:hover {
   color: var(--dark-red-color);
   text-decoration: underline;
+  font-family: var(--heading-font-family);
 }
 
 /* Add arrow to the explore link */
@@ -176,7 +177,7 @@
 }
 
 .category-nav-card .category-nav-card-link:hover {
-  border-color: var(--dark-red-color);
+  border-color: var(--dark-red-link-color);
   box-shadow: 0 4px 12px rgb(157 29 39 / 15%);
   transform: translateY(-2px);
 }
@@ -231,6 +232,7 @@
 .category-nav-card .category-nav-tag.tg-clr-pale-purple { background-color: #f2e5ff; }
 .category-nav-card .category-nav-tag.tg-clr-pale-mint { background-color: #eefff2; }
 .category-nav-card .category-nav-tag.tg-clr-pale-white { background-color: #fff7f7; }
+.category-nav-card .category-nav-tag.tg-clr-none { background-color: unset; }
 
 /* Card Title */
 .category-nav-card .category-nav-card-title {
@@ -238,8 +240,9 @@
   justify-content: space-between;
   align-items: center;
   color: #333;
-  font-size: 13px;
-  font-weight: 500;
+  font-family: var(--heading-font-family);
+  font-size: 16px;
+  font-weight: 700;
   line-height: 1.4;
   position: relative;
   z-index: 1;
@@ -287,7 +290,7 @@
 
 /* Gradient Card Variants - Card background gradients */
 .category-nav-card.default-tan-gradient .category-nav-card-link {
-  background: linear-gradient(135deg, #f9f7f3 0%, #ede8df 100%);
+  background: linear-gradient(143deg, #ffebeb, #faf2da);
 }
 
 .category-nav-card.gradient-red .category-nav-card-link {

--- a/blocks/category-nav/category-nav.css
+++ b/blocks/category-nav/category-nav.css
@@ -74,7 +74,7 @@
   display: none;
   position: absolute;
   top: 100%;
-  margin-top: 8px;
+  left: 0;
   border-radius: 0 8px 8px;
   box-shadow: 0 4px 16px rgb(0 0 0 / 12%);
   background: #fff;
@@ -332,13 +332,6 @@
 
   .tabs-pane-js {
     padding: 0 24px;
-  }
-}
-
-@media (width >= 1200px) and (width < 1440px) {
-  .category-nav-dropdown {
-    min-width: 800px;
-    max-width: 800px;
   }
 }
 

--- a/blocks/category-nav/category-nav.js
+++ b/blocks/category-nav/category-nav.js
@@ -10,8 +10,6 @@ let unifiedNavBuilt = false;
  * @returns {void}
  */
 export function resetUnifiedNavFlag() {
-  // eslint-disable-next-line no-console
-  console.log('[Category Nav Block] Resetting unified nav flag for rebuild');
   unifiedNavBuilt = false;
 }
 
@@ -126,15 +124,6 @@ function parseCategoryNavBlock(block) {
   let linkText = '';
   let linkUrl = '';
 
-  // Debug: log first few rows to understand structure
-  // eslint-disable-next-line no-console
-  console.log('[Category Nav] Block rows:', rows.length);
-  rows.slice(0, 4).forEach((row, idx) => {
-    const cells = Array.from(row.children);
-    // eslint-disable-next-line no-console
-    console.log(`[Category Nav] Row ${idx} cells:`, cells.length, cells.map((c) => c.textContent?.trim()));
-  });
-
   // Category-level fields are in separate rows with 1 cell each at the top
   // Row 0: eyebrow-title (1 cell, plain text)
   // Row 1: explore-link (1 cell, URL - can be plain text or <a> tag)
@@ -174,15 +163,6 @@ function parseCategoryNavBlock(block) {
     if (card) {
       items.push(card);
     }
-  });
-
-  // eslint-disable-next-line no-console
-  console.log(`[Category Nav] Parsed category "${categoryName}":`, {
-    eyebrowTitle,
-    linkUrl,
-    linkText,
-    itemCount: items.length,
-    metadataRowCount,
   });
 
   return {
@@ -294,6 +274,42 @@ function buildUnifiedNavigation(categoriesData) {
 }
 
 /**
+ * Smart positioning for dropdown menus to prevent overflow
+ * Positions each dropdown to stay within viewport with 20px padding
+ */
+function positionDropdowns() {
+  const navItems = document.querySelectorAll('.category-nav-item');
+  const viewportWidth = window.innerWidth;
+  const padding = 40; // Extra padding from right edge
+
+  navItems.forEach((item) => {
+    const dropdown = item.querySelector('.category-nav-dropdown');
+    if (!dropdown) return;
+
+    // Get the position of the nav item
+    const itemRect = item.getBoundingClientRect();
+    const dropdownWidth = 860; // Fixed width from CSS
+
+    // Calculate if dropdown would overflow
+    const dropdownRightEdge = itemRect.left + dropdownWidth;
+    const overflow = dropdownRightEdge - (viewportWidth - padding);
+
+    // Reset any previous positioning
+    dropdown.style.left = '';
+    dropdown.style.right = '';
+
+    if (overflow > 0) {
+      // Dropdown would overflow, shift it left
+      const shift = overflow;
+      dropdown.style.left = `-${shift}px`;
+    } else {
+      // Dropdown fits, align to left edge of trigger
+      dropdown.style.left = '0';
+    }
+  });
+}
+
+/**
  * Check if we're viewing a framework page (either in Universal Editor or directly)
  * Framework pages are template/fragment pages and should display their raw content
  * @returns {boolean} True if viewing a framework page
@@ -302,11 +318,6 @@ function isEditingFrameworkPage() {
   // Check if current path is in the framework folder
   // The path could be /framework/* or /content/idfc-edge/framework/*
   const isFrameworkPath = window.location.pathname.includes('/framework/');
-
-  if (isFrameworkPath) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav] Skipping framework page:', window.location.pathname);
-  }
 
   return isFrameworkPath;
 }
@@ -321,43 +332,30 @@ export default function decorate(block) {
   // Skip decoration if this block is in a fragment being loaded
   // It will be decorated explicitly after injection into the page
   if (block.hasAttribute('data-fragment-block')) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Block] Skipping decoration - block is in fragment');
     return;
   }
 
   // Only build the unified nav once, from the first block that loads
   if (unifiedNavBuilt) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Block] Skipping - unified nav already built');
     // Hide subsequent blocks
     block.style.display = 'none';
     return;
   }
 
-  // eslint-disable-next-line no-console
-  console.log('[Category Nav Block] Starting decoration - first block loading');
   unifiedNavBuilt = true;
 
   // Find ALL category-nav blocks on the page
   const allCategoryNavBlocks = document.querySelectorAll('.category-nav.block');
 
-  // eslint-disable-next-line no-console
-  console.log(`[Category Nav Block] Found ${allCategoryNavBlocks.length} block(s) on page`);
-
   if (allCategoryNavBlocks.length === 0) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Block] No blocks found, aborting');
     block.style.display = 'none';
     return;
   }
 
   // Parse data from all blocks and add section IDs
   const categoriesData = [];
-  allCategoryNavBlocks.forEach((navBlock, index) => {
+  allCategoryNavBlocks.forEach((navBlock) => {
     const categoryData = parseCategoryNavBlock(navBlock);
-    // eslint-disable-next-line no-console
-    console.log(`[Category Nav Block] Block ${index + 1}: "${categoryData.title}" with ${categoryData.items.length} items`);
     if (categoryData.items.length > 0) {
       categoriesData.push(categoryData);
 
@@ -366,21 +364,14 @@ export default function decorate(block) {
       if (section && !section.id) {
         section.id = categoryData.id;
         section.setAttribute('data-category-id', categoryData.id);
-        // eslint-disable-next-line no-console
-        console.log(`[Category Nav Block] Added ID "${categoryData.id}" to section`);
       }
     }
   });
 
   if (categoriesData.length === 0) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Block] No valid categories with items found');
     block.style.display = 'none';
     return;
   }
-
-  // eslint-disable-next-line no-console
-  console.log(`[Category Nav Block] Building unified navigation with ${categoriesData.length} categories`);
 
   // Build the unified navigation
   const unifiedNav = buildUnifiedNavigation(categoriesData);
@@ -389,8 +380,6 @@ export default function decorate(block) {
   let categoryNavWrapper = document.querySelector('.category-nav-wrapper[data-nav-placeholder="true"]');
 
   if (!categoryNavWrapper) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Block] No placeholder wrapper found, creating one');
     // If no placeholder wrapper exists, create one
     categoryNavWrapper = document.createElement('div');
     categoryNavWrapper.classList.add('category-nav-wrapper');
@@ -401,9 +390,6 @@ export default function decorate(block) {
       // eslint-disable-next-line no-console
       console.error('[Category Nav Block] Could not find main element to insert wrapper');
     }
-  } else {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Block] Found placeholder wrapper, populating it');
   }
 
   // Populate the wrapper with the unified navigation
@@ -416,11 +402,6 @@ export default function decorate(block) {
   if (navWrapper && !navWrapper.contains(categoryNavWrapper)) {
     navWrapper.appendChild(categoryNavWrapper);
     categoryNavWrapper.classList.add('header-category-nav');
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Block] Moved navigation to header');
-  } else if (!navWrapper) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Block] Header nav-wrapper not found, keeping navigation in main');
   }
 
   // Hide all the individual category-nav blocks in the main content
@@ -438,6 +419,25 @@ export default function decorate(block) {
     }
   });
 
-  // eslint-disable-next-line no-console
-  console.log('[Category Nav Block] Decoration complete - navigation is ready');
+  // Position dropdowns intelligently after a short delay to ensure DOM is fully rendered
+  setTimeout(() => {
+    positionDropdowns();
+  }, 100);
+
+  // Reposition dropdowns on window resize
+  let resizeTimer;
+  window.addEventListener('resize', () => {
+    clearTimeout(resizeTimer);
+    resizeTimer = setTimeout(() => {
+      positionDropdowns();
+    }, 150);
+  });
+
+  // Also reposition on mouseenter for extra accuracy
+  const navItems = document.querySelectorAll('.category-nav-item');
+  navItems.forEach((item) => {
+    item.addEventListener('mouseenter', () => {
+      positionDropdowns();
+    });
+  });
 }

--- a/blocks/category-nav/category-nav.js
+++ b/blocks/category-nav/category-nav.js
@@ -275,12 +275,19 @@ function buildUnifiedNavigation(categoriesData) {
 
 /**
  * Smart positioning for dropdown menus to prevent overflow
- * Positions each dropdown to stay within viewport with 20px padding
+ * Positions each dropdown to stay within viewport with padding
+ * Accounts for responsive dropdown widths based on viewport size
  */
 function positionDropdowns() {
   const navItems = document.querySelectorAll('.category-nav-item');
   const viewportWidth = window.innerWidth;
   const padding = 40; // Extra padding from right edge
+
+  // Determine dropdown width based on viewport (matches CSS media queries)
+  let dropdownWidth = 860; // Default width for >= 1200px
+  if (viewportWidth >= 900 && viewportWidth < 1200) {
+    dropdownWidth = 720; // Medium screens
+  }
 
   navItems.forEach((item) => {
     const dropdown = item.querySelector('.category-nav-dropdown');
@@ -288,7 +295,6 @@ function positionDropdowns() {
 
     // Get the position of the nav item
     const itemRect = item.getBoundingClientRect();
-    const dropdownWidth = 860; // Fixed width from CSS
 
     // Calculate if dropdown would overflow
     const dropdownRightEdge = itemRect.left + dropdownWidth;

--- a/component-models.json
+++ b/component-models.json
@@ -392,6 +392,10 @@
         "description": "Background color of the 1st tag of the category navigation card item.",
         "options": [
           {
+            "name": "None",
+            "value": "tg-clr-none"
+          },
+          {
             "name": "Pale Yellow",
             "value": "tg-clr-pale-yellow"
           },
@@ -438,6 +442,10 @@
         "description": "Background color of the 2nd tag of the category navigation card item.",
         "options": [
           {
+            "name": "None",
+            "value": "tg-clr-none"
+          },
+          {
             "name": "Pale Yellow",
             "value": "tg-clr-pale-yellow"
           },
@@ -483,6 +491,10 @@
         "label": "Tag 3 Background Color",
         "description": "Background color of the 3rd tag of the category navigation card item.",
         "options": [
+          {
+            "name": "None",
+            "value": "tg-clr-none"
+          },
           {
             "name": "Pale Yellow",
             "value": "tg-clr-pale-yellow"

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -18,12 +18,7 @@ import { decorateMain, loadFragment } from './scripts.js';
  */
 function isEditingFrameworkPage() {
   const isFrameworkPath = window.location.pathname.includes('/framework/');
-  const shouldSkip = isFrameworkPath;
-  if (shouldSkip) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Editor] Skipping framework page:', window.location.pathname);
-  }
-  return shouldSkip;
+  return isFrameworkPath;
 }
 
 /**
@@ -38,13 +33,8 @@ async function reloadCategoryNav(main) {
 
   const categoryNavBlocks = main.querySelectorAll('.category-nav');
   if (categoryNavBlocks.length === 0) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Editor] No blocks found after update');
     return;
   }
-
-  // eslint-disable-next-line no-console
-  console.log(`[Category Nav Editor] Reloading with ${categoryNavBlocks.length} block(s)`);
 
   // Reset the unified nav flag so it can be rebuilt
   try {
@@ -60,8 +50,6 @@ async function reloadCategoryNav(main) {
   // Remove existing wrapper if present
   const existingWrapper = document.querySelector('.category-nav-wrapper');
   if (existingWrapper) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Editor] Removing existing wrapper');
     existingWrapper.remove();
   }
 
@@ -70,8 +58,6 @@ async function reloadCategoryNav(main) {
   categoryNavWrapper.classList.add('category-nav-wrapper');
   categoryNavWrapper.setAttribute('data-nav-placeholder', 'true');
   main.insertBefore(categoryNavWrapper, main.firstChild);
-  // eslint-disable-next-line no-console
-  console.log('[Category Nav Editor] New wrapper created');
 
   // Load CSS
   const blockName = 'category-nav';
@@ -84,26 +70,18 @@ async function reloadCategoryNav(main) {
 
   // Load the category-nav blocks to trigger their decoration
   const navBlocks = [...main.querySelectorAll('.category-nav.block')];
-  // eslint-disable-next-line no-console
-  console.log(`[Category Nav Editor] Loading ${navBlocks.length} block(s) to trigger decoration`);
   for (let i = 0; i < navBlocks.length; i += 1) {
     // eslint-disable-next-line no-await-in-loop
     await loadBlock(navBlocks[i]);
   }
-  // eslint-disable-next-line no-console
-  console.log('[Category Nav Editor] Category navigation reload complete');
 
   // Clean up: Remove the fragment sections from main
   // These were injected from the fragment but are no longer needed
   const categoryNavSections = main.querySelectorAll('.category-nav-container');
   if (categoryNavSections.length > 0) {
-    // eslint-disable-next-line no-console
-    console.log(`[Category Nav Editor] Removing ${categoryNavSections.length} fragment section(s) from main`);
     categoryNavSections.forEach((section) => {
       section.remove();
     });
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Editor] Fragment sections cleaned up');
   }
 }
 
@@ -133,14 +111,10 @@ async function applyChanges(event) {
       // This handles when content authors change the category-nav page property
       const categoryNavPath = getMetadata('category-nav', parsedUpdate);
       if (categoryNavPath) {
-        // eslint-disable-next-line no-console
-        console.log(`[Category Nav Editor] Loading fragment from metadata: ${categoryNavPath}`);
         try {
           const fragment = await loadFragment(categoryNavPath);
           if (fragment) {
             const fragmentSections = fragment.querySelectorAll(':scope > .section');
-            // eslint-disable-next-line no-console
-            console.log(`[Category Nav Editor] Injecting ${fragmentSections.length} section(s) from fragment`);
             const { firstChild } = newMain;
             fragmentSections.forEach((section) => {
               const sectionClone = section.cloneNode(true);
@@ -163,8 +137,6 @@ async function applyChanges(event) {
                     titleElement.classList.add('category-title');
                     const categoryName = titleElement.textContent.trim();
                     sectionClone.setAttribute('data-category-name', categoryName);
-                    // eslint-disable-next-line no-console
-                    console.log(`[Category Nav Editor] Tagged section with category: ${categoryName}`);
                   }
                 }
 
@@ -192,8 +164,6 @@ async function applyChanges(event) {
       await loadSections(newMain);
 
       // Reload category navigation if present
-      // eslint-disable-next-line no-console
-      console.log('[Category Nav Editor] Main element updated, checking for category-nav');
       await reloadCategoryNav(newMain);
 
       element.remove();
@@ -220,8 +190,6 @@ async function applyChanges(event) {
 
         // If this is a category-nav block, reload the unified navigation
         if (newBlock.classList.contains('category-nav')) {
-          // eslint-disable-next-line no-console
-          console.log('[Category Nav Editor] Category-nav block updated, rebuilding navigation');
           const main = newBlock.closest('main');
           if (main) {
             await reloadCategoryNav(main);
@@ -253,8 +221,6 @@ async function applyChanges(event) {
 
           // If this section contains category-nav blocks, reload the navigation
           if (newSection.querySelector('.category-nav')) {
-            // eslint-disable-next-line no-console
-            console.log('[Category Nav Editor] Section with category-nav updated, rebuilding navigation');
             const main = newSection.closest('main');
             if (main) {
               await reloadCategoryNav(main);

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -13,10 +13,29 @@ import { decorateRichtext } from './editor-support-rte.js';
 import { decorateMain, loadFragment } from './scripts.js';
 
 /**
+ * Check if we're editing a framework page (should skip nav building)
+ * @returns {boolean} true if we should skip navigation building
+ */
+function isEditingFrameworkPage() {
+  const isFrameworkPath = window.location.pathname.includes('/framework/');
+  const shouldSkip = isFrameworkPath;
+  if (shouldSkip) {
+    // eslint-disable-next-line no-console
+    console.log('[Category Nav Editor] Skipping framework page:', window.location.pathname);
+  }
+  return shouldSkip;
+}
+
+/**
  * Reload category navigation after main content updates
  * This handles changes to page-level category-nav aem-content field
  */
 async function reloadCategoryNav(main) {
+  // Skip if editing framework pages - let authors see the uncollapsed content
+  if (isEditingFrameworkPage()) {
+    return;
+  }
+
   const categoryNavBlocks = main.querySelectorAll('.category-nav');
   if (categoryNavBlocks.length === 0) {
     // eslint-disable-next-line no-console

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -337,8 +337,6 @@ export async function loadFragment(path) {
       const categoryNavBlocks = main.querySelectorAll('.category-nav');
       categoryNavBlocks.forEach((block) => {
         block.setAttribute('data-fragment-block', 'true');
-        // eslint-disable-next-line no-console
-        console.log('[Fragment Load] Marked category-nav block to skip loading in fragment');
       });
 
       // eslint-disable-next-line
@@ -374,11 +372,6 @@ function isEditingFrameworkPage() {
   // The path could be /framework/* or /content/idfc-edge/framework/*
   const isFrameworkPath = window.location.pathname.includes('/framework/');
 
-  if (isFrameworkPath) {
-    // eslint-disable-next-line no-console
-    console.log('[Framework Check] Skipping framework page:', window.location.pathname);
-  }
-
   return isFrameworkPath;
 }
 
@@ -398,13 +391,8 @@ async function loadCategoryNavFragment(main) {
   const categoryNavPath = getMetadata('category-nav');
 
   if (!categoryNavPath) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Fragment] No category-nav metadata found on page');
     return;
   }
-
-  // eslint-disable-next-line no-console
-  console.log(`[Category Nav Fragment] Found category-nav metadata: ${categoryNavPath}`);
 
   try {
     // Load the fragment content
@@ -420,13 +408,8 @@ async function loadCategoryNavFragment(main) {
     const fragmentSections = fragment.querySelectorAll(':scope > .section');
 
     if (fragmentSections.length === 0) {
-      // eslint-disable-next-line no-console
-      console.log('[Category Nav Fragment] No sections found in fragment');
       return;
     }
-
-    // eslint-disable-next-line no-console
-    console.log(`[Category Nav Fragment] Injecting ${fragmentSections.length} section(s) from fragment`);
 
     // Insert all fragment sections at the beginning of main
     // They should be inserted before any existing content
@@ -442,8 +425,6 @@ async function loadCategoryNavFragment(main) {
         categoryNavBlock.removeAttribute('data-fragment-block');
         // Reset block status so it can be loaded explicitly later
         categoryNavBlock.dataset.blockStatus = '';
-        // eslint-disable-next-line no-console
-        console.log('[Category Nav Fragment] Prepared category-nav block for page loading');
 
         // Add class to identify this as a category navigation section
         sectionClone.classList.add('category-nav-section');
@@ -458,8 +439,6 @@ async function loadCategoryNavFragment(main) {
             // Add data attribute with the category name
             const categoryName = titleElement.textContent.trim();
             sectionClone.setAttribute('data-category-name', categoryName);
-            // eslint-disable-next-line no-console
-            console.log(`[Category Nav Fragment] Tagged section with category: ${categoryName}`);
           }
         }
 
@@ -476,9 +455,6 @@ async function loadCategoryNavFragment(main) {
         main.appendChild(sectionClone);
       }
     });
-
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav Fragment] Fragment sections injected successfully');
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('[Category Nav Fragment] Error loading fragment:', error);
@@ -675,13 +651,8 @@ async function loadCategoryNav(main) {
   const categoryNavBlocks = main.querySelectorAll('.category-nav.block');
 
   if (categoryNavBlocks.length === 0) {
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav] No category-nav blocks found on page');
     return;
   }
-
-  // eslint-disable-next-line no-console
-  console.log(`[Category Nav] Found ${categoryNavBlocks.length} block(s), initializing wrapper and loading blocks`);
 
   // Create category-nav wrapper at the top of main
   const categoryNavWrapper = document.createElement('div');
@@ -695,8 +666,6 @@ async function loadCategoryNav(main) {
   const blockName = 'category-nav';
   try {
     await loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`);
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav] CSS loaded, now loading all category-nav blocks');
   } catch (error) {
     // eslint-disable-next-line no-console
     console.error('[Category Nav] Failed to load CSS:', error);
@@ -705,8 +674,6 @@ async function loadCategoryNav(main) {
   // Load ALL category-nav blocks together to ensure they all see each other
   // This is critical because the first block to load will build the unified navigation
   const navBlocksArray = Array.from(categoryNavBlocks);
-  // eslint-disable-next-line no-console
-  console.log(`[Category Nav] Loading ${navBlocksArray.length} category-nav block(s)...`);
 
   // Reset the unified nav flag in case blocks were partially decorated earlier
   // This ensures the first block we explicitly load will build the unified navigation
@@ -714,8 +681,6 @@ async function loadCategoryNav(main) {
     const categoryNavModule = await import(`${window.hlx.codeBasePath}/blocks/category-nav/category-nav.js`);
     if (categoryNavModule.resetUnifiedNavFlag) {
       categoryNavModule.resetUnifiedNavFlag();
-      // eslint-disable-next-line no-console
-      console.log('[Category Nav] Reset unified nav flag before loading blocks');
     }
   } catch (error) {
     // eslint-disable-next-line no-console
@@ -724,35 +689,21 @@ async function loadCategoryNav(main) {
 
   for (let i = 0; i < navBlocksArray.length; i += 1) {
     const navBlock = navBlocksArray[i];
-    const currentStatus = navBlock.dataset.blockStatus;
-    // eslint-disable-next-line no-console
-    console.log(`[Category Nav] Block ${i + 1} status before load: ${currentStatus}`);
-
     // Remove block status entirely to force fresh decoration
     delete navBlock.dataset.blockStatus;
 
     // eslint-disable-next-line no-await-in-loop
     await loadBlock(navBlock);
-
-    // eslint-disable-next-line no-console
-    console.log(`[Category Nav] Block ${i + 1} status after load: ${navBlock.dataset.blockStatus}`);
   }
-
-  // eslint-disable-next-line no-console
-  console.log('[Category Nav] All category-nav blocks loaded');
 
   // Clean up: Remove the fragment sections from main
   // These were injected from the fragment but are no longer needed
   // since the navigation has been built and moved to the header
   const categoryNavSections = main.querySelectorAll('.category-nav-container');
   if (categoryNavSections.length > 0) {
-    // eslint-disable-next-line no-console
-    console.log(`[Category Nav] Removing ${categoryNavSections.length} fragment section(s) from main`);
     categoryNavSections.forEach((section) => {
       section.remove();
     });
-    // eslint-disable-next-line no-console
-    console.log('[Category Nav] Fragment sections cleaned up');
   }
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -21,6 +21,7 @@
   --link-hover-color: #1d3ecf;
   --purple-color: #563b80;
   --dark-red-color: #9c1d26;
+  --dark-red-link-color:#801c1e;
   --red-color: #D73F41;
   --gradient-red: linear-gradient(92deg, #5D2227 36.27%, #982B35 70.68%, #5D2227 85.89%);
   --gradient-blue: linear-gradient(137deg, #08133C 4.07%, #2E3E79 75.46%);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -656,12 +656,12 @@ section.faq-accordion-container h4 {
   }
 
   header {
-    height: 160px;
+    height: 140px;
   }
 
   /* Increase header height when category navigation is present */
   header:has(.category-nav-wrapper) {
-    height: 224px; /* 160px base + 64px for category nav */
+    height: 204px; /* 140px base + 64px for category nav */
   }
 
 }


### PR DESCRIPTION
Nav page for the 3rd level "Credit Card" navigation is now fully authored at `/content/idfc-edge/framework/ccnav`. This change includes a few minor CSS adjustments, a small fix to the js logic to prevent any dynamic reloads when editing framework pages in UE, and some small header height adjustments. 

Fix #17 

Final UE structure looks like this (one item shown as an example): 

<img width="461" height="1098" alt="image" src="https://github.com/user-attachments/assets/9ed4fd5e-ee16-4b47-948e-8ac44ac821a4" />


Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://16-categorynav--idfc--aemsites.aem.page/credit-card/rupay-credit-card
