### PR TITLE
put all fields in

### DIFF
--- a/blocks/anchor-nav/_anchor-nav.json
+++ b/blocks/anchor-nav/_anchor-nav.json
@@ -20,7 +20,42 @@
     "models": [
       {
         "id": "button",
-        "title": "Button"
+        "fields": [
+          {
+            "component": "aem-content",
+            "name": "link",
+            "label": "Link"
+          },
+          {
+            "component": "text",
+            "name": "linkText",
+            "label": "Text"
+          },
+          {
+            "component": "text",
+            "name": "linkTitle",
+            "label": "Title"
+          },
+          {
+            "component": "select",
+            "name": "linkType",
+            "label": "Type",
+            "options": [
+              {
+                "name": "default",
+                "value": ""
+              },
+              {
+                "name": "primary",
+                "value": "primary"
+              },
+              {
+                "name": "secondary",
+                "value": "secondary"
+              }
+            ]
+          }
+        ]
       }
     ],
     "filters": [

--- a/component-models.json
+++ b/component-models.json
@@ -209,7 +209,42 @@
   },
   {
     "id": "button",
-    "title": "Button"
+    "fields": [
+      {
+        "component": "aem-content",
+        "name": "link",
+        "label": "Link"
+      },
+      {
+        "component": "text",
+        "name": "linkText",
+        "label": "Text"
+      },
+      {
+        "component": "text",
+        "name": "linkTitle",
+        "label": "Title"
+      },
+      {
+        "component": "select",
+        "name": "linkType",
+        "label": "Type",
+        "options": [
+          {
+            "name": "default",
+            "value": ""
+          },
+          {
+            "name": "primary",
+            "value": "primary"
+          },
+          {
+            "name": "secondary",
+            "value": "secondary"
+          }
+        ]
+      }
+    ]
   },
   {
     "id": "banner-item",


### PR DESCRIPTION
Copilot says:

When you reference a model in a block's component definition, you need to include the full model definition with its fields, not just reference it by id. The Universal Editor needs the complete field definitions to render the form.

Fix #15 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://42-faqaccordion--idfc--aemsites.aem.page/
