### PR TITLE
Update paths.json

### DIFF
--- a/paths.json
+++ b/paths.json
@@ -12,6 +12,6 @@
   ],
   "includes": [
     "/content/idfc-edge/",
-    "/content/dam/idfc-edge/"
+    "/content/dam/idfc-edge/icons"
   ]
 }


### PR DESCRIPTION
I learned we can't have any dam folders in the paths.json except for /icons and /pds, otherwise .webp and .avif (or avifs masquerading as jpgs) will clog the queue.

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://fix-stuck-queue--idfc--aemsites.aem.page/
