### PR TITLE
Add overflow-hidden to card container

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -257,6 +257,7 @@
   max-width: 1005px;
   padding-top: 50px;
   margin: 0 auto;
+  overflow: hidden;
 }
 
 .cards.all-about-card .swiper-slide {


### PR DESCRIPTION
Fixing a bug where more than the "slidesPerView" amount of slides are actually visible when the page width is wider than the slider component width.

Fix #<gh-issue-id>

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://24a-bugfix-allaboutcard--idfc--aemsites.aem.page/credit-card/rupay-credit-card

<img width="3365" height="880" alt="SCR-20251119-pmsl" src="https://github.com/user-attachments/assets/2715bcf0-a863-42ac-9479-1f0abf8e30fc" />
