### PR TITLE
add block to the section filters

### DIFF
--- a/component-filters.json
+++ b/component-filters.json
@@ -35,7 +35,8 @@
       "banner",
       "sticky-cta",
       "anchor-nav",
-      "steps"
+      "steps",
+      "tabs-upi-link"
     ]
   },
   {

--- a/models/_section.json
+++ b/models/_section.json
@@ -90,7 +90,8 @@
         "banner",
         "sticky-cta",
         "anchor-nav",
-        "steps"
+        "steps",
+        "tabs-upi-link"
       ]
     }
   ]


### PR DESCRIPTION
I missed adding the block to the section filters. 

Fix #30 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://30-tabs-upi-UE--idfc--aemsites.aem.page/
