### PR TITLE
Add button group wrapper for responsive layouts

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -441,6 +441,32 @@ function decorateButtons(element) {
       }
     }
   });
+
+  // Handle button groups: wrap button with preceding superscript text
+  // This allows text (in superscript) and button to be moved together in responsive layouts
+  element.querySelectorAll('p.button-container').forEach((buttonContainer) => {
+    // Check if this button container hasn't already been grouped
+    if (buttonContainer.parentElement?.classList.contains('button-group')) {
+      return;
+    }
+
+    // Check if the previous sibling is a <p> containing a <sup>
+    const previousSibling = buttonContainer.previousElementSibling;
+    if (previousSibling
+      && previousSibling.tagName === 'P'
+      && previousSibling.querySelector('sup')) {
+      // Create a new div with class 'button-group'
+      const buttonGroup = document.createElement('div');
+      buttonGroup.className = 'button-group';
+
+      // Insert the new div before the previous sibling
+      buttonContainer.parentElement.insertBefore(buttonGroup, previousSibling);
+
+      // Move both elements into the button-group
+      buttonGroup.appendChild(previousSibling);
+      buttonGroup.appendChild(buttonContainer);
+    }
+  });
 }
 
 /**

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -441,32 +441,6 @@ function decorateButtons(element) {
       }
     }
   });
-
-  // Handle button groups: wrap button with preceding superscript text
-  // This allows text (in superscript) and button to be moved together in responsive layouts
-  element.querySelectorAll('p.button-container').forEach((buttonContainer) => {
-    // Check if this button container hasn't already been grouped
-    if (buttonContainer.parentElement?.classList.contains('button-group')) {
-      return;
-    }
-
-    // Check if the previous sibling is a <p> containing a <sup>
-    const previousSibling = buttonContainer.previousElementSibling;
-    if (previousSibling
-      && previousSibling.tagName === 'P'
-      && previousSibling.querySelector('sup')) {
-      // Create a new div with class 'button-group'
-      const buttonGroup = document.createElement('div');
-      buttonGroup.className = 'button-group';
-
-      // Insert the new div before the previous sibling
-      buttonContainer.parentElement.insertBefore(buttonGroup, previousSibling);
-
-      // Move both elements into the button-group
-      buttonGroup.appendChild(previousSibling);
-      buttonGroup.appendChild(buttonContainer);
-    }
-  });
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -391,7 +391,7 @@ async function loadCategoryNavFragment(main) {
 
   // Read the category-nav metadata value from the page
   const categoryNavPath = getMetadata('category-nav');
-
+ 
   if (!categoryNavPath) {
     return;
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -365,6 +365,37 @@ export default async function decorateFragment(block) {
 }
 
 /**
+ * Handle button groups: wrap button with preceding superscript text
+ * This allows text (in superscript) and button to be moved together in responsive layouts
+ * @param {Element} element container element
+ */
+function decorateButtonGroups(element) {
+  element.querySelectorAll('p.button-container').forEach((buttonContainer) => {
+    // Check if this button container hasn't already been grouped
+    if (buttonContainer.parentElement?.classList.contains('button-group')) {
+      return;
+    }
+
+    // Check if the previous sibling is a <p> containing a <sup>
+    const previousSibling = buttonContainer.previousElementSibling;
+    if (previousSibling
+      && previousSibling.tagName === 'P'
+      && previousSibling.querySelector('sup')) {
+      // Create a new div with class 'button-group'
+      const buttonGroup = document.createElement('div');
+      buttonGroup.className = 'button-group';
+
+      // Insert the new div before the previous sibling
+      buttonContainer.parentElement.insertBefore(buttonGroup, previousSibling);
+
+      // Move both elements into the button-group
+      buttonGroup.appendChild(previousSibling);
+      buttonGroup.appendChild(buttonContainer);
+    }
+  });
+}
+
+/**
  * Check if we're viewing a framework page (either in Universal Editor or directly)
  * Framework pages are template/fragment pages and should display their raw content
  * @returns {boolean} True if viewing a framework page
@@ -391,7 +422,7 @@ async function loadCategoryNavFragment(main) {
 
   // Read the category-nav metadata value from the page
   const categoryNavPath = getMetadata('category-nav');
- 
+
   if (!categoryNavPath) {
     return;
   }
@@ -712,6 +743,7 @@ function buildAutoBlocks(main) {
 export function decorateMain(main) {
   // hopefully forward compatible button decoration
   decorateButtons(main);
+  decorateButtonGroups(main);
   decorateIcons(main);
   buildAutoBlocks(main);
   decorateSections(main);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -288,6 +288,22 @@ button.secondary {
   color: var(--text-color);
 }
 
+/* button groups - wraps text (typically superscript) and button together for responsive layouts */
+.button-group {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5em;
+  align-items: flex-start;
+}
+
+.button-group p {
+  margin: 0;
+}
+
+.button-group .button-container {
+  margin: 0;
+}
+
 main img {
   max-width: 100%;
   width: auto;


### PR DESCRIPTION
Wrap button containers with preceding superscript text in a 'button-group' div. Add corresponding CSS for alignment and spacing.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #106 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/buttons
- After: https://106-btn-group--idfc--aemsites.aem.page/library/buttons