### PR TITLE
Add JSON-LD schema generation for testimonial cards

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -2,6 +2,200 @@ import { createOptimizedPicture, loadScript, loadCSS } from '../../scripts/aem.j
 import { moveInstrumentation } from '../../scripts/scripts.js';
 
 /**
+ * Sanitizes text for JSON-LD by removing/replacing problematic characters
+ * @param {string} text The text to sanitize
+ * @returns {string} Sanitized text
+ */
+function sanitizeText(text) {
+  if (!text) return '';
+  // Remove control characters and normalize whitespace
+  return (
+    text
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x1F\x7F-\x9F]/g, '') // Remove control characters
+      .replace(/\s+/g, ' ') // Normalize whitespace
+      // Replace smart quotes with regular quotes
+      .replace(/[\u2018\u2019]/g, "'") // Single smart quotes to apostrophe
+      .replace(/[\u201C\u201D]/g, '"') // Double smart quotes to regular quotes
+      // Replace other problematic characters
+      .replace(/[\u2013\u2014]/g, '-') // En-dash and em-dash to hyphen
+      .replace(/\u2026/g, '...') // Ellipsis
+      .trim()
+  );
+}
+
+/**
+ * Generates JSON-LD schema for testimonial cards
+ * @param {HTMLElement} block The testimonial cards block
+ * @returns {Object} JSON-LD schema object
+ */
+function generateTestimonialSchema(block) {
+  const testimonials = [];
+  const cards = block.querySelectorAll('li');
+
+  cards.forEach((card) => {
+    const cardBody = card.querySelector('.cards-card-body');
+    if (!cardBody) return;
+
+    // Extract review text (skip the first paragraph with icon)
+    const paragraphs = cardBody.querySelectorAll('p');
+    let reviewText = '';
+    paragraphs.forEach((p, index) => {
+      // Skip first paragraph (icon) and product name paragraph (has <u> tag)
+      if (index > 0 && !p.querySelector('u')) {
+        reviewText += p.textContent.trim();
+      }
+    });
+    reviewText = sanitizeText(reviewText);
+
+    // Extract author name from h5
+    const authorElement = cardBody.querySelector('h5');
+    const authorName = sanitizeText(authorElement ? authorElement.textContent : '');
+
+    // Extract product name from underlined paragraph
+    const productElement = cardBody.querySelector('p u');
+    const productName = sanitizeText(
+      productElement ? productElement.textContent : 'IDFC FIRST Bank Credit Card',
+    );
+
+    // Extract rating from star icons count
+    const starIcons = cardBody.querySelectorAll('[class*="icon-star"]');
+    const ratingValue = starIcons.length;
+
+    // Extract date from h6
+    const dateElement = cardBody.querySelector('h6');
+    let datePublished = '';
+    if (dateElement) {
+      const dateText = sanitizeText(dateElement.textContent);
+      // Extract date after the pipe symbol
+      const dateParts = dateText.split('|');
+      if (dateParts.length > 1) {
+        const dateString = dateParts[1].trim();
+        // Convert "March 26, 2025" to ISO format "2025-03-26"
+        try {
+          const parsedDate = new Date(dateString);
+          if (!Number.isNaN(parsedDate.getTime()) && parsedDate.getFullYear() > 2000) {
+            [datePublished] = parsedDate.toISOString().split('T');
+          }
+        } catch (e) {
+          // Silently fail, will use fallback below
+        }
+      }
+    }
+
+    // Fallback to current date if no valid date found
+    if (!datePublished) {
+      [datePublished] = new Date().toISOString().split('T');
+    }
+
+    // Only add testimonial if we have the required fields
+    if (reviewText && authorName && ratingValue > 0) {
+      testimonials.push({
+        '@type': 'Review',
+        reviewBody: reviewText,
+        reviewRating: {
+          '@type': 'Rating',
+          ratingValue: ratingValue.toString(),
+          bestRating: '5',
+        },
+        author: {
+          '@type': 'Person',
+          name: authorName,
+        },
+        datePublished,
+        itemReviewed: {
+          '@type': 'Product',
+          name: productName,
+        },
+      });
+    }
+  });
+
+  // Don't generate schema if no valid testimonials found
+  if (testimonials.length === 0) {
+    return null;
+  }
+
+  // Create aggregate rating
+  const totalRating = testimonials.reduce(
+    (sum, t) => sum + parseInt(t.reviewRating.ratingValue, 10),
+    0,
+  );
+  const avgRating = (totalRating / testimonials.length).toFixed(1);
+
+  // Return Product schema with reviews
+  return {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: 'IDFC FIRST Bank RuPay Credit Card',
+    description: 'Apply for RuPay Credit Card at IDFC FIRST Bank & get 3X rewards on UPI transactions. Enjoy exclusive benefits, cashback, seamless digital payments.',
+    brand: {
+      '@type': 'Brand',
+      name: 'IDFC FIRST Bank',
+    },
+    aggregateRating: {
+      '@type': 'AggregateRating',
+      ratingValue: avgRating,
+      ratingCount: testimonials.length.toString(),
+      reviewCount: testimonials.length.toString(),
+    },
+    review: testimonials,
+  };
+}
+
+/**
+ * Injects JSON-LD schema into the document head
+ * @param {Object} schema The schema object to inject
+ */
+function injectSchema(schema) {
+  // Don't inject if schema is null or empty
+  if (!schema) {
+    return;
+  }
+
+  // Remove existing testimonial schemas and any with errors
+  const existingSchemas = document.querySelectorAll(
+    'script[type="application/ld+json"][data-schema-type="testimonial"], script[type="application/ld+json"][data-error]',
+  );
+  existingSchemas.forEach((script) => script.remove());
+
+  // Use a global flag to ensure we only inject once per page
+  if (window.testimonialSchemaInjected) {
+    return;
+  }
+
+  try {
+    // Stringify the schema with pretty printing for readability
+    const jsonString = JSON.stringify(schema, null, 2);
+
+    // Validate by parsing it back (this will throw if invalid)
+    JSON.parse(jsonString);
+
+    // Create script element with content already set
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.setAttribute('data-schema-type', 'testimonial');
+    script.text = jsonString; // Set content before appending
+
+    // Append to head immediately
+    document.head.appendChild(script);
+
+    // Mark as injected globally to prevent duplicates
+    window.testimonialSchemaInjected = true;
+
+    // Clean up any error scripts after a brief delay
+    setTimeout(() => {
+      const errorScripts = document.querySelectorAll('script[type="application/ld+json"][data-error]');
+      errorScripts.forEach((errScript) => errScript.remove());
+    }, 500);
+  } catch (error) {
+    // Silently fail - don't break the page if schema generation fails
+    // eslint-disable-next-line no-console
+    console.error('Failed to inject JSON-LD schema:', error);
+  }
+}
+
+/**
  * Extracts block-level properties from placeholder cards and sets them as data attributes
  * @param {HTMLElement} block The block element
  * @param {HTMLElement} ul The ul containing card items
@@ -267,5 +461,12 @@ export default async function decorate(block) {
       cards.forEach((card) => { card.style.display = 'flex'; });
       setupToggleButton();
     });
+  }
+
+  // Generate and inject JSON-LD schema for ALL testimonial cards (with or without swiper)
+  // This runs at the end after all DOM manipulation is complete
+  if (isTestimonial) {
+    const schema = generateTestimonialSchema(block);
+    injectSchema(schema);
   }
 }


### PR DESCRIPTION
- Implemented functions to sanitize text and generate JSON-LD schema for testimonials.
- Added logic to extract review details, including review text, author name, product name, rating, and publication date.
- Injected the generated schema into the document head, ensuring no duplicates are created.
- Enhanced error handling for schema injection to prevent page breaks on failure.

You can see a validation of the schema here: https://validator.schema.org/#url=https%3A%2F%2F76-schematestimonial--idfc--aemsites.aem.page%2Fcredit-card%2Frupay-credit-card

Fix #76

Schema output looks like this in `head`:
<img width="844" height="1012" alt="image" src="https://github.com/user-attachments/assets/fbf8c86f-4d07-4ac6-a90f-0bb8a847c287" />


Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://76-schematestimonial--idfc--aemsites.aem.page/credit-card/rupay-credit-card
