### PR TITLE
Add modal block implementation with CSS and JavaScript

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -1,0 +1,84 @@
+body.modal-open {
+  overflow: hidden;
+}
+
+.modal dialog::backdrop {
+  background-color: rgb(19 19 19 / 75%);
+}
+
+.modal dialog {
+  overscroll-behavior: none;
+  overflow-y: hidden;
+  width: calc(100vw - 48px);
+  max-width: 900px;
+  max-height: calc(100dvh - (2 * var(--header-height)));
+  padding: 0;
+  border: 1px solid var(--dark-color);
+}
+
+.modal dialog .modal-content {
+  box-sizing: border-box;
+  overflow-y: auto;
+  overscroll-behavior: none;
+  width: 100%;
+  max-height: calc(100dvh - (2 * var(--header-height)) - 48px);
+  padding: 24px;
+  padding-top: 0;
+  margin-top: 44px;
+}
+
+@media (width >= 900px) {
+  .modal dialog {
+    width: calc(100vw - 64px);
+  }
+  
+  .modal dialog .modal-content {
+    max-height: calc(100dvh - (2 * var(--header-height)) - 64px);
+    padding: 32px;
+    padding-top: 0;
+  }
+}
+
+.modal .close-button {
+  position: absolute;
+  top: 0;
+  right: 0;
+  width: 44px;
+  height: 44px;
+  margin: 0;
+  border: none;
+  border-radius: 0;
+  padding: 0;
+  background-color: transparent;
+  color: var(--text-color);
+  line-height: 0;
+}
+
+.modal .close-button .icon.icon-close {
+  content: '';
+  width: 24px;
+  height: 24px;
+}
+
+.modal .close-button .icon.icon-close::before,
+.modal .close-button .icon.icon-close::after {
+  content: '';
+  box-sizing: border-box;
+  display: block;
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%) rotate(45deg);
+  width: 24px;
+  height: 2px;
+  border-radius: 2px;
+  background-color: currentcolor;
+}
+
+.modal .close-button .icon.icon-close::after {
+  transform: translate(-50%, -50%) rotate(-45deg)
+}
+
+.modal dialog .section {
+  padding: 0;
+}

--- a/blocks/modal/modal.js
+++ b/blocks/modal/modal.js
@@ -1,0 +1,71 @@
+import {
+  buildBlock, decorateBlock, loadBlock, loadCSS,
+} from '../../scripts/aem.js';
+import { loadFragment } from '../../scripts/scripts.js';
+
+/*
+  This is not a traditional block, so there is no decorate function.
+  Instead, links to a /modals/ path are automatically transformed into a modal.
+  Other blocks can also use the createModal() and openModal() functions.
+*/
+
+export async function createModal(contentNodes) {
+  await loadCSS(`${window.hlx.codeBasePath}/blocks/modal/modal.css`);
+  const dialog = document.createElement('dialog');
+  const dialogContent = document.createElement('div');
+  dialogContent.classList.add('modal-content');
+  dialogContent.append(...contentNodes);
+  dialog.append(dialogContent);
+
+  const closeButton = document.createElement('button');
+  closeButton.classList.add('close-button');
+  closeButton.setAttribute('aria-label', 'Close');
+  closeButton.type = 'button';
+  closeButton.innerHTML = '<span class="icon icon-close"></span>';
+  closeButton.addEventListener('click', () => dialog.close());
+  dialog.prepend(closeButton);
+
+  const block = buildBlock('modal', '');
+  document.querySelector('main').append(block);
+  decorateBlock(block);
+  await loadBlock(block);
+
+  // close on click outside the dialog
+  dialog.addEventListener('click', (e) => {
+    const {
+      left, right, top, bottom,
+    } = dialog.getBoundingClientRect();
+    const { clientX, clientY } = e;
+    if (clientX < left || clientX > right || clientY < top || clientY > bottom) {
+      dialog.close();
+    }
+  });
+
+  dialog.addEventListener('close', () => {
+    document.body.classList.remove('modal-open');
+    block.remove();
+  });
+
+  block.innerHTML = '';
+  block.append(dialog);
+
+  return {
+    block,
+    showModal: () => {
+      dialog.showModal();
+      // reset scroll position
+      setTimeout(() => { dialogContent.scrollTop = 0; }, 0);
+      document.body.classList.add('modal-open');
+    },
+  };
+}
+
+export async function openModal(fragmentUrl) {
+  const path = fragmentUrl.startsWith('http')
+    ? new URL(fragmentUrl, window.location).pathname
+    : fragmentUrl;
+
+  const fragment = await loadFragment(path);
+  const { showModal } = await createModal(fragment.childNodes);
+  showModal();
+}

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -63,6 +63,10 @@ async function loadFonts() {
   }
 }
 
+/**
+ * Autolinks modals
+ * @param {Element} element The element to autolink modals
+ */
 function autolinkModals(element) {
   element.addEventListener('click', async (e) => {
     const origin = e.target.closest('a');


### PR DESCRIPTION
https://www.aem.live/developer/block-collection/modal.

Add official modal block featuring styles for modal dialogs, includes a close button and functionality to close when clicking outside the dialog.

Be aware that the logic for triggering and auto-linking modals depends on the URL having the literal path `/modals/` somewhere within it. Ensure that naming of subfolders or a root global modals folders is the full `modals` literal text, and not `modal` or `global-modal` or `rupay-modals`, etc., as those will not get auto-modal'd. 

```
function autolinkModals(element) {
  element.addEventListener('click', async (e) => {
    const origin = e.target.closest('a');

    if (origin && origin.href && origin.href.includes('/modals/')) {
      e.preventDefault();
      const { openModal } = await import(`${window.hlx.codeBasePath}/blocks/modal/modal.js`);
      openModal(origin.href);
    }
  });
}
```

Fix #128

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://128-automodals--idfc--aemsites.aem.page/credit-card/rupay-credit-card
