### PR TITLE
Add UE styles for Tab Titles

### DIFF
--- a/blocks/tabs/_tabs.json
+++ b/blocks/tabs/_tabs.json
@@ -42,7 +42,29 @@
             "component": "text",
             "valueType": "string",
             "name": "classes",
-            "label": "Style"
+            "label": "Style",
+            "options": [
+              {
+                "name": "Standard",
+                "value": ""
+              },
+              {
+                "name": "Silver with Blue Text",
+                "value": "silver-blue-text"
+              },
+              {
+                "name": "Silver with Red Text",
+                "value": "silver-red-text"
+              },
+              {
+                "name": "Blue with White Text",
+                "value": "blue-white-text"
+              },
+              {
+                "name": "Red with White Text",
+                "value": "red-white-text"
+              }
+            ]
           }
         ]
       },

--- a/component-models.json
+++ b/component-models.json
@@ -1224,7 +1224,29 @@
         "component": "text",
         "valueType": "string",
         "name": "classes",
-        "label": "Style"
+        "label": "Style",
+        "options": [
+          {
+            "name": "Standard",
+            "value": ""
+          },
+          {
+            "name": "Silver with Blue Text",
+            "value": "silver-blue-text"
+          },
+          {
+            "name": "Silver with Red Text",
+            "value": "silver-red-text"
+          },
+          {
+            "name": "Blue with White Text",
+            "value": "blue-white-text"
+          },
+          {
+            "name": "Red with White Text",
+            "value": "red-white-text"
+          }
+        ]
       }
     ]
   },


### PR DESCRIPTION
Adding the UE definitions for the styles available to be authored. 

Fix #125 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://125-tabs-title-styles--idfc--aemsites.aem.page/
