### PR TITLE
148 sectioncolor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -18,5 +18,9 @@ module.exports = {
     'import/extensions': ['error', { js: 'always' }], // require js file extensions in imports
     'linebreak-style': ['error', 'unix'], // enforce unix linebreaks
     'no-param-reassign': [2, { props: false }], // allow modifying properties of param
+    'xwalk/max-cells': ['error', {
+      section: 100, // section is a key-value block
+      container: 100, // container is a key-value block
+    }],
   },
 };

--- a/component-models.json
+++ b/component-models.json
@@ -162,6 +162,30 @@
         "multi": false
       },
       {
+        "component": "reference",
+        "valueType": "string",
+        "name": "sectionBackgroundImageMobile",
+        "label": "Background Image Mobile",
+        "description": "The background image of the section, displayed on top of the background color if specified",
+        "multi": false
+      },
+      {
+        "component": "text",
+        "name": "height",
+        "label": "Desktop Height",
+        "value": "",
+        "valueType": "string",
+        "description": "optional minimum height when in desktop, e.g. 400px"
+      },
+      {
+        "component": "text",
+        "name": "height_mobile",
+        "label": "Mobile Height",
+        "value": "",
+        "valueType": "string",
+        "description": "optional minimum height when in mobile, e.g. 400px"
+      },
+      {
         "component": "multiselect",
         "name": "style",
         "label": "Style",

--- a/component-models.json
+++ b/component-models.json
@@ -179,7 +179,7 @@
       },
       {
         "component": "text",
-        "name": "height_mobile",
+        "name": "heightmobile",
         "label": "Mobile Height",
         "value": "",
         "valueType": "string",

--- a/models/_section.json
+++ b/models/_section.json
@@ -42,6 +42,30 @@
           "multi": false
         },
         {
+          "component": "reference",
+          "valueType": "string",
+          "name": "sectionBackgroundImageMobile",
+          "label": "Background Image Mobile",
+          "description": "The background image of the section, displayed on top of the background color if specified",
+          "multi": false
+        },
+        {
+          "component": "text",
+          "name": "height",
+          "label": "Desktop Height",
+          "value": "",
+          "valueType": "string",
+          "description": "optional minimum height when in desktop, e.g. 400px"
+        },
+        {
+          "component": "text",
+          "name": "height_mobile",
+          "label": "Mobile Height",
+          "value": "",
+          "valueType": "string",
+          "description": "optional minimum height when in mobile, e.g. 400px"
+        },
+        {
           "component": "multiselect",
           "name": "style",
           "label": "Style",

--- a/models/_section.json
+++ b/models/_section.json
@@ -59,7 +59,7 @@
         },
         {
           "component": "text",
-          "name": "height_mobile",
+          "name": "heightmobile",
           "label": "Mobile Height",
           "value": "",
           "valueType": "string",

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -473,49 +473,7 @@ function decorateIcons(element, prefix = '') {
   });
 }
 
-/**
- * Decorates all sections in a container element.
- * @param {Element} main The container element
- */
-function decorateSections(main) {
-  main.querySelectorAll(':scope > div:not([data-section-status])').forEach((section) => {
-    const wrappers = [];
-    let defaultContent = false;
-    [...section.children].forEach((e) => {
-      if ((e.tagName === 'DIV' && e.className) || !defaultContent) {
-        const wrapper = document.createElement('div');
-        wrappers.push(wrapper);
-        defaultContent = e.tagName !== 'DIV' || !e.className;
-        if (defaultContent) wrapper.classList.add('default-content-wrapper');
-      }
-      wrappers[wrappers.length - 1].append(e);
-    });
-    wrappers.forEach((wrapper) => section.append(wrapper));
-    section.classList.add('section');
-    section.dataset.sectionStatus = 'initialized';
-    section.style.display = 'none';
-
-    // Process section metadata
-    const sectionMeta = section.querySelector('div.section-metadata');
-    if (sectionMeta) {
-      const meta = readBlockConfig(sectionMeta);
-      Object.keys(meta).forEach((key) => {
-        if (key === 'style') {
-          const styles = meta.style
-            .split(',')
-            .filter((style) => style)
-            .map((style) => toClassName(style.trim()));
-          styles.forEach((style) => section.classList.add(style));
-        } else if (key === 'id') {
-          section.id = meta[key];
-        } else {
-          section.dataset[toCamelCase(key)] = meta[key];
-        }
-      });
-      sectionMeta.parentNode.remove();
-    }
-  });
-}
+/* decorateSections moved to scripts.js */
 
 /**
  * Gets placeholders object.
@@ -736,7 +694,6 @@ export {
   decorateBlocks,
   decorateButtons,
   decorateIcons,
-  decorateSections,
   decorateTemplateAndTheme,
   fetchPlaceholders,
   getMetadata,

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -3,14 +3,13 @@ import {
   decorateBlocks,
   decorateButtons,
   decorateIcons,
-  decorateSections,
   loadBlock,
   loadSections,
   loadCSS,
   getMetadata,
 } from './aem.js';
 import { decorateRichtext } from './editor-support-rte.js';
-import { decorateMain, loadFragment, applySectionBackgroundColors } from './scripts.js';
+import { decorateSections, decorateMain, loadFragment } from './scripts.js';
 
 /**
  * Check if we're editing a framework page (should skip nav building)
@@ -214,7 +213,6 @@ async function applyChanges(event) {
           decorateIcons(newSection);
           decorateRichtext(newSection);
           decorateSections(parentElement);
-          applySectionBackgroundColors(parentElement);
           decorateBlocks(parentElement);
           await loadSections(parentElement);
           element.remove();

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -883,9 +883,8 @@ export function decorateSections(main) {
       const isMobile = MEDIA_QUERIES.mobile.matches;
       sectionsWithHeight.forEach(({ section, heightDesktop, heightMobile }) => {
         const height = isMobile && heightMobile ? heightMobile : heightDesktop;
-        if (height) {
-          section.style.minHeight = height;
-        }
+        // Always set minHeight (or clear it with empty string if no value for current breakpoint)
+        section.style.minHeight = height || '';
       });
     };
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -726,25 +726,15 @@ function extractSectionPropertiesFromEditor(section) {
  */
 export function applySectionBackgroundColors(main) {
   main.querySelectorAll('.section').forEach((section) => {
-    // Normalize backgroundColor data attribute variations
-    // The HTML may serialize as data-backgroundcolor, data-background-color,
-    // or data-backgroundColor. Ensure section.dataset.backgroundColor is set.
-    const bgColorVariants = ['backgroundcolor', 'background-color'];
-    bgColorVariants.forEach((variant) => {
-      if (section.dataset[variant] && !section.dataset.backgroundColor) {
-        section.dataset.backgroundColor = section.dataset[variant];
-      }
-    });
+    // Normalize backgroundColor data attribute
+    if (section.dataset.backgroundcolor && !section.dataset.backgroundColor) {
+      section.dataset.backgroundColor = section.dataset.backgroundcolor;
+    }
 
-    // Normalize sectionBackgroundImage data attribute variations
-    // The HTML may serialize as data-sectionbackgroundimage, data-section-background-image, etc.
-    // Ensure we always have section.dataset.sectionBackgroundImage set for the JavaScript to use
-    const bgImageVariants = ['sectionbackgroundimage', 'section-background-image'];
-    bgImageVariants.forEach((variant) => {
-      if (section.dataset[variant] && !section.dataset.sectionBackgroundImage) {
-        section.dataset.sectionBackgroundImage = section.dataset[variant];
-      }
-    });
+    // Normalize sectionBackgroundImage data attribute
+    if (section.dataset.sectionbackgroundimage && !section.dataset.sectionBackgroundImage) {
+      section.dataset.sectionBackgroundImage = section.dataset.sectionbackgroundimage;
+    }
 
     let bgValue = null;
     let bgImageValue = null;
@@ -763,12 +753,12 @@ export function applySectionBackgroundColors(main) {
     if (section.hasAttribute('data-aue-resource')) {
       const editorProps = extractSectionPropertiesFromEditor(section);
 
-      if (!bgValue && (editorProps['background-color'] || editorProps.backgroundColor)) {
-        bgValue = (editorProps['background-color'] || editorProps.backgroundColor).trim();
+      if (!bgValue && editorProps.backgroundColor) {
+        bgValue = editorProps.backgroundColor.trim();
       }
 
-      if (!bgImageValue && (editorProps['section-background-image'] || editorProps.sectionBackgroundImage)) {
-        bgImageValue = (editorProps['section-background-image'] || editorProps.sectionBackgroundImage).trim();
+      if (!bgImageValue && editorProps.sectionBackgroundImage) {
+        bgImageValue = editorProps.sectionBackgroundImage.trim();
       }
     }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -326,6 +326,8 @@ main img {
 /* sections */
 main>.section {
   margin: 0;
+  position: relative;
+  overflow: hidden;
 }
 
 main>.section>div {
@@ -520,6 +522,17 @@ main .section.upi-steps-red-bg {
   background: var(--gradient-upi-steps-red);
   margin: 0;
   padding: 40px 0 56px;
+}
+
+.section .bg-images picture {
+  position: absolute;
+  top: 0;
+  right: 0;
+}
+
+.section:has(.bg-images) > div:not(.bg-images) {
+  position: relative;
+  z-index: 1;
 }
 
 /* IDFC */


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #148 
- Fixed 'background-color' to just 'background' so that a gradient can be used.
- Added a mobile image option, since I saw this on the live Mayura page. I can't pick more than 1 image until this is merged though so I will do more testing after.
- Changed from actual background styles to creating a new bg-images DIV and Picture element that can contain both mobile and a default image to be used as a background.
- Added "min-height" options, since I see those are being used on the live Mayura page. (I didn't add as many as they had).
I couldn't test the height values until I get the UE fields merged in.
- I hope these heights don't affect CLS scores.

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/sections
- After: https://148-sectioncolor--idfc--aemsites.aem.page/library/sections
