### PR TITLE
add  icon name as alt for accessibility

### DIFF
--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -456,7 +456,7 @@ function decorateIcon(span, prefix = '', alt = '') {
   const img = document.createElement('img');
   img.dataset.iconName = iconName;
   img.src = `${window.hlx.codeBasePath}${prefix}/icons/${iconName}.svg`;
-  img.alt = alt;
+  img.alt = alt ? `${alt} ${iconName}` : iconName;
   img.loading = 'lazy';
   span.append(img);
 }


### PR DESCRIPTION
Add alt name to icons with links for accessibility improvement. 
Check the alt name on the social media icons in the footer

Fix #161 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://161-icon-link-names--idfc--aemsites.aem.page/credit-card/rupay-credit-card
