### PR TITLE
fix typo

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -873,7 +873,7 @@ function decorateContainerSections(main) {
 
   sections.forEach((section, index) => {
     const includeNext = parseInt(
-      section.dataset.includeNextSections || '0',
+      section.dataset.includenextsections || '0',
       10,
     );
     if (!includeNext || includeNext <= 0) {
@@ -923,6 +923,7 @@ export function decorateMain(main) {
   decorateSections(main);
   decorateBlocks(main);
   buildEmbedBlocks(main);
+  decorateContainerSections(main);
 }
 
 function addOverlayRule(ruleSet, selector, property, value) {
@@ -1417,7 +1418,6 @@ async function loadLazy(doc) {
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
   loadAutoBlock(doc);
-  decorateContainerSections(main);
   createResponsiveBackgroundPicture(main);
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -343,6 +343,7 @@ main>.section:first-of-type {
 /* Container with a large background */
 .section.container-section--merged {
   position: relative;
+  overflow: visible;
 }
 
 /* All merged siblings share positioning context */


### PR DESCRIPTION
for issue 153. This fixes a typo I had.

The container section is generally doing what I am telling it to do, which is to add a special class to the next amount of sections specified and let the Container's BG image bleed through. 
Still to do: How to cut off the background after the last "container-section--merged-sibling".
I am setting the rest of this for after we have Rupay done though.

Test URLs:

Before: https://main--idfc--aemsites.aem.page/library/sections
After: https://153-container--idfc--aemsites.aem.page/library/sections