### PR TITLE
Add related-search card styles and JS

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -100,7 +100,7 @@
 }
 
 .cards .card-clickable:focus {
-  outline: 2px solid var(--link-color, #B31B1B);
+  outline: 2px solid #B31B1B;
   outline-offset: 2px;
 }
 
@@ -320,6 +320,113 @@
   text-align: center;
   margin: 32px 0;
   padding: 0 16px;
+}
+
+/* === RELATED SEARCH CARD VARIANT === */
+.section:has(.cards.related-search) {
+  padding: 40px 16px 60px;
+}
+
+.section:has(.cards.related-search) .default-content-wrapper h2 {
+  color: #54565b;
+  font-size: 21px;
+  font-weight: 600;
+  margin: 0 0 24px;
+}
+
+.section:has(.cards.related-search) .cards-wrapper {
+  padding: 0 12px;
+}
+
+/* Hide View All button for related-search */
+.cards.related-search .view-toggle {
+  display: none;
+}
+
+/* Related Search Cards Container */
+.cards.related-search .grid-cards {
+  display: grid;
+  grid-template-columns: 1fr;
+  gap: 16px;
+}
+
+/* Related Search Card Styling */
+.cards.related-search .benefit-cards {
+  display: flex;
+  flex-direction: row;
+  align-items: center;
+  height: 90px;
+  padding: 0 16px;
+  margin-bottom: 24px;
+  background: #fff;
+  border-radius: 12px;
+  box-shadow: 0 2px 8px rgba(0 0 0 / 8%);
+  width: 100%;
+  gap: 16px;
+  position: relative;
+  transition: box-shadow 0.2s ease, transform 0.2s ease;
+}
+
+.cards.related-search .benefit-cards:hover {
+  box-shadow: 0 4px 16px rgba(0 0 0 / 12%);
+  transform: translateY(-2px);
+}
+
+/* Related Search Card Image */
+.cards.related-search .benefit-cards .cards-card-image {
+  flex-shrink: 0;
+  width: 70px;
+  height: 70px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cards.related-search .benefit-cards .cards-card-image img {
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
+  border-radius: 4px;
+}
+
+/* Related Search Card Body */
+.cards.related-search .benefit-cards .cards-card-body {
+  flex: 1;
+  margin: 0;
+  padding-right: 40px;
+}
+
+.cards.related-search .benefit-cards .cards-card-body h3 {
+  font-size: 14px;
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0;
+}
+
+.cards.related-search .benefit-cards .cards-card-body h3 a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.cards.related-search .benefit-cards .cards-card-body h3 a:hover {
+  text-decoration: none;
+}
+
+/* Related Search Arrow Circle */
+.cards.related-search .benefit-cards::after {
+  content: '';
+  position: absolute;
+  right: 16px;
+  top: 50%;
+  transform: translateY(-50%);
+  width: 40px;
+  height: 40px;
+  background-color: #f0f0f0;
+  border-radius: 50%;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='16' height='16' viewBox='0 0 24 24' fill='none' stroke='%238B1B2D' stroke-width='2.5' stroke-linecap='round' stroke-linejoin='round'%3E%3Cpath d='M5 12h14'/%3E%3Cpath d='m12 5 7 7-7 7'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-position: center;
+  background-size: 24px 24px;
 }
 
 /* === KEY BENEFITS CARD VARIANT === */
@@ -956,6 +1063,34 @@
   .cards.blog-posts .blog-post-card .cards-card-body p {
     font-size: 13px;
   }
+
+  /* Related Search Cards - Tablet (2 columns) */
+  .section:has(.cards.related-search) {
+    padding: 40px 24px 60px;
+  }
+
+  .section:has(.cards.related-search) .default-content-wrapper h2 {
+    font-size: 28px;
+    margin-bottom: 32px;
+  }
+
+  .cards.related-search .grid-cards {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px 30px;
+  }
+
+  .cards.related-search .benefit-cards {
+    margin-bottom: 0;
+  }
+
+  .cards.related-search .benefit-cards .cards-card-image {
+    width: 80px;
+    height: 70px;
+  }
+
+  .cards.related-search .benefit-cards .cards-card-body h3 {
+    font-size: 15px;
+  }
 }
 
 
@@ -1345,6 +1480,37 @@
 
   .cards.blog-posts .blog-post-card .cards-card-body p {
     font-size: 14px;
+  }
+
+  /* Related Search Cards - Desktop (3 columns) */
+  .section:has(.cards.related-search) {
+    padding: 48px 40px 72px;
+  }
+
+  .section:has(.cards.related-search) .default-content-wrapper h2 {
+    font-size: 32px;
+    margin-bottom: 40px;
+  }
+
+  .cards.related-search .grid-cards {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 20px 30px;
+    max-width: 1120px;
+    margin: 0 auto;
+  }
+
+  .cards.related-search .benefit-cards {
+    padding: 0 20px;
+    margin-bottom: 0;
+  }
+
+  .cards.related-search .benefit-cards .cards-card-image {
+    width: 90px;
+    height: 75px;
+  }
+
+  .cards.related-search .benefit-cards .cards-card-body h3 {
+    font-size: 16px;
   }
 }
 

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -337,13 +337,19 @@ function setupCardInteractivity(li) {
   const mainBody = cardBodies[0];
   const modalContentDiv = cardBodies.length > 1 ? cardBodies[cardBodies.length - 1] : null;
 
-  // Check if modal content div has actual content
+  // Check if modal content div has actual content (not just a link from cardLink field)
+  // If the div only contains a single link with no other text, it's a cardLink, not modal content
+  const isJustALink = modalContentDiv
+    && modalContentDiv.querySelector('a')
+    && modalContentDiv.textContent.trim() === modalContentDiv.querySelector('a')?.textContent.trim();
+
   const hasModalContent = modalContentDiv
     && modalContentDiv.textContent.trim().length > 0
-    && modalContentDiv !== mainBody;
+    && modalContentDiv !== mainBody
+    && !isJustALink;
 
-  // Mark the modal content div with a specific class for styling/hiding
-  if (hasModalContent) {
+  // Hide the secondary body div (whether it's modal content or just a cardLink)
+  if (modalContentDiv && modalContentDiv !== mainBody) {
     modalContentDiv.classList.add('cards-modal-content');
   }
 
@@ -544,6 +550,8 @@ export default async function decorate(block) {
   const isTestimonial = block.classList.contains('testimonial-card');
   // Check if important-documents variant
   const isImportantDocuments = block.classList.contains('important-documents');
+  // Check if related-search variant
+  const isRelatedSearch = block.classList.contains('related-search');
   // Check if experience-life variant
   const isExperienceLife = block.classList.contains('experience-life');
   // Check if blog-posts variant
@@ -775,7 +783,7 @@ export default async function decorate(block) {
       swiper.on('slideChangeTransitionEnd', updateStarIcons);
       swiper.on('slideChange', updateStarIcons);
     }
-  } else if (!isTestimonial && !isImportantDocuments) {
+  } else if (!isTestimonial && !isImportantDocuments && !isRelatedSearch) {
     // === View All / View Less Toggle (Mobile Only) - Only for benefit cards ===
     const cards = ul.querySelectorAll('li');
     const maxVisible = 3;


### PR DESCRIPTION
- Updated CSS for related-search cards. 
- Modified JavaScript to handle related search variant logic and ensure proper modal content display as some certain authoring cases caused things to modal-ize instead of just link to an HREF.

Fix #171

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://171-relatedsearchcard--idfc--aemsites.aem.page/credit-card/rupay-credit-card
