### PR TITLE
change height value

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -800,13 +800,7 @@ section.faq-accordion-container h4 {
   }
 
   header {
-    height: 140px;
-  }
-
-  /* Reserve space for category navigation to prevent CLS */
-  /* Category nav wrapper is always present as placeholder, so always reserve space */
-  header:has(.category-nav-wrapper) {
-    height: 204px; /* 140px base + 64px for category nav */
+    height: 204px;
   }
   
   /* If category-nav-wrapper exists but is empty, still reserve the space */


### PR DESCRIPTION
Change the height of the header. Instead of trying to add in the category nav bar, we are now assuming it will always be present. We adjusted the base height and removed the calculation that was deciding on if the category nav would be present. 

Fix #190 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://190-cls-fix--idfc--aemsites.aem.page/credit-card/rupay-credit-card
