### PR TITLE
updated image and color handling

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -161,6 +161,14 @@
             "value": "center"
           },
           {
+            "name": "Light scheme",
+            "value": "light-scheme"
+          },
+          {
+            "name": "Dark scheme",
+            "value": "dark-scheme"
+          },
+          {
             "name": "UPI steps red background",
             "value": "upi-steps-red-bg"
           }
@@ -196,6 +204,56 @@
             "label": "Background Image Mobile",
             "description": "Background image for mobile",
             "multi": false
+          },
+          {
+            "component": "select",
+            "valueType": "string",
+            "name": "object-fit",
+            "label": "Background Fit",
+            "value": "cover",
+            "options": [
+              {
+                "name": "cover",
+                "value": "cover"
+              },
+              {
+                "name": "contain",
+                "value": "contain"
+              },
+              {
+                "name": "none",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "component": "select",
+            "valueType": "string",
+            "name": "object-position",
+            "label": "Background Image Position",
+            "value": "center",
+            "options": [
+              {
+                "name": "center",
+                "value": "center"
+              },
+              {
+                "name": "top left",
+                "value": "top left"
+              },
+              {
+                "name": "top right",
+                "value": "top right"
+              },
+              {
+                "name": "bottom left",
+                "value": "bottom left"
+              },
+              {
+                "name": "bottom right",
+                "value": "bottom right"
+              }
+            ]
           },
           {
             "component": "text",

--- a/models/_section.json
+++ b/models/_section.json
@@ -41,6 +41,14 @@
               "value": "center"
             },
             {
+              "name": "Light scheme",
+              "value": "light-scheme"
+            },
+            {
+              "name": "Dark scheme",
+              "value": "dark-scheme"
+            },
+            {
               "name": "UPI steps red background",
               "value": "upi-steps-red-bg"
             }
@@ -76,6 +84,56 @@
           "label": "Background Image Mobile",
           "description": "Background image for mobile",
           "multi": false
+        },
+        {
+          "component": "select",
+          "valueType": "string",
+          "name": "object-fit",
+          "label": "Background Fit",
+          "value": "cover",
+          "options": [
+            {
+              "name": "cover",
+              "value": "cover"
+            },
+            {
+              "name": "contain",
+              "value": "contain"
+            },
+            {
+              "name": "none",
+              "value": "none"
+            }
+          ]
+        },
+        {
+          "component": "select",
+          "valueType": "string",
+          "name": "object-position",
+          "label": "Background Image Position",
+          "value": "center",
+          "options": [
+            {
+              "name": "center",
+              "value": "center"
+            },
+            {
+              "name": "top left",
+              "value": "top left"
+            },
+            {
+              "name": "top right",
+              "value": "top right"
+            },
+            {
+              "name": "bottom left",
+              "value": "bottom left"
+            },
+            {
+              "name": "bottom right",
+              "value": "bottom right"
+            }
+          ]
         },
         {
           "component": "text",

--- a/package-lock.json
+++ b/package-lock.json
@@ -2844,10 +2844,11 @@
       "dev": true
     },
     "node_modules/js-yaml": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.0.tgz",
-      "integrity": "sha512-wpxZs9NoxZaJESJGIZTyDEaYpl0FKSA+FB9aJiyemKhMwkxQg63h4T1KJgUGHpTqPDNRcmmYLugrRjJlBtWvRA==",
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.1.1.tgz",
+      "integrity": "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "argparse": "^2.0.1"
       },

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -704,15 +704,6 @@ export function setColorScheme(section) {
   });
 }
 
-function handleBackground(background, section) {
-  const pic = background.content.querySelector('picture');
-  if (pic) {
-    section.classList.add('has-bg-image');
-    pic.classList.add('section-background');
-    section.prepend(pic);
-  }
-}
-
 /**
  * Helper function to create a <source> element
  * @param {string} src the image url
@@ -771,6 +762,7 @@ function createResponsiveBackgroundPicture(main) {
       newImg.src = defaultImgUrl;
 
       newPic.appendChild(newImg);
+      sectionImgContainer.classList.add('has-bg-images');
       sectionImgContainer.prepend(newPic);
     }
   });
@@ -806,17 +798,6 @@ export function decorateSections(main) {
     let heightMobile = null;
 
     if (sectionMeta) {
-      // Handle background images before readBlockConfig processes metadata
-      const backgroundRow = [...sectionMeta.querySelectorAll(':scope > div')].find((row) => {
-        const cols = [...row.children];
-        return cols[0] && toClassName(cols[0].textContent) === 'background' && cols[1];
-      });
-
-      if (backgroundRow) {
-        const backgroundContent = backgroundRow.children[1];
-        handleBackground({ content: backgroundContent }, section);
-      }
-
       const meta = readBlockConfig(sectionMeta);
       Object.keys(meta).forEach((key) => {
         if (key === 'style') {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -647,6 +647,73 @@ function loadAutoBlock(doc) {
 /** SECTIONS */
 
 /**
+ * Converts a CSS color value to RGB values
+ * @param {string} color - CSS color value (hex, rgb, rgba, hsl, hsla, or named color)
+ * @returns {Object|null} Object with r, g, b values (0-255) or null if invalid
+ */
+function parseColor(section) {
+  if (!section) return null;
+
+  const computedBg = getComputedStyle(section).backgroundColor;
+  const rgbMatch = computedBg.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
+  if (!rgbMatch) return null;
+  return {
+    r: parseInt(rgbMatch[1], 10),
+    g: parseInt(rgbMatch[2], 10),
+    b: parseInt(rgbMatch[3], 10),
+  };
+}
+
+function getRelativeLuminance({ r, g, b }) {
+  // Convert to sRGB
+  const rsRGB = r / 255;
+  const gsRGB = g / 255;
+  const bsRGB = b / 255;
+
+  // Apply gamma correction
+  const rLinear = rsRGB <= 0.03928 ? rsRGB / 12.92 : ((rsRGB + 0.055) / 1.055) ** 2.4;
+  const gLinear = gsRGB <= 0.03928 ? gsRGB / 12.92 : ((gsRGB + 0.055) / 1.055) ** 2.4;
+  const bLinear = bsRGB <= 0.03928 ? bsRGB / 12.92 : ((bsRGB + 0.055) / 1.055) ** 2.4;
+
+  // Calculate relative luminance
+  return 0.2126 * rLinear + 0.7152 * gLinear + 0.0722 * bLinear;
+}
+
+/**
+ * The color scheme detection uses the WCAG relative luminance formula to determine if a bg color
+ * is light or dark, ensuring accessible and appropriate styling for content within the section.
+ * Determines if a CSS color value is light or dark
+ * @param {string} color - CSS color value
+ * @param {number} threshold - Luminance threshold (default: 0.5)
+ * @returns {boolean} true if light, false if dark, null if invalid color
+ */
+export function getColorScheme(section) {
+  const rgb = parseColor(section);
+  if (!rgb) return null;
+
+  return getRelativeLuminance(rgb) > 0.5 ? 'light-scheme' : 'dark-scheme';
+}
+
+export function setColorScheme(section) {
+  const scheme = getColorScheme(section);
+  if (!scheme) return;
+  section.querySelectorAll(':scope > *').forEach((el) => {
+    // Reset any pre-made color schemes
+    el.classList.remove('light-scheme', 'dark-scheme');
+    el.classList.add(scheme);
+  });
+}
+
+function handleBackground(background, section) {
+  const pic = background.content.querySelector('picture');
+  if (pic) {
+    section.classList.add('has-bg-image');
+    pic.classList.add('section-background');
+    section.prepend(pic);
+  }
+}
+
+/**
  * Helper function to create a <source> element
  * @param {string} src the image url
  * @param {number} width the width of the image
@@ -676,11 +743,9 @@ function createResponsiveBackgroundPicture(main) {
     const sectionMobImg = sectionImgContainer.dataset.sectionbackgroundimagemobile;
     let defaultImgUrl = null;
 
-    const bgImagesDiv = document.createElement('div');
-    bgImagesDiv.classList.add('bg-images');
-    sectionImgContainer.prepend(bgImagesDiv);
-
     const newPic = document.createElement('picture');
+    newPic.classList.add('bg-images');
+
     if (sectionImg) {
       newPic.appendChild(createSource(sectionImg, 1920, MEDIA_QUERIES.desktop.media));
       newPic.appendChild(createSource(sectionImg, 899, MEDIA_QUERIES.tablet.media));
@@ -707,7 +772,6 @@ function createResponsiveBackgroundPicture(main) {
 
       newPic.appendChild(newImg);
       sectionImgContainer.prepend(newPic);
-      bgImagesDiv.appendChild(newPic);
     }
   });
 }
@@ -742,6 +806,17 @@ export function decorateSections(main) {
     let heightMobile = null;
 
     if (sectionMeta) {
+      // Handle background images before readBlockConfig processes metadata
+      const backgroundRow = [...sectionMeta.querySelectorAll(':scope > div')].find((row) => {
+        const cols = [...row.children];
+        return cols[0] && toClassName(cols[0].textContent) === 'background' && cols[1];
+      });
+
+      if (backgroundRow) {
+        const backgroundContent = backgroundRow.children[1];
+        handleBackground({ content: backgroundContent }, section);
+      }
+
       const meta = readBlockConfig(sectionMeta);
       Object.keys(meta).forEach((key) => {
         if (key === 'style') {
@@ -773,6 +848,9 @@ export function decorateSections(main) {
       }
       section.style.background = bgValue;
     }
+
+    // Apply color scheme based on background color
+    setColorScheme(section);
 
     // Store sections with height for batch processing all on page
     if (heightDesktop || heightMobile) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -342,6 +342,24 @@ main>.section:first-of-type {
   margin-top: 0;
 }
 
+.section .bg-images {
+  position: absolute;
+  display: block;
+  inset: 0;
+  z-index: 0;
+}
+
+.section .bg-images img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center;
+}
+
+.section.has-bg-images > *:not(.bg-images) {
+  position: relative;
+}
+
 [data-object-fit="none"] .bg-images img {
   object-fit: none;
 }
@@ -352,6 +370,8 @@ main>.section:first-of-type {
 
 [data-object-fit="cover"] .bg-images img {
   object-fit: cover;
+  height: 100%;
+  width: 100%;
 }
 
 [data-object-position="center"] .bg-images img {
@@ -585,17 +605,6 @@ main .section.upi-steps-red-bg {
 
 .section > .default-content-wrapper.dark-scheme {
   color: var(--white);
-}
-
-.section .bg-images picture {
-  position: absolute;
-  top: 0;
-  right: 0;
-}
-
-.section:has(.bg-images) > div:not(.bg-images) {
-  position: relative;
-  z-index: 1;
 }
 
 /* IDFC */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -342,6 +342,38 @@ main>.section:first-of-type {
   margin-top: 0;
 }
 
+[data-object-fit="none"] .bg-images img {
+  object-fit: none;
+}
+
+[data-object-fit="contain"] .bg-images img {
+  object-fit: contain;
+}
+
+[data-object-fit="cover"] .bg-images img {
+  object-fit: cover;
+}
+
+[data-object-position="center"] .bg-images img {
+  object-position: center;
+}
+
+[data-object-position="top left"] .bg-images img {
+  object-position: top left;
+}
+
+[data-object-position="top right"] .bg-images img {
+  object-position: top right;
+}
+
+[data-object-position="bottom left"] .bg-images img {
+  object-position: bottom left;
+}
+
+[data-object-position="bottom right"] .bg-images img {
+  object-position: bottom right;
+}
+
 /* Container with a large background */
 .section.container-section--merged {
   position: relative;
@@ -545,6 +577,14 @@ main .section.upi-steps-red-bg {
   background: var(--gradient-upi-steps-red);
   margin: 0;
   padding: 40px 0 56px;
+}
+
+.section > .default-content-wrapper.light-scheme {
+  color: var(--text-color);
+}
+
+.section > .default-content-wrapper.dark-scheme {
+  color: var(--white);
 }
 
 .section .bg-images picture {


### PR DESCRIPTION
<img width="425" height="813" alt="image" src="https://github.com/user-attachments/assets/14aac94d-d3d4-4974-a918-e840fa911600" />
the top image is cover/100% by default. Here is one with overriding properties:
<img width="1602" height="1106" alt="image" src="https://github.com/user-attachments/assets/c59ae50a-c7c1-4e2d-901e-6635fd687e41" />

new dark scheme and light scheme
<img width="1302" height="693" alt="image" src="https://github.com/user-attachments/assets/5b8452f2-7658-4874-b27d-66f4797760c2" />


Fix #204 , #166

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/sections
- After: https://204-sectionredo--idfc--aemsites.aem.page/library/sections
