### PR TITLE
simplify light and dark scheme css

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -599,11 +599,11 @@ main .section.upi-steps-red-bg {
   padding: 40px 0 56px;
 }
 
-.section > .default-content-wrapper.light-scheme {
+.light-scheme {
   color: var(--text-color);
 }
 
-.section > .default-content-wrapper.dark-scheme {
+.dark-scheme {
   color: var(--white);
 }
 


### PR DESCRIPTION
- simplify the .light-scheme and .dark-scheme CSS
- authored background attachment options on the test page

Fix #166 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/sections
- After: https://204-sectionredo--idfc--aemsites.aem.page/library/sections

After shows white text in the gradient section now. 
<img width="841" height="1109" alt="image" src="https://github.com/user-attachments/assets/5aefe036-8232-4dd3-ab71-2f2156aa847d" />

Despite what the aem-code-sync bot is saying, I got 100's here https://pagespeed.web.dev/analysis/https-204-sectionredo--idfc--aemsites-aem-page-library-sections/nf3y13ano8?utm_source=psi&utm_medium=redirect&form_factor=desktop
