### PR TITLE
Rename 'background' to 'backgroundColor' in JSON

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -183,7 +183,7 @@
         "fields": [
           {
             "component": "text",
-            "name": "background",
+            "name": "backgroundColor",
             "label": "Background Color/gradient",
             "value": "",
             "valueType": "string",


### PR DESCRIPTION
Removing it was a mistake. I will put it back properly in my next PR



Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://temp-fix--idfc--aemsites.aem.page/
