### PR TITLE
section refactor

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,5 +21,20 @@ module.exports = {
     'xwalk/max-cells': ['error', {
       section: 100, // section is a key-value block
     }],
+    'no-restricted-syntax': [
+      'error',
+      {
+        selector: 'ForInStatement',
+        message: 'for..in loops iterate over the entire prototype chain. Use Object.{keys,values,entries}, and iterate over the resulting array.',
+      },
+      {
+        selector: 'LabeledStatement',
+        message: 'Labels are a form of GOTO; using them makes code confusing and hard to maintain and understand.',
+      },
+      {
+        selector: 'WithStatement',
+        message: '`with` is disallowed in strict mode because it makes code impossible to predict and optimize.',
+      },
+    ],
   },
 };

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -201,7 +201,6 @@ footer .footer ul {
   align-items: center;
 }
 
-
 .footer>div>div:nth-child(3) {
   padding: 50px 0;
   padding-bottom: 27px;
@@ -230,11 +229,6 @@ footer .footer ul {
   line-height: 1;
   font: 400 24px / 1.25rem 'Roboto', sans-serif;
 }
-
-/* .footer>div>div:nth-child(3) .accordion {
-  width: 15%;
-} */
-
 
 .footer>div>div:nth-child(3) .accordion-wrapper .accordion>div,
 .footer>div>div:nth-child(3) .accordion-wrapper .accordion .accordion-item {
@@ -337,7 +331,6 @@ footer .footer>div .section:nth-child(4)>div p a {
     max-width: 100%;
     border: none;
     border-radius: unset;
-    border-bottom: 1px solid #dadada;
     font-weight: 700;
     border-bottom: 1px solid rgba(255, 255, 255, 0.21);
     letter-spacing: .5px;
@@ -416,11 +409,11 @@ footer .footer>div .section:nth-child(4)>div p a {
   }
 
   footer .footer>div .section:nth-child(4)>div ul li:nth-child(2) {
-    padding-bottom: 0px;
+    padding-bottom: 0;
   }
 
   footer .footer>div .section:nth-child(4)>div ul li:nth-child(3) {
-    padding-bottom: 0px;
+    padding-bottom: 0;
   }
 
   .footer>div>div:nth-child(2)>div>ul li>p {
@@ -429,16 +422,12 @@ footer .footer>div .section:nth-child(4)>div p a {
   }
 
   .footer>div>div:nth-child(2)>div>ul>li:nth-child(2)>ul>li:nth-child(2) {
-    display: block;
     display: inline-block;
     height: 48px;
-    min-width: 160px;
-    padding: 10px 30px;
     border-radius: 25px;
     background: #FFFFFF;
     color: var(--dark-red-color) !important;
     text-align: center;
-    line-height: 30px;
     white-space: nowrap;
     border: 0;
     font-size: 16px;

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -117,7 +117,7 @@ export default async function decorate(block) {
   nav.id = 'nav';
 
   // Get the default-content-wrapper from fragment
-  const contentWrapper = fragment.querySelector('.default-content-wrapper');
+  const contentWrapper = fragment.querySelector('.default-content');
   if (!contentWrapper) return;
 
   // Create the three main sections

--- a/component-models.json
+++ b/component-models.json
@@ -183,7 +183,7 @@
         "fields": [
           {
             "component": "text",
-            "name": "background",
+            "name": "backgroundColor",
             "label": "Background Color/gradient",
             "value": "",
             "valueType": "string",

--- a/models/_section.json
+++ b/models/_section.json
@@ -63,7 +63,7 @@
           "fields": [
         {
           "component": "text",
-          "name": "background",
+          "name": "backgroundColor",
           "label": "Background Color/gradient",
           "value": "",
           "valueType": "string",

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1497,7 +1497,6 @@ async function loadLazy(doc) {
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
   loadAutoBlock(doc);
-  // createResponsiveBackgroundPicture(main);
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -957,7 +957,7 @@ function groupChildren(section) {
   return groups;
 }
 
-function decorateSections(parent, isDoc) {
+export function decorateSections(parent, isDoc) {
   const selector = isDoc ? 'main > div' : ':scope > div';
   return [...parent.querySelectorAll(selector)].map((section) => {
     const groups = groupChildren(section);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,7 +14,7 @@ import {
   loadCSS,
   toClassName,
   getMetadata,
-  readBlockConfig,
+  // readBlockConfig,
   toCamelCase,
 } from './aem.js';
 
@@ -652,9 +652,9 @@ function loadAutoBlock(doc) {
  * @returns {Object|null} Object with r, g, b values (0-255) or null if invalid
  */
 function parseColor(section) {
-  if (!section) return null;
+  if (!section) return null; // for now, only using on sections
 
-  const computedBg = getComputedStyle(section).backgroundColor;
+  const computedBg = getComputedStyle(section).background;
   const rgbMatch = computedBg.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
   if (!rgbMatch) return null;
   return {
@@ -723,141 +723,256 @@ export function createSource(src, width, mediaQuery) {
 }
 
 /**
- * Creates a responsive picture element for background images with optimization
- * Similar to createOptimizedPicture, but for 2 background image options
- * @param {Element} main the main element
+ * Extracts image URL from metadata content (picture or img element)
+ * @param {Element} content the metadata content element
+ * @returns {string|null} the image URL or null
  */
-function createResponsiveBackgroundPicture(main) {
-  const sectionImgContainers = main.querySelectorAll(':scope > .section[data-sectionbackgroundimagemobile], :scope > .section[data-sectionbackgroundimage]');
-  sectionImgContainers.forEach((sectionImgContainer) => {
-    const sectionImg = sectionImgContainer.dataset.sectionbackgroundimage;
-    const sectionMobImg = sectionImgContainer.dataset.sectionbackgroundimagemobile;
-    let defaultImgUrl = null;
-
-    const newPic = document.createElement('picture');
-    newPic.classList.add('bg-images');
-
-    if (sectionImg) {
-      newPic.appendChild(createSource(sectionImg, 1920, MEDIA_QUERIES.desktop.media));
-      newPic.appendChild(createSource(sectionImg, 899, MEDIA_QUERIES.tablet.media));
-      defaultImgUrl = sectionImg;
-    }
-
-    if (sectionMobImg) {
-      newPic.appendChild(createSource(sectionMobImg, 600, MEDIA_QUERIES.mobile.media));
-      defaultImgUrl = sectionMobImg;
-    }
-
-    const newImg = document.createElement('img');
-    newImg.alt = '';
-    newImg.className = 'section-img';
-    newImg.loading = 'lazy';
-
-    if (defaultImgUrl) {
-      // Set width and height once image loads to get native dimensions
-      newImg.onload = () => {
-        newImg.width = newImg.naturalWidth;
-        newImg.height = newImg.naturalHeight;
-      };
-      newImg.src = defaultImgUrl;
-
-      newPic.appendChild(newImg);
-      sectionImgContainer.classList.add('has-bg-images');
-      sectionImgContainer.prepend(newPic);
-    }
-  });
+function extractImageUrl(content) {
+  const img = content.querySelector('img');
+  return img?.src || null;
 }
 
 /**
- * Decorates all sections in a container element. Moved from aem.js
- * @param {Element} main The container element
+ * Creates a responsive picture element for background images with optimization
+ * @param {string} desktopUrl the desktop background image URL
+ * @param {string|null} mobileUrl the mobile background image URL (optional)
+ * @param {Element} section the section element to add the background to
  */
-export function decorateSections(main) {
-  const sectionsWithHeight = [];
+function handleBackgroundImages(desktopUrl, mobileUrl, section) {
+  if (!desktopUrl) return;
 
-  main.querySelectorAll(':scope > div:not([data-section-status])').forEach((section) => {
-    const wrappers = [];
-    let defaultContent = false;
-    [...section.children].forEach((e) => {
-      if ((e.tagName === 'DIV' && e.className) || !defaultContent) {
-        const wrapper = document.createElement('div');
-        wrappers.push(wrapper);
-        defaultContent = e.tagName !== 'DIV' || !e.className;
-        if (defaultContent) wrapper.classList.add('default-content-wrapper');
-      }
-      wrappers[wrappers.length - 1].append(e);
-    });
-    wrappers.forEach((wrapper) => section.append(wrapper));
-    section.classList.add('section');
-    section.dataset.sectionStatus = 'initialized';
-    section.style.display = 'none';
+  const newPic = document.createElement('picture');
+  newPic.classList.add('bg-images');
 
-    // Process section metadata
-    const sectionMeta = section.querySelector('div.section-metadata');
-    let heightDesktop = null;
-    let heightMobile = null;
+  // Add mobile source if provided
+  if (mobileUrl) {
+    newPic.appendChild(createSource(mobileUrl, 600, MEDIA_QUERIES.mobile.media));
+  } else {
+    newPic.appendChild(createSource(desktopUrl, 899, MEDIA_QUERIES.tablet.media));
+  }
 
-    if (sectionMeta) {
-      const meta = readBlockConfig(sectionMeta);
-      Object.keys(meta).forEach((key) => {
-        if (key === 'style') {
-          const styles = meta.style
-            .split(',')
-            .filter((style) => style)
-            .map((style) => toClassName(style.trim()));
-          styles.forEach((style) => section.classList.add(style));
-        } else if (key === 'id') {
-          section.id = meta[key];
-        } else if (key === 'height') {
-          heightDesktop = meta[key];
-        } else if (key === 'heightmobile') {
-          heightMobile = meta[key];
-        } else {
-          section.dataset[toCamelCase(key)] = meta[key];
-        }
-      });
-      sectionMeta.parentNode.remove();
-    }
+  // Add desktop source
+  newPic.appendChild(createSource(desktopUrl, 1920, MEDIA_QUERIES.desktop.media));
 
-    // Apply background color if specified
-    if (section.dataset.backgroundcolor) {
-      let bgValue = section.dataset.backgroundcolor.trim();
+  // Create the default img element
+  const newImg = document.createElement('img');
+  newImg.alt = '';
+  newImg.className = 'section-img';
+  newImg.loading = 'lazy';
 
-      // If it looks like a hex color (3 or 6 characters, alphanumeric), prepend with #
-      if (/^[0-9A-Fa-f]{3}$|^[0-9A-Fa-f]{6}$/.test(bgValue)) {
-        bgValue = `#${bgValue}`;
-      }
-      section.style.background = bgValue;
-    }
+  // Use mobile image as default if available, otherwise desktop
+  const defaultImgUrl = mobileUrl || desktopUrl;
 
-    // Apply color scheme based on background color
+  // Set width and height once image loads to get native dimensions
+  newImg.onload = () => {
+    newImg.width = newImg.naturalWidth;
+    newImg.height = newImg.naturalHeight;
+  };
+  newImg.src = defaultImgUrl;
+
+  newPic.appendChild(newImg);
+  section.classList.add('has-bg-images');
+  section.prepend(newPic);
+}
+
+function handleBackground(background, section) {
+  const color = background.text;
+  // instead of typing "var(--color-name)" authors can use "color-token-name"
+  if (color) {
+    section.style.background = color.startsWith('color-token')
+      ? `var(${color.replace('color-token', '--color')})`
+      : color;
     setColorScheme(section);
+  }
+}
 
-    // Store sections with height for batch processing all on page
-    if (heightDesktop || heightMobile) {
-      sectionsWithHeight.push({
-        section,
-        heightDesktop,
-        heightMobile,
-      });
-    }
+async function handleStyle(text, section) {
+  // Split by comma (with or without spaces) and trim each style
+  const styles = text.split(',').map((style) => style.trim().replaceAll(' ', '-'));
+  section.classList.add(...styles);
+}
+
+// Registry for sections with height - batch processing for performance
+const sectionsWithHeight = [];
+let heightListenersInitialized = false;
+
+function handleHeight(heightDesktop, heightMobile, section) {
+  if (!heightDesktop && !heightMobile) return;
+
+  // Add section to registry
+  sectionsWithHeight.push({
+    section,
+    heightDesktop,
+    heightMobile,
   });
 
-  // Set up single event listener for all sections with height
-  if (sectionsWithHeight.length > 0) {
+  // Set up single event listener for all sections (only once)
+  if (!heightListenersInitialized) {
+    heightListenersInitialized = true;
+
     const updateAllHeights = () => {
       const isMobile = MEDIA_QUERIES.mobile.matches;
-      sectionsWithHeight.forEach(({ section, heightDesktop, heightMobile }) => {
-        const height = isMobile && heightMobile ? heightMobile : heightDesktop;
+      sectionsWithHeight.forEach(({ section: sec, heightDesktop: hd, heightMobile: hm }) => {
+        const height = isMobile && hm ? hm : hd;
         // Always set minHeight (or clear it with empty string if no value for current breakpoint)
-        section.style.minHeight = height || '';
+        sec.style.minHeight = height || '';
       });
     };
 
+    // Initial update and set up listeners
     updateAllHeights();
     MEDIA_QUERIES.mobile.addEventListener('change', updateAllHeights);
     MEDIA_QUERIES.desktop.addEventListener('change', updateAllHeights);
+  } else {
+    // If listeners already set up, just apply the height for this section
+    const isMobile = MEDIA_QUERIES.mobile.matches;
+    const height = isMobile && heightMobile ? heightMobile : heightDesktop;
+    section.style.minHeight = height || '';
   }
+}
+
+const getSectionMetadata = (el) => [...el.childNodes].reduce((rdx, row) => {
+  if (row.children && row.children.length >= 2) {
+    const key = row.children[0].textContent.trim().toLowerCase();
+    const content = row.children[1];
+    const text = content.textContent.trim().toLowerCase();
+    if (key && content) rdx[key] = { content, text };
+  }
+  return rdx;
+}, {});
+
+export async function handleSectionMetadata(el) {
+  const section = el.closest('.section');
+  if (!section) return;
+  const metadata = getSectionMetadata(el);
+
+  // Special cases for SECTION - handle these first
+  if (metadata.style?.text) await handleStyle(metadata.style.text, section);
+  if (metadata.backgroundcolor?.text) handleBackground(metadata.backgroundcolor, section);
+
+  // Handle section height (desktop and mobile)
+  const heightDesktop = metadata.height?.text || null;
+  const heightMobile = metadata.heightmobile?.text || null;
+  if (heightDesktop || heightMobile) {
+    handleHeight(heightDesktop, heightMobile, section);
+  }
+
+  // Define which keys are handled specially for section or block-content
+  const specialKeys = ['style', 'height', 'heightmobile', 'sectionbackgroundimage', 'sectionbackgroundimagemobile', 'backgroundcolor', 'background-block', 'background-block-image', 'background-block-image-mobile', 'object-fit-block', 'object-position-block'];
+
+  // Catch-all: set any other metadata as data- attributes on section
+  Object.keys(metadata).forEach((key) => {
+    if (!specialKeys.includes(key)) {
+      section.dataset[toCamelCase(key)] = metadata[key].text;
+    }
+  });
+
+  // Handle SECTION background images (desktop and mobile variants)
+  const desktopBgImg = metadata.sectionbackgroundimage?.content
+    ? extractImageUrl(metadata.sectionbackgroundimage.content)
+    : null;
+  const mobileBgImg = metadata.sectionbackgroundimagemobile?.content
+    ? extractImageUrl(metadata.sectionbackgroundimagemobile.content)
+    : null;
+
+  if (desktopBgImg || mobileBgImg) {
+    handleBackgroundImages(desktopBgImg, mobileBgImg, section);
+  }
+
+  // Handle BLOCK-CONTENT specific properties
+  const blockContents = section.querySelectorAll(':scope > div.block-content');
+  if (blockContents.length > 0) {
+    // Handle background-block color
+    if (metadata['background-block']?.text) {
+      blockContents.forEach((blockContent) => {
+        handleBackground(metadata['background-block'], blockContent);
+      });
+    }
+
+    // Handle block-content background images
+    const desktopBlockBgImg = metadata['background-block-image']?.content
+      ? extractImageUrl(metadata['background-block-image'].content)
+      : null;
+    const mobileBlockBgImg = metadata['background-block-image-mobile']?.content
+      ? extractImageUrl(metadata['background-block-image-mobile'].content)
+      : null;
+
+    if (desktopBlockBgImg || mobileBlockBgImg) {
+      blockContents.forEach((blockContent) => {
+        handleBackgroundImages(desktopBlockBgImg, mobileBlockBgImg, blockContent);
+      });
+    }
+
+    // Set object-fit-block and object-position-block as data attributes on block-content
+    if (metadata['object-fit-block']?.text) {
+      blockContents.forEach((blockContent) => {
+        blockContent.dataset.objectFit = metadata['object-fit-block'].text;
+      });
+    }
+    if (metadata['object-position-block']?.text) {
+      blockContents.forEach((blockContent) => {
+        blockContent.dataset.objectPosition = metadata['object-position-block'].text;
+      });
+    }
+  }
+
+  el.remove();
+}
+
+/* separates default content from block content for sections */
+function groupChildren(section) {
+  const allChildren = section.querySelectorAll(':scope > *');
+
+  // Filter out section-metadata elements from "blocks"
+  const children = [...allChildren].filter((child) => !child.classList.contains('section-metadata'));
+  if (children.length === 0) return [];
+  const hasBlocks = children.some((child) => child.tagName === 'DIV' && child.className);
+
+  // If no blocks, just wrap everything in default-content and return
+  if (!hasBlocks) {
+    const defaultWrapper = document.createElement('div');
+    defaultWrapper.className = 'default-content';
+    children.forEach((child) => defaultWrapper.append(child));
+    return [defaultWrapper];
+  }
+
+  // Otherwise, group blocks and default content separately
+  const groups = [];
+  let currentGroup = null;
+
+  for (const child of children) {
+    const isDiv = child.tagName === 'DIV';
+    const currentType = currentGroup?.classList.contains('block-content');
+
+    if (!currentGroup || currentType !== isDiv) {
+      currentGroup = document.createElement('div');
+      currentGroup.className = isDiv
+        ? 'block-content' : 'default-content';
+      groups.push(currentGroup);
+    }
+
+    currentGroup.append(child);
+  }
+
+  return groups;
+}
+
+function decorateSections(parent, isDoc) {
+  const selector = isDoc ? 'main > div' : ':scope > div';
+  return [...parent.querySelectorAll(selector)].map((section) => {
+    const groups = groupChildren(section);
+    section.append(...groups);
+
+    section.classList.add('section');
+    section.blocks = [...section.querySelectorAll('.block-content > div[class]')];
+
+    const sectionMeta = section.querySelector('.section-metadata');
+    if (sectionMeta) {
+      handleSectionMetadata(sectionMeta);
+    }
+
+    return section;
+  });
 }
 
 /**
@@ -1382,7 +1497,7 @@ async function loadLazy(doc) {
   loadCSS(`${window.hlx.codeBasePath}/styles/lazy-styles.css`);
   loadFonts();
   loadAutoBlock(doc);
-  createResponsiveBackgroundPicture(main);
+  // createResponsiveBackgroundPicture(main);
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -583,6 +583,25 @@ main .section.upi-steps-red-bg {
   color: var(--white);
 }
 
+/* when scheme is manually chosen from the section style */
+.section.dark-scheme {
+  color: var(--white);
+
+  > .default-content.light-scheme,
+  > .block-content.light-scheme {
+    color: var(--white);
+  }
+}
+
+.section.light-scheme {
+  color: var(--text-color);
+
+  > .default-content.dark-scheme,
+  > .block-content.dark-scheme {
+    color: var(--text-color);
+  }
+}
+
 /* Category navbar is now part of header, so simpler styling */
 .category-nav-wrapper {
   width: 100%;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -342,56 +342,66 @@ main>.section:first-of-type {
   margin-top: 0;
 }
 
-.section .bg-images {
-  position: absolute;
+/* custom styles for sections 2025-12-24T10:35:58-05:00 
+was in section-medata.css */
+
+.section {
   display: block;
-  inset: 0;
-  z-index: 0;
+
+  .bg-images {
+    display: block;
+    position: absolute;
+    inset: 0;
+    z-index: 0;
+  }
+
+  .bg-images img {
+    object-fit: cover;
+    height: 100%;
+    width: 100%;
+  }
 }
 
-.section .bg-images img {
-  width: 100%;
-  height: 100%;
-  object-fit: cover;
-  object-position: center;
-}
-
-.section.has-bg-images > *:not(.bg-images) {
+.has-bg-images {
   position: relative;
-}
 
-[data-object-fit="none"] .bg-images img {
+  > div {
+    position: relative;
+  }
+
+&[data-object-fit="none"] > .bg-images img {
   object-fit: none;
 }
 
-[data-object-fit="contain"] .bg-images img {
+&[data-object-fit="contain"] > .bg-images img {
   object-fit: contain;
 }
 
-[data-object-fit="cover"] .bg-images img {
+&[data-object-fit="cover"] > .bg-images img {
   object-fit: cover;
   height: 100%;
   width: 100%;
 }
 
-[data-object-position="center"] .bg-images img {
+&[data-object-position="center"] > .bg-images img {
   object-position: center;
 }
 
-[data-object-position="top left"] .bg-images img {
+&[data-object-position="top left"] > .bg-images img {
   object-position: top left;
 }
 
-[data-object-position="top right"] .bg-images img {
+&[data-object-position="top right"] > .bg-images img {
   object-position: top right;
 }
 
-[data-object-position="bottom left"] .bg-images img {
+&[data-object-position="bottom left"] > .bg-images img {
   object-position: bottom left;
 }
 
-[data-object-position="bottom right"] .bg-images img {
+&[data-object-position="bottom right"] > .bg-images img {
   object-position: bottom right;
+}
 }
 
 /* Reserve space for breadcrumbs to prevent CLS - Mobile First */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -342,9 +342,6 @@ main>.section:first-of-type {
   margin-top: 0;
 }
 
-/* custom styles for sections 2025-12-24T10:35:58-05:00 
-was in section-medata.css */
-
 .section {
   display: block;
 


### PR DESCRIPTION
This is a refactor of the section so that we can include background attributes to blocks within sections too.
Section colors do require using full hex values (include the number sign) now, some may need to be reauthored.

Also note that there is a section of the footer that needs to be fixed via another ticket, but I didn't see any other regressions.

Fix #153 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://153-sectioninnerbg--idfc--aemsites.aem.page/credit-card/rupay-credit-card

- Before: https://main--idfc--aemsites.aem.page/library/sections
- After: https://153-sectioninnerbg--idfc--aemsites.aem.page/library/sections
