### PR TITLE
Accordion more/less, show/hide schema

### DIFF
--- a/blocks/accordion/_accordion.json
+++ b/blocks/accordion/_accordion.json
@@ -52,12 +52,12 @@
               "name": "Styles",
               "children": [
             {
-              "name": "light text on dark",
-              "value": "light-text"
+              "name": "dark scheme",
+              "value": "dark-scheme"
             },
             {
-              "name": "dark text on light",
-              "value": "dark-text-on-light"
+              "name": "light scheme",
+              "value": "light-scheme"
             }
           ]
           }
@@ -68,19 +68,7 @@
           "valueType": "boolean",
           "name": "no-schema",
           "label": "No LD+JSON schema",
-          "description": "TODO - this toggle is inop"
-        },
-        {
-          "component": "aem-content",
-          "name": "cta",
-          "label": "CTA URL",
-          "value": "#"
-        },
-        {
-          "component": "text",
-          "name": "ctaText",
-          "label": "CTA Text",
-          "value": "More FAQs"
+          "description": "Disables schema.org microdata attributes on accordion items"
         },
         {
           "component": "text",
@@ -88,6 +76,19 @@
           "label": "CTA location (number of items before the CTA)",
           "valueType": "number",
           "value": ""
+        },
+        {
+          "component": "text",
+          "hidden": "true",
+          "name": "link",
+          "label": "CTA URL",
+          "value": "#"
+        },
+        {
+          "component": "text",
+          "name": "linkText",
+          "label": "CTA Text",
+          "value": "More FAQs"
         }
       ]
     },

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -1,19 +1,13 @@
-.accordion details {
-  border: 1px solid #dadada;
-  border-radius: 4px;
-  overflow: hidden;
+.accordion {
+  margin: 20px 0;
 }
 
-.accordion.light-text details {
-  border: none;
+.accordion details {
+  overflow: hidden;
 }
 
 /* spacing between items */
 .accordion details + details {
-  margin-top: 16px;
-}
-
-.accordion.light-text details + details {
   margin-top: 0;
 }
 
@@ -27,44 +21,48 @@
   transition: background-color 0.2s ease;
 }
 
-.accordion.light-text details summary {
-  border-bottom: 1px solid #9A9A9A;
-  color: #c7c7c7;
-  transition: all 0.2s ease-in-out;
-  padding: 20px 16px 0;
-  font-weight: 400;
-  box-shadow: 0 1px 2px rgba(0, 0, 0, .22);
-
-  > p > strong {
-    font-weight: 400;
-  }
-}
-
-.accordion.light-text details[open]{
-  border-bottom: 1px solid;
-  border-radius: 5px;
-}
-
-
-.accordion.light-text details[open] summary {
-  font-weight: 600;
-  border-bottom: 0;
-
-  > p > strong {
-    font-weight: 600;
-  }
-}
-
-.accordion.light-text details[open], .accordion.light-text details[open] summary {
-  box-shadow: none;
-  background-color: var(--white);
-  color: var(--text-color);
-  transition: all 0.2s ease-in-out;
-}
-
 .accordion details summary::-webkit-details-marker {
   display: none;
 }
+
+.accordion .accordion-cta {
+  color: var(--text-color);
+  display: block;
+  padding: 10px;
+  font-weight: bold;
+  text-align: right;
+}
+
+/* Smooth transition for hidden accordion items */
+.accordion details.accordion-item {
+  max-height: unset;
+  overflow: hidden;
+  opacity: 1;
+  transition: max-height 0.3s ease-in-out, opacity 0.3s ease-in-out, margin 0.3s ease-in-out;
+}
+
+.accordion details.accordion-item-hidden {
+  max-height: 0;
+  opacity: 0;
+  margin: 0;
+  pointer-events: none;
+}
+
+.accordion .accordion-cta::after {
+    content: '';
+    transform: translateY(-50%) rotate(135deg);
+    width: 10px;
+    height: 10px;
+    border: 2px solid;
+    border-width: 2px 2px 0 0;
+    transition: transform 0.2s;
+    display: inline-block;
+    margin-left: 10px;
+  }
+
+  .accordion.expanded .accordion-cta::after {
+    transform: translateY(-50%) rotate(-45deg);
+  }
 
 .accordion details summary::after {
   content: '';
@@ -82,20 +80,76 @@
   transform: translateY(-50%) rotate(-45deg);
 }
 
-.accordion.light-text details[open] summary::after {
-  background-color: var(--white);
-  color: var(--text-color);
-}
-
 .accordion .accordion-item-body {
   padding: 12px 16px;
-  border-top: 1px solid #dadada;
-}
-
-.accordion.light-text .accordion-item-body {
-  border-top: none;
 }
 
 .accordion details p {
   margin: 0 0 0.8em 0;
 }
+
+.accordion details summary {
+  transition: all 0.2s ease-in-out;
+  padding: 20px 16px 0;
+  font-weight: 400;
+  box-shadow: 0 1px 2px rgba(0, 0, 0, .22);
+}
+
+.accordion details[open], .accordion details[open] summary {
+  box-shadow: none;
+  background: var(--gradient-pewter);
+  color: #DDDBDA;
+  transition: all 0.2s ease-in-out;
+}
+
+.accordion .accordion-cta {
+  color: var(--white);
+}
+
+.accordion details[open]{
+  border-bottom: 1px solid;
+  border-radius: 5px;
+}
+
+
+.accordion details[open] summary {
+  font-weight: 600;
+  border-bottom: 0;
+
+  > p > strong {
+    font-weight: 600;
+  }
+}
+
+.dark-scheme {
+
+  .accordion details summary {
+    border-bottom: 1px solid #c8c6c6;
+    color: var(--text-color);
+  }
+  
+  .accordion details[open], .accordion details[open] summary {
+    box-shadow: none;
+    background: var(--white);
+    color: var(--text-color);
+    transition: all 0.2s ease-in-out;
+  }
+  
+  .accordion .accordion-cta {
+    color: var(--white);
+  }
+
+  .accordion details summary {
+    border-bottom: 1px solid #9A9A9A;
+    color: #c7c7c7;
+
+    > p > strong {
+      font-weight: 400;
+    }
+  }
+  
+  .accordion details[open] summary::after {
+    background-color: var(--white);
+    color: var(--text-color);
+  }
+  }

--- a/blocks/accordion/accordion.js
+++ b/blocks/accordion/accordion.js
@@ -1,8 +1,44 @@
 import { moveInstrumentation } from '../../scripts/scripts.js';
 
 export default function decorate(block) {
+  let noSchema = false;
+  let ctaUrl = null;
+  let ctaText = null;
+  let ctaLocation = null;
+
+  // Find and remove any single-cell configuration rows
+  [...block.children].forEach((row) => {
+    if (row.children.length === 1) {
+      const cell = row.children[0];
+      const value = cell.textContent.trim();
+      const valueLower = value.toLowerCase();
+
+      // Check if this single cell indicates no-schema is enabled
+      if (valueLower === 'true' || valueLower === 'no-schema') {
+        noSchema = true;
+      } else {
+        // Check if it's a number for ctaLocation
+        const locationNum = parseInt(value, 10);
+        if (!Number.isNaN(locationNum) && locationNum > 0) {
+          ctaLocation = locationNum;
+        } else {
+          // Check if it's a link element (CTA)
+          const link = cell.querySelector('a');
+          if (link) {
+            ctaUrl = link.href;
+            ctaText = link.textContent.trim();
+          }
+        }
+      }
+
+      // Remove single-cell rows as they're configuration, not content
+      row.remove();
+    }
+  });
+
   // const isMobile = window.matchMedia('(max-width: 767px)').matches;
   // if (!isMobile) return; // Skip accordion transformation on desktop
+  const accordionItems = [];
   [...block.children].forEach((row) => {
     const children = [...row.children];
     // only process rows with exactly 2 children (question + answer)
@@ -10,39 +46,104 @@ export default function decorate(block) {
       const label = children[0];
       const summary = document.createElement('summary');
       summary.className = 'accordion-item-label';
-      summary.setAttribute('itemscope', '');
-      summary.setAttribute('itemprop', 'mainEntity');
-      summary.setAttribute('itemtype', 'https://schema.org/Question');
+
+      // Only add schema.org attributes if no-schema is not enabled
+      if (!noSchema) {
+        summary.setAttribute('itemscope', '');
+        summary.setAttribute('itemprop', 'mainEntity');
+        summary.setAttribute('itemtype', 'https://schema.org/Question');
+      }
+
       summary.append(...label.childNodes);
-      if (summary.firstElementChild) {
+
+      if (!noSchema && summary.firstElementChild) {
         summary.firstElementChild.setAttribute('itemprop', 'name');
       }
+
       const body = children[1];
       body.className = 'accordion-item-body';
       const details = document.createElement('details');
       moveInstrumentation(row, details);
       details.className = 'accordion-item';
-      details.setAttribute('itemscope', '');
-      details.setAttribute('itemprop', 'acceptedAnswer');
-      details.setAttribute('itemtype', 'https://schema.org/Answer');
+
+      // Only add schema.org attributes if no-schema is not enabled
+      if (!noSchema) {
+        details.setAttribute('itemscope', '');
+        details.setAttribute('itemprop', 'acceptedAnswer');
+        details.setAttribute('itemtype', 'https://schema.org/Answer');
+      }
+
       details.append(summary, body);
       row.replaceWith(details);
+      accordionItems.push(details);
     } else {
       // remove or ignore malformed rows (like dummy divs)
       row.remove();
     }
   });
-  // Optional: Only one open at a time
-  const footerAccordion = document.querySelector('footer .section.accordion-container:first-of-type');
-  if (footerAccordion) {
-    block.querySelectorAll('details').forEach((detail) => {
-      detail.addEventListener('toggle', () => {
-      // if (detail.open) {
-      //   block.querySelectorAll('details').forEach((el) => {
-      //     if (el !== detail) el.removeAttribute('open');
-      //   });
-      // }
-      });
+
+  // Handle CTA "Show More/Less" functionality
+  if (ctaLocation && ctaLocation < accordionItems.length && ctaUrl && ctaText) {
+    let isExpanded = false;
+    const originalText = ctaText;
+    const expandedText = 'Show less';
+
+    // Hide items after ctaLocation initially
+    for (let i = ctaLocation; i < accordionItems.length; i += 1) {
+      accordionItems[i].classList.add('accordion-item-hidden');
+    }
+
+    // Create CTA button
+    const ctaButton = document.createElement('a');
+    ctaButton.href = ctaUrl;
+    ctaButton.textContent = originalText;
+    ctaButton.className = 'accordion-cta button';
+
+    // Append CTA at the end of the block
+    block.appendChild(ctaButton);
+
+    // Add click handler to toggle hidden items
+    ctaButton.addEventListener('click', (e) => {
+      // Check if URL ends with '#' (handles both relative '#' and absolute URLs ending with '#')
+      if (ctaUrl.endsWith('#') || ctaUrl === '') {
+        e.preventDefault();
+
+        if (!isExpanded) {
+          // Show all hidden items
+          for (let i = ctaLocation; i < accordionItems.length; i += 1) {
+            accordionItems[i].classList.remove('accordion-item-hidden');
+          }
+          ctaButton.textContent = expandedText;
+          block.classList.add('expanded');
+          isExpanded = true;
+        } else {
+          // Hide items after ctaLocation
+          for (let i = ctaLocation; i < accordionItems.length; i += 1) {
+            accordionItems[i].classList.add('accordion-item-hidden');
+          }
+          ctaButton.textContent = originalText;
+          block.classList.remove('expanded');
+          isExpanded = false;
+        }
+      }
     });
   }
+
+  // Only one accordion item open at a time (default behavior)
+  // Footer accordions can disable this by removing the listeners in footer.js
+  block.querySelectorAll('details').forEach((detail) => {
+    const toggleHandler = () => {
+      if (detail.open) {
+        // Close all other accordion items in this block
+        block.querySelectorAll('details').forEach((el) => {
+          if (el !== detail && el.open) {
+            el.removeAttribute('open');
+          }
+        });
+      }
+    };
+    detail.addEventListener('toggle', toggleHandler);
+    // Store reference to handler so it can be removed if needed
+    detail.accordionToggleHandler = toggleHandler;
+  });
 }

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -64,6 +64,7 @@ footer .footer ul {
   width: 100%;
   border: none;
   border-radius: unset;
+  background: transparent;
 }
 
 .footer>div>div .accordion-wrapper .accordion .accordion-item {
@@ -89,10 +90,12 @@ footer .footer ul {
   margin-right: 15px;
   margin-left: 15px;
   border: unset;
+  box-shadow: none;
 }
 
 .footer .section.accordion-container:first-of-type .accordion-wrapper .accordion .accordion-item-label {
   border-bottom: 1px solid rgba(255, 255, 255, 0.21);
+  background: transparent;
 }
 
 .footer>div>div .accordion-wrapper .accordion>div>div:first-child ::after,
@@ -121,6 +124,12 @@ footer .footer ul {
   font-size: 14px;
   font-weight: 700;
   font: 700 1rem / 1.25rem 'Roboto', sans-serif;
+}
+
+.footer>div>div .accordion-wrapper .accordion details[open],
+.footer>div>div .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label {
+  color: white;
+  background: transparent;
 }
 
 .footer>div>div .accordion-wrapper .accordion>div>div:nth-child(2) ul,
@@ -282,6 +291,7 @@ footer .footer>div .section:nth-child(4)>div p a {
 
 .footer .section.accordion-container:first-of-type .accordion details summary {
   pointer-events: none;
+  box-shadow: none;
 }
 
 .footer .section.accordion-container:first-of-type .accordion details summary::after,
@@ -337,7 +347,6 @@ footer .footer>div .section:nth-child(4)>div p a {
     max-width: 100%;
     border: none;
     border-radius: unset;
-    border-bottom: 1px solid #dadada;
     font-weight: 700;
     border-bottom: 1px solid rgba(255, 255, 255, 0.21);
     letter-spacing: .5px;
@@ -416,11 +425,11 @@ footer .footer>div .section:nth-child(4)>div p a {
   }
 
   footer .footer>div .section:nth-child(4)>div ul li:nth-child(2) {
-    padding-bottom: 0px;
+    padding-bottom: 0;
   }
 
   footer .footer>div .section:nth-child(4)>div ul li:nth-child(3) {
-    padding-bottom: 0px;
+    padding-bottom: 0;
   }
 
   .footer>div>div:nth-child(2)>div>ul li>p {
@@ -429,16 +438,12 @@ footer .footer>div .section:nth-child(4)>div p a {
   }
 
   .footer>div>div:nth-child(2)>div>ul>li:nth-child(2)>ul>li:nth-child(2) {
-    display: block;
     display: inline-block;
     height: 48px;
-    min-width: 160px;
-    padding: 10px 30px;
     border-radius: 25px;
     background: #FFFFFF;
     color: var(--dark-red-color) !important;
     text-align: center;
-    line-height: 30px;
     white-space: nowrap;
     border: 0;
     font-size: 16px;

--- a/blocks/footer/footer.js
+++ b/blocks/footer/footer.js
@@ -18,11 +18,20 @@ export default async function decorate(block) {
 
   block.append(footer);
 
+  // Remove "only one open" behavior from footer accordions (allow multiple open)
+  block.querySelectorAll('.accordion details').forEach((detail) => {
+    if (detail.accordionToggleHandler) {
+      detail.removeEventListener('toggle', detail.accordionToggleHandler);
+      delete detail.accordionToggleHandler;
+    }
+  });
+
   // Open accordion details on desktop
-  const details = block.querySelectorAll('footer .section.accordion-container:first-of-type details');
+  const details = block.querySelectorAll('.footer .section.accordion-container:first-of-type details');
   if (window.innerWidth > 768) {
+    // Use setAttribute to avoid triggering toggle events
     details.forEach((detail) => {
-      detail.open = true;
+      detail.setAttribute('open', '');
     });
   }
 }

--- a/component-models.json
+++ b/component-models.json
@@ -183,7 +183,7 @@
         "fields": [
           {
             "component": "text",
-            "name": "backgroundColor",
+            "name": "background",
             "label": "Background Color/gradient",
             "value": "",
             "valueType": "string",
@@ -370,12 +370,12 @@
             "name": "Styles",
             "children": [
               {
-                "name": "light text on dark",
-                "value": "light-text"
+                "name": "dark scheme",
+                "value": "dark-scheme"
               },
               {
-                "name": "dark text on light",
-                "value": "dark-text-on-light"
+                "name": "light scheme",
+                "value": "light-scheme"
               }
             ]
           }
@@ -386,19 +386,7 @@
         "valueType": "boolean",
         "name": "no-schema",
         "label": "No LD+JSON schema",
-        "description": "TODO - this toggle is inop"
-      },
-      {
-        "component": "aem-content",
-        "name": "cta",
-        "label": "CTA URL",
-        "value": "#"
-      },
-      {
-        "component": "text",
-        "name": "ctaText",
-        "label": "CTA Text",
-        "value": "More FAQs"
+        "description": "Disables schema.org microdata attributes on accordion items"
       },
       {
         "component": "text",
@@ -406,6 +394,19 @@
         "label": "CTA location (number of items before the CTA)",
         "valueType": "number",
         "value": ""
+      },
+      {
+        "component": "text",
+        "hidden": "true",
+        "name": "link",
+        "label": "CTA URL",
+        "value": "#"
+      },
+      {
+        "component": "text",
+        "name": "linkText",
+        "label": "CTA Text",
+        "value": "More FAQs"
       }
     ]
   },


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

- All accordions get the "only one open" behavior by default
- Footer deletes that behavior in footer.js
- changed the names of the properties in the JSON from cta to link as needed
- Accordions respect the section color schemes, so I don't think we will need the light-scheme and dark-scheme styles anymore... probably we will add more specific styles for certain pages. I'm leaving the style dropdown as it is for now.
- I've let the default accordion style have the pewter backgrouind color on opened items for now, since that's what the Mayura page uses. But I didn't refine the margins/padding because I want to see how the section grid/container options will affect this first.

Fix #42 

Second accordion has the More FAQs feature after the 5th one and is in a black section, so it is getting the dark-scheme styles.

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/accordion
- After: https://42-accordionfixes--idfc--aemsites.aem.page/library/accordion
