### PR TITLE
fix for JSON

### DIFF
--- a/blocks/accordion/_accordion.json
+++ b/blocks/accordion/_accordion.json
@@ -82,13 +82,14 @@
           "hidden": "true",
           "name": "link",
           "label": "CTA URL",
-          "value": "#"
+          "value": "",
+          "description": "Use # for more/less toggle functionality"
         },
         {
           "component": "text",
           "name": "linkText",
-          "label": "CTA Text",
-          "value": "More FAQs"
+          "label": "CTA Text (e.g. Show More)",
+          "value": ""
         }
       ]
     },

--- a/component-models.json
+++ b/component-models.json
@@ -208,7 +208,7 @@
         "fields": [
           {
             "component": "text",
-            "name": "background",
+            "name": "backgroundColor",
             "label": "Background Color/gradient",
             "value": "",
             "valueType": "string",
@@ -425,13 +425,14 @@
         "hidden": "true",
         "name": "link",
         "label": "CTA URL",
-        "value": "#"
+        "value": "",
+        "description": "Use # for more/less toggle functionality"
       },
       {
         "component": "text",
         "name": "linkText",
-        "label": "CTA Text",
-        "value": "More FAQs"
+        "label": "CTA Text (e.g. Show More)",
+        "value": ""
       }
     ]
   },


### PR DESCRIPTION
1. I am putting back the section background property that I must have removed
2. Removing default values for the accordion link and linkText because they are not automatically wrtitten to the JCR upon creation, apparently. Now you have to author them, at which time they will be written back.

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://220-sectiongrids--idfc--aemsites.aem.page/
