### PR TITLE
Add delayed Google Tag Manager script loading to improve performance.…

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1389,6 +1389,33 @@ async function loadLazy(doc) {
  * Loads everything that happens a lot later,
  * without impacting the user experience.
  */
+
+// delayed GTM script
+
+window.dataLayer = window.dataLayer || [];
+
+function loadGTM() {
+  const gtmScript = document.createElement('script');
+  gtmScript.async = true;
+  gtmScript.src = 'https://www.googletagmanager.com/gtm.js?id=GTM-M5CHMQ2Z';
+
+  window.dataLayer.push({
+    'gtm.start': new Date().getTime(),
+    event: 'gtm.js',
+  });
+
+  document.head.appendChild(gtmScript);
+
+  gtmScript.onload = () => {
+    window.dataLayer.push({
+      event: 'gtm_loaded',
+      timestamp: new Date().getTime(),
+    });
+  };
+}
+
+loadGTM();
+
 function loadDelayed() {
   // eslint-disable-next-line import/no-cycle
   window.setTimeout(() => import('./delayed.js'), 3000);


### PR DESCRIPTION
… Updated the ID to GTM-M5CHMQ2Z which matches in their current script.

Added the GTM script from the shared delayed.js script. The GTM ID was updated to match the same one used on Stage and Prod (M5CHMQ2Z). 

Fix #189 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://189-add-gtm-script--idfc--aemsites.aem.page/
