### PR TITLE
added templating ability

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -325,6 +325,35 @@ function loadAutoBlock(doc) {
   });
 }
 
+/**
+ * Loads a template.
+ * @param {Element} doc The container element
+ * @param {string} templateName The name of the template
+ */
+async function loadTemplate(doc, templateName) {
+  try {
+    const cssLoaded = loadCSS(`${window.hlx.codeBasePath}/templates/${templateName}/${templateName}.css`);
+    const decorationComplete = new Promise((resolve) => {
+      (async () => {
+        try {
+          const mod = await import(`../templates/${templateName}/${templateName}.js`);
+          if (mod.default) {
+            await mod.default(doc);
+          }
+        } catch (error) {
+          // eslint-disable-next-line no-console
+          console.log(`failed to load module for ${templateName}`, error);
+        }
+        resolve();
+      })();
+    });
+    await Promise.all([cssLoaded, decorationComplete]);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.log(`failed to load block ${templateName}`, error);
+  }
+}
+
 /** SECTIONS */
 
 /**
@@ -789,6 +818,11 @@ async function loadEager(doc) {
   document.documentElement.lang = 'en';
   decorateTemplateAndTheme();
   loadThemeSpreadSheetConfig();
+
+  const templateName = getMetadata('template');
+  if (templateName) {
+    await loadTemplate(doc, templateName);
+  }
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);

--- a/templates/mayura/mayura.css
+++ b/templates/mayura/mayura.css
@@ -1,0 +1,18 @@
+.mayura .cards-container h2,
+.mayura .tabs-container h2 {
+    text-align: center;
+    font-size: 40px;
+    font-style: normal;
+    font-weight: 700;
+    line-height: normal;
+    background: var(--gradient-red);
+    background-clip: text;
+    -webkit-background-clip: text;
+    -webkit-text-fill-color: rgba(0, 0, 0, 0);
+    margin-bottom: 35px;
+}
+
+.mayura .dark-scheme .cards-container h2,
+.mayura .dark-scheme .tabs-container h2 {
+  color: white;
+}

--- a/templates/mayura/mayura.css
+++ b/templates/mayura/mayura.css
@@ -14,5 +14,8 @@
 
 .mayura .cards-container .dark-scheme h2,
 .mayura .tabs-container .dark-scheme h2 {
-  color: white;
+  background: var(--gradient-silver);
+  background-clip: text;
+  -webkit-background-clip: text;
+  -webkit-text-fill-color: rgba(0, 0, 0, 0);
 }

--- a/templates/mayura/mayura.css
+++ b/templates/mayura/mayura.css
@@ -12,7 +12,7 @@
     margin-bottom: 35px;
 }
 
-.mayura .dark-scheme .cards-container h2,
-.mayura .dark-scheme .tabs-container h2 {
+.mayura .cards-container .dark-scheme h2,
+.mayura .tabs-container .dark-scheme h2 {
   color: white;
 }

--- a/templates/mayura/mayura.js
+++ b/templates/mayura/mayura.js
@@ -1,0 +1,1 @@
+/* javascript here */


### PR DESCRIPTION
SEe the Mayura page for the example, where I added a new folder under /templates, added some CSS as a start, and can see that the CSS file is indeed being loaded on the Mayura page.

<img width="454" height="377" alt="image" src="https://github.com/user-attachments/assets/76e5e6ab-962c-4302-a55f-e9e57b2df604" />


Fix #258 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://258-templates--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
