### PR TITLE
UE only for new doodle images on sections

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -308,6 +308,29 @@
             "value": "",
             "valueType": "string",
             "description": "optional minimum height when in mobile, e.g. 400px"
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "doodle-image-top",
+            "label": "Background accessory image - top",
+            "description": "Displayed at top left of the section",
+            "multi": false
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "doodle-image-bottom",
+            "label": "Background accessory image - bottom",
+            "description": "Displayed at bottom right of the section",
+            "multi": false
+          },
+          {
+            "component": "boolean",
+            "valueType": "boolean",
+            "name": "doodle-reverse",
+            "label": "Reverse background accessory images",
+            "description": "Display at top right and bottom left of the section"
           }
         ]
       },

--- a/models/_section.json
+++ b/models/_section.json
@@ -175,6 +175,29 @@
           "value": "",
           "valueType": "string",
           "description": "optional minimum height when in mobile, e.g. 400px"
+        },
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "doodle-image-top",
+          "label": "Background accessory image - top",
+          "description": "Displayed at top left of the section",
+          "multi": false
+        },
+        {
+          "component": "reference",
+          "valueType": "string",
+          "name": "doodle-image-bottom",
+          "label": "Background accessory image - bottom",
+          "description": "Displayed at bottom right of the section",
+          "multi": false
+        },
+        {
+          "component": "boolean",
+          "valueType": "boolean",
+          "name": "doodle-reverse",
+          "label": "Reverse background accessory images",
+          "description": "Display at top right and bottom left of the section"
         }
           ]
         },


### PR DESCRIPTION
UE only to add fields for what I call "doodle images".
<img width="1016" height="691" alt="image" src="https://github.com/user-attachments/assets/7e9d7bba-637a-4d0c-bafc-134a6fcaaf1d" />

Top and bottom, opposite sides.

Fix 261

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://261-sectiondoodles--idfc--aemsites.aem.page/
