### PR TITLE
Remove Google Tag Manager loading function from scripts.js

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1279,28 +1279,6 @@ async function loadLazy(doc) {
 
 window.dataLayer = window.dataLayer || [];
 
-function loadGTM() {
-  const gtmScript = document.createElement('script');
-  gtmScript.async = true;
-  gtmScript.src = 'https://www.googletagmanager.com/gtm.js?id=GTM-M5CHMQ2Z';
-
-  window.dataLayer.push({
-    'gtm.start': new Date().getTime(),
-    event: 'gtm.js',
-  });
-
-  document.head.appendChild(gtmScript);
-
-  gtmScript.onload = () => {
-    window.dataLayer.push({
-      event: 'gtm_loaded',
-      timestamp: new Date().getTime(),
-    });
-  };
-}
-
-loadGTM();
-
 function loadDelayed() {
   // eslint-disable-next-line import/no-cycle
   window.setTimeout(() => import('./delayed.js'), 3000);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #237 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://237-gtm-duplicate--idfc--aemsites.aem.page/

This now matches IDFC's main site page with GTM-M5CHMQ2Z being referenced from three sources (async, function, iframe). The duplicate was from an extra reference added in scripts.js right above the delay.js where the source from the iframe is located. 
