### PR TITLE
Heritage CC Hero - Change link component type from 'reference' to 'aem-content'

### DIFF
--- a/blocks/hero-heritage-cc/_hero-heritage-cc.json
+++ b/blocks/hero-heritage-cc/_hero-heritage-cc.json
@@ -28,7 +28,7 @@
           "value": ""
         },
         {
-          "component": "reference",
+          "component": "aem-content",
           "valueType": "string",
           "name": "headerCta_link",
           "label": "Header CTA Link",

--- a/component-models.json
+++ b/component-models.json
@@ -1087,7 +1087,7 @@
         "value": ""
       },
       {
-        "component": "reference",
+        "component": "aem-content",
         "valueType": "string",
         "name": "headerCta_link",
         "label": "Header CTA Link",


### PR DESCRIPTION
Had the wrong type set

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://121-heritageccbanner--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
