### PR TITLE
Update footer styles to adjust margins and alignment

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -24,12 +24,12 @@ footer {
   color: #FFFFFF;
 } */
 
-footer .footer>div .section>div {
-  max-width: 75%;
+/* swapna removing this for desktop view */
+/* footer .footer>div .section>div {
   margin: 0;
-  /* padding: 50px 0px; */
-  /* padding-top: 50px; */
-}
+  padding: 50px 0px;
+  padding-top: 50px;
+} */ 
 
 footer .footer p,
 footer .footer ul {
@@ -105,6 +105,13 @@ footer .footer ul {
   .footer .section.accordion-container:first-child > .default-content > p {
     display: flex;
   }
+}
+
+/* swapna added for desktop view */
+footer .footer>div .section>div {
+  margin: 0 auto;
+	align-items: anchor-center;
+  max-width: 75%;
 }
 
 .footer>div>div .accordion-wrapper {
@@ -250,8 +257,7 @@ footer .footer ul {
 }
 
 .footer>div>div:nth-child(2)>div>ul>li:nth-child(2) {
-  flex: 0 0 50%;
-  justify-items: anchor-center;
+  flex: 0 0 50%;  
 }
 
 .footer>div>div:nth-child(2)>div>ul>li:nth-child(3) {
@@ -295,7 +301,6 @@ footer .footer ul {
   display: flex;
   text-size-adjust: auto;
   position: relative;
-  max-width: 75%;
   width: 100%;
   margin: 0;
   flex-direction: column;
@@ -423,6 +428,12 @@ footer .footer>div .section:nth-child(4)>div p a {
     order: 1;
     padding-top: 14px;
   }
+
+  /* swapna added for mobile view */
+footer .footer>div .section>div {
+  margin: 0;
+  max-width: 100%;
+}
 
   .footer .section.accordion-container:first-of-type .accordion details summary {
     pointer-events: all;

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -24,7 +24,7 @@ footer {
   color: #FFFFFF;
 } */
 
-/* swapna removing this for desktop view */
+/* Removing this for desktop view */
 /* footer .footer>div .section>div {
   margin: 0;
   padding: 50px 0px;
@@ -107,7 +107,7 @@ footer .footer ul {
   }
 }
 
-/* swapna added for desktop view */
+/* Added for desktop view */
 footer .footer>div .section>div {
   margin: 0 auto;
 	align-items: anchor-center;
@@ -430,7 +430,7 @@ footer .footer>div .section:nth-child(4)>div p a {
     padding-top: 14px;
   }
 
-  /* swapna added for mobile view */
+  /* Added for mobile view */
 footer .footer>div .section>div {
   margin: 0;
   max-width: 100%;

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -111,7 +111,7 @@ footer .footer ul {
 footer .footer>div .section>div {
   margin: 0 auto;
 	align-items: anchor-center;
-  max-width: 75%;
+  max-width: var(--grid-container-width);
 }
 
 .footer>div>div .accordion-wrapper {
@@ -302,11 +302,12 @@ footer .footer>div .section>div {
   text-size-adjust: auto;
   position: relative;
   width: 100%;
-  margin: 0;
+  margin: 0 auto;
   flex-direction: column;
   justify-content: space-between;
   align-items: flex-start;
   box-sizing: content-box;
+  max-width: var(--grid-container-width);
 }
 
 .footer>div>div:nth-child(3) .block-content.accordion-wrapper > .accordion.block {

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -26,7 +26,7 @@ footer {
 
 footer .footer>div .section>div {
   max-width: 75%;
-  margin: 0 auto;
+  margin: 0;
   /* padding: 50px 0px; */
   /* padding-top: 50px; */
 }
@@ -297,10 +297,10 @@ footer .footer ul {
   position: relative;
   max-width: 75%;
   width: 100%;
-  margin: 0 auto;
+  margin: 0;
   flex-direction: column;
   justify-content: space-between;
-  align-items: center;
+  align-items: flex-start;
   box-sizing: content-box;
 }
 
@@ -315,6 +315,7 @@ footer .footer ul {
   flex-direction: row;
   align-items: center;
   justify-content: space-between;
+  color: var(--white);
 }
 
 .footer>div>div:nth-child(3)>div {
@@ -625,6 +626,7 @@ footer .footer>div .section:nth-child(4)>div p a {
 
   .footer .section.accordion-container:first-of-type .accordion-wrapper .accordion .accordion-item-label {
     border-bottom: unset;
+    color: var(--white);
   }
 
   .footer .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label {


### PR DESCRIPTION
PLEASE CONSIDER THIS AS DRAFT :
- Removed auto margin from footer sections for better layout control for mobile.
- Aligned footer list items to flex-start and added color styling for improved visibility.


Following task taken care :
- accordions should have white header text (mobile and desktop)
- The dark red section should have the items aligned left in Mobile
- the NSE text should be white

Following has NOT taken care 
- left and right margins, mobile + desktop. Generally too much left margin.
- As items aligned left is made to Mobile; it impacted the desktop also. In other words desktop needs to get fixed.


Fix #278

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://278-footer--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
