### PR TITLE
additionally add #id (along with data-id) to section when it's defined.

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -591,6 +591,11 @@ export function handleSectionMetadata(el) {
     }
   });
 
+  // If 'id' metadata is defined, also set it as the actual HTML id attribute
+  if (metadata.id?.text) {
+    section.id = metadata.id.text;
+  }
+
   // Handle SECTION background images (desktop and mobile variants)
   const desktopBgImg = metadata.sectionbackgroundimage?.content
     ? extractImageUrl(metadata.sectionbackgroundimage.content)


### PR DESCRIPTION
Should scroll down to that section.

Fix #298

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura#get-in-touch
- After: https://298-id-to-sections--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura#get-in-touch
