### PR TITLE
FIx "full-screen" view sizing on Hero Heritage CC after adjusting nav height globally

### DIFF
--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -566,10 +566,10 @@
   }
 
   .hero-heritage-cc-container {
-    min-height: calc(100vh - 200px);
-    min-height: calc(100dvh - 200px);
-    height: calc(100vh - 200px);
-    height: calc(100dvh - 200px);
+    min-height: calc(100vh - 120px);
+    min-height: calc(100dvh - 120px);
+    height: calc(100vh - 120px);
+    height: calc(100dvh - 120px);
   }
 
 /* Decoration image - top right */


### PR DESCRIPTION
Hero sizing was incorrect after fixing global nav heights

Fix #304

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://304-navheightfix--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

<img width="2649" height="1146" alt="image" src="https://github.com/user-attachments/assets/66a4cfea-2b82-4f74-bf90-079214991f41" />
