### PR TITLE
313 button adjustment

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -167,14 +167,14 @@
 }
 
 .dark-scheme .hero a.button.primary:any-link {
-  background-color: var(--dark-red-color);
+  background-color: var(--red-color);
   color: var(--btn-color-white);
   border: 1px solid transparent;
 }
 
 .dark-scheme .hero a.button.primary:hover,
 .dark-scheme .hero a.button.primary:focus {
-  background-color: var(--dark-red-color);
+  background-color: var(-red-color);
   color: var(--btn-color-white);
   border: 1px solid transparent;
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -146,6 +146,7 @@
   font-style: normal;
   display: inline-block;
   overflow: hidden;
+  margin: 0;
 }
 
 .hero .button.secondary:hover {
@@ -264,6 +265,7 @@
   .hero .button-groups-wrapper {
     flex-direction: row;
     gap: 20px;
+    align-items: flex-end;
   }
 
   .hero .button-group {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -167,15 +167,15 @@
 }
 
 .dark-scheme .hero a.button.primary:any-link {
-  background-color: var(--btn-color-white);
-  color: var(--btn-color-red);
+  background-color: var(--btn-color-red);
+  color: var(--btn-color-white);
   border: 1px solid transparent;
 }
 
 .dark-scheme .hero a.button.primary:hover,
 .dark-scheme .hero a.button.primary:focus {
-  background-color: var(--btn-color-white);
-  color: var(--btn-color-red);
+  background-color: var(--btn-color-red);
+  color: var(--btn-color-white);
   border: 1px solid transparent;
 }
 

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -144,7 +144,6 @@
   border: 1px solid #fff;
   font-weight: 700;
   font-style: normal;
-  display: inline-block;
   overflow: hidden;
   margin: 0;
 }
@@ -220,7 +219,9 @@
   }
 
   .hero .button {
-    display: inline-block;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
     width: auto;
     padding: 14px 18px;
     font-size: 15px;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -264,7 +264,6 @@
   .hero .button-groups-wrapper {
     flex-direction: row;
     gap: 20px;
-    align-items: flex-end;
   }
 
   .hero .button-group {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -167,14 +167,14 @@
 }
 
 .dark-scheme .hero a.button.primary:any-link {
-  background-color: var(--btn-color-red);
+  background-color: var(--dark-red-color);
   color: var(--btn-color-white);
   border: 1px solid transparent;
 }
 
 .dark-scheme .hero a.button.primary:hover,
 .dark-scheme .hero a.button.primary:focus {
-  background-color: var(--btn-color-red);
+  background-color: var(--dark-red-color);
   color: var(--btn-color-white);
   border: 1px solid transparent;
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -264,6 +264,7 @@
   .hero .button-groups-wrapper {
     flex-direction: row;
     gap: 20px;
+    align-items: flex-end;
   }
 
   .hero .button-group {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -155,6 +155,17 @@
 }
 
 /* Override dark-scheme global styles to maintain hero button consistency */
+.dark-scheme .hero a.button.primary:any-link,
+.dark-scheme .hero a.button.secondary:any-link {
+  padding: 14px 18px;
+  height: 52px;
+  line-height: 1;
+  box-sizing: border-box;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
 .dark-scheme .hero a.button.primary:any-link {
   background-color: var(--red-color);
   color: #fff;
@@ -240,11 +251,16 @@
     padding: 14px 18px;
     font-size: 15px;
     height: 52px;
-    line-height: 1.5;
+    line-height: 1;
+    box-sizing: border-box;
   }
 
-  .hero a.button.primary {
+  .hero a.button.primary,
+  .hero a.button.secondary {
     padding: 14px 18px;
+    height: 52px;
+    line-height: 1;
+    box-sizing: border-box;
   }
 }
 

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -187,9 +187,9 @@
 
 .dark-scheme .hero a.button.secondary:hover,
 .dark-scheme .hero a.button.secondary:focus {
-  background-color: var(--btn-color-white);
-  color: var(--btn-color-red);
-  border: 1px solid transparent;
+  background-color: transparent;
+  color: #fff;
+  border: 1px solid #fff;
 }
 
 /* Tablet: 600px and up */

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -167,9 +167,9 @@
 }
 
 .dark-scheme .hero a.button.primary:any-link {
-  background-color: var(--red-color);
-  color: #fff;
-  border: 1px solid var(--red-color);
+  background-color: var(--btn-color-white);
+  color: var(--btn-color-red);
+  border: 1px solid var(--btn-color-white);
 }
 
 .dark-scheme .hero a.button.secondary:any-link {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -138,6 +138,7 @@
   border-color: var(--dark-red-color);
 }
 
+.hero a.button.secondary:any-link,
 .hero .button.secondary {
   background-color: transparent;
   color: #fff;
@@ -151,6 +152,19 @@
 .hero .button.secondary:hover {
   background-color: var(--dark-red-color);
   border-color: var(--dark-red-color);
+}
+
+/* Override dark-scheme global styles to maintain hero button consistency */
+.dark-scheme .hero a.button.primary:any-link {
+  background-color: var(--red-color);
+  color: #fff;
+  border: 1px solid var(--red-color);
+}
+
+.dark-scheme .hero a.button.secondary:any-link {
+  background-color: transparent;
+  color: #fff;
+  border: 1px solid #fff;
 }
 
 /* Tablet: 600px and up */

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -169,13 +169,27 @@
 .dark-scheme .hero a.button.primary:any-link {
   background-color: var(--btn-color-white);
   color: var(--btn-color-red);
-  border: 1px solid var(--btn-color-white);
+  border: 1px solid transparent;
+}
+
+.dark-scheme .hero a.button.primary:hover,
+.dark-scheme .hero a.button.primary:focus {
+  background-color: var(--btn-color-white);
+  color: var(--btn-color-red);
+  border: 1px solid transparent;
 }
 
 .dark-scheme .hero a.button.secondary:any-link {
   background-color: transparent;
   color: #fff;
   border: 1px solid #fff;
+}
+
+.dark-scheme .hero a.button.secondary:hover,
+.dark-scheme .hero a.button.secondary:focus {
+  background-color: var(--btn-color-white);
+  color: var(--btn-color-red);
+  border: 1px solid transparent;
 }
 
 /* Tablet: 600px and up */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -324,12 +324,6 @@ button.secondary:focus {
 }
 
 /* Button block styles (Universal Editor component) - base states */
-.button.block.primary,
-.button.block.secondary {
-  display: inline-block;
-  vertical-align: middle;
-}
-
 .button.block.primary a,
 .button.block.secondary a {
   box-sizing: border-box;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -327,6 +327,7 @@ button.secondary:focus {
 .button.block.primary,
 .button.block.secondary {
   display: inline-block;
+  vertical-align: middle;
 }
 
 .button.block.primary a,

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -324,6 +324,11 @@ button.secondary:focus {
 }
 
 /* Button block styles (Universal Editor component) - base states */
+.button.block.primary,
+.button.block.secondary {
+  display: inline-block;
+}
+
 .button.block.primary a,
 .button.block.secondary a {
   box-sizing: border-box;


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #313 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/drafts/rupay-credit-card
- After: https://313-button-adjustment--idfc--aemsites.aem.page/credit-card/rupay-credit-card

There were three issues:
1. Text wasn't aligning correctly in the buttons
 - Buttons have a fixed height of 52px but the text wasn't being centered. The base .hero .button uses line-height:1.5 which doesn't center the text in the fixed-height container
 - Added flex properties to vertically center the text in the buttons

2. Buttons in button-groups-wrapper weren't aligning horizontally
 - In hero.css at the desktop breakpoint (900px+), the .button-groups-wrapper only sets flex-direction: row but doesn't reset align-items. It inherits align-items: flex-start from the tablet breakpoint, causing button groups to align at the top instead of aligning the buttons at the bottom.
 
3. Inconsistent button margins
 - In hero.css, the primary button explicitly removes margin, but the secondary button doesn't. The secondary button inherits margin: 12px 0 from the base button style in styles.css (line 277), while primary has margin: 0. Added margin: 0; to .hero .button.secondary