### PR TITLE
Resolve pagespeed heading out-of-order report

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -45,7 +45,7 @@ footer .footer ul {
 
 .footer .section.accordion-container:first-child > .default-content {width: 100%;padding-left: 15px;padding-right: 15px;padding-top: 35px;padding-bottom: 15px;}
 
-.footer .section.accordion-container:first-child > .default-content > h6 {
+.footer .section.accordion-container:first-child > .default-content > h5 {
   color: rgb(188, 59, 69);
   font-size: 36px;
   font-style: normal;
@@ -55,7 +55,7 @@ footer .footer ul {
   margin: unset;
 }
 
-.footer .section.accordion-container:first-child > .default-content > h5 {
+.footer .section.accordion-container:first-child > .default-content > h6 {
   color: rgb(188, 59, 69);
   font-family: Inter;
   font-size: 77px;


### PR DESCRIPTION
Reverse H5 and H6 elements on footer page to resolve pagespeed report of out-of-order headings. Reversed styling to keep same appearance. Verified pagespeed issue resolved.

Fixes #335 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://335-footer-h6--idfc--aemsites.aem.page/

Verification: confirm in footer first header "ON A MISSION..." is H5 and second header "CUSTOMER-FRIENDLY BANK" is H6
