### PR TITLE
Enhance CLS prevention measures across multiple files

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1269,8 +1269,7 @@
 
 .explore-other-cards .swiper-slide {
   display: flex;
-  flex-direction: column;
-  flex-wrap: wrap;
+  flex-flow: column wrap;
   align-items: center;
   align-content: center;
   height: auto;
@@ -1288,7 +1287,7 @@
   width: 100%;
   border-radius: 20px;
   margin-top: -30px;
-  padding: 55px 20px 40px 20px;
+  padding: 55px 20px 40px;
   background: linear-gradient(270deg, #332B28 0%, #514A44 21.11%, #8B837D 50.14%, #625A50 71.74%, #7A766D 90.18%, #433C32 100%);
   z-index: -1;
 }
@@ -1340,6 +1339,7 @@
   justify-content: center;
   gap: 8px;
 }
+
 /*
 .cards.key-benefits .swiper-pagination {
   bottom: 36px;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1,6 +1,9 @@
 /* stylelint-disable no-descending-specificity */
 
-/* BASE STYLING (mobile first) */
+/* =================================================================
+   BASE STYLING (mobile first)
+   Note: CLS prevention rules are in styles.css (loads earlier)
+   ================================================================= */
 .cards > ul {
   list-style: none;
   margin: 0;
@@ -16,8 +19,10 @@
   margin: 0;
 }
 
+/* Note: Do NOT set background-color here - it causes white flash on dark-themed pages.
+   Card variants that need backgrounds should set them explicitly. */
 .cards > ul > li {
-  background-color: var(--background-color);
+  background-color: transparent;
 }
 
 .cards .cards-card-body {
@@ -1612,74 +1617,8 @@
   text-align: left;
 }
 
-/* Desktop adjustments for All About variant */
+/* Desktop adjustments - CLS prevention rules moved to styles.css */
 @media (width >= 900px) {
-  .section.cards-container .cards:not([data-block-status="loaded"]) {
-    visibility: hidden;
-  }
-
-  /* Reserve desktop space for swipable cards to reduce CLS 
-  .section.cards-container .cards-wrapper {
-    min-height: 520px;
-  }
-  
-
-  .section.cards-container:has(.cards.all-about-card) {
-    min-height: 1900px;
-  }
-
-  .section.cards-container:has(.cards.all-about-card) .cards-wrapper,
-  .cards.all-about-card {
-    min-height: 1810px;
-  }
-
-  .cards.all-about-card > ul {
-    min-height: 1760px;
-  }
-  */
-
-  .cards.all-about-card > ul > li {
-    min-height: 520px;
-    display: grid;
-    grid-template-rows: 240px 1fr;
-  }
-
-  .cards.all-about-card .cards-card-image {
-    min-height: 360px;
-    height: 360px;
-  }
-
-  .cards.all-about-card .cards-card-body {
-    min-height: 280px;
-  }
-/*
-  .section.cards-container:has(.cards[data-swipable="true"]) {
-    min-height: 720px;
-  }
-
-  .section.cards-container:has(.cards[data-swipable="true"]):not([data-section-status="loaded"]) {
-    max-height: 720px;
-    overflow: hidden;
-  }
-  
-  .section.cards-container:has(.cards[data-swipable="true"]) .cards-wrapper {
-    min-height: 590px;
-  }
-
-  .cards[data-swipable="true"] {
-    min-height: 590px;
-  }
-
-  .cards[data-swipable="true"] > ul {
-    min-height: 480px;
-  }
-
-  */
-
-  .cards[data-swipable="true"]:not([data-block-status="loaded"]) {
-    visibility: hidden;
-  }
-
   /* Important Documents Cards - Desktop View (900px+) */
   .cards.important-documents .grid-cards {
     grid-template-columns: repeat(4, 175px);

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -675,15 +675,6 @@ function identifySemanticCardElements(li) {
 }
 
 export default async function decorate(block) {
-  const debugTime = () => performance.now().toFixed(2) + 'ms';
-  const blockClasses = [...block.classList].join('.');
-  // eslint-disable-next-line no-console
-  console.log(`[CLS-DEBUG][cards.js] decorate() START for .${blockClasses}`, debugTime());
-  // eslint-disable-next-line no-console
-  console.log(`[CLS-DEBUG][cards.js] Swiper available at decorate start:`, typeof Swiper !== 'undefined', debugTime());
-  // eslint-disable-next-line no-console
-  console.log(`[CLS-DEBUG][cards.js] data-swipable:`, block.dataset.swipable, debugTime());
-
   const isDesktop = window.matchMedia('(min-width: 900px)').matches;
   const section = block.closest('.section');
   const wrapper = block.closest('.cards-wrapper') || block.parentElement;
@@ -890,48 +881,29 @@ export default async function decorate(block) {
   const startingCard = parseInt(block.dataset.startingCard || '0', 10);
 
   if (isSwipable) {
-    // eslint-disable-next-line no-console
-    console.log(`[CLS-DEBUG][cards.js] isSwipable=true, checking Swiper availability`, debugTime());
-    // eslint-disable-next-line no-console
-    console.log(`[CLS-DEBUG][cards.js] Swiper defined BEFORE loadCSS/loadScript:`, typeof Swiper !== 'undefined', debugTime());
-
     // Load Swiper library (will skip if already loaded from head.html)
     await loadCSS('/scripts/swiperjs/swiper-bundle.min.css');
-    // eslint-disable-next-line no-console
-    console.log(`[CLS-DEBUG][cards.js] After loadCSS swiper`, debugTime());
     await loadScript('/scripts/swiperjs/swiper-bundle.min.js');
-    // eslint-disable-next-line no-console
-    console.log(`[CLS-DEBUG][cards.js] After loadScript swiper, Swiper defined:`, typeof Swiper !== 'undefined', debugTime());
 
     // Wait for Swiper to be available (script may need time to execute)
     const waitForSwiper = () => new Promise((resolve) => {
       if (typeof Swiper !== 'undefined') {
-        // eslint-disable-next-line no-console
-        console.log(`[CLS-DEBUG][cards.js] Swiper ALREADY available, no wait needed`, debugTime());
         resolve();
       } else {
-        // eslint-disable-next-line no-console
-        console.log(`[CLS-DEBUG][cards.js] Swiper NOT available, starting poll...`, debugTime());
         const checkInterval = setInterval(() => {
           if (typeof Swiper !== 'undefined') {
-            // eslint-disable-next-line no-console
-            console.log(`[CLS-DEBUG][cards.js] Swiper became available after poll`, debugTime());
             clearInterval(checkInterval);
             resolve();
           }
         }, 10);
         // Timeout after 2 seconds
         setTimeout(() => {
-          // eslint-disable-next-line no-console
-          console.log(`[CLS-DEBUG][cards.js] Swiper poll TIMEOUT`, debugTime());
           clearInterval(checkInterval);
           resolve();
         }, 2000);
       }
     });
     await waitForSwiper();
-    // eslint-disable-next-line no-console
-    console.log(`[CLS-DEBUG][cards.js] Adding .swiper class to block`, debugTime());
 
     // Add Swiper classes
     block.classList.add('swiper');
@@ -1190,7 +1162,4 @@ export default async function decorate(block) {
     const schema = generateTestimonialSchema(block);
     injectSchema(schema);
   }
-
-  // eslint-disable-next-line no-console
-  console.log(`[CLS-DEBUG][cards.js] decorate() COMPLETE for .${blockClasses}`, debugTime());
 }

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -675,6 +675,15 @@ function identifySemanticCardElements(li) {
 }
 
 export default async function decorate(block) {
+  const debugTime = () => performance.now().toFixed(2) + 'ms';
+  const blockClasses = [...block.classList].join('.');
+  // eslint-disable-next-line no-console
+  console.log(`[CLS-DEBUG][cards.js] decorate() START for .${blockClasses}`, debugTime());
+  // eslint-disable-next-line no-console
+  console.log(`[CLS-DEBUG][cards.js] Swiper available at decorate start:`, typeof Swiper !== 'undefined', debugTime());
+  // eslint-disable-next-line no-console
+  console.log(`[CLS-DEBUG][cards.js] data-swipable:`, block.dataset.swipable, debugTime());
+
   const isDesktop = window.matchMedia('(min-width: 900px)').matches;
   const section = block.closest('.section');
   const wrapper = block.closest('.cards-wrapper') || block.parentElement;
@@ -881,29 +890,48 @@ export default async function decorate(block) {
   const startingCard = parseInt(block.dataset.startingCard || '0', 10);
 
   if (isSwipable) {
-    // Load Swiper library
+    // eslint-disable-next-line no-console
+    console.log(`[CLS-DEBUG][cards.js] isSwipable=true, checking Swiper availability`, debugTime());
+    // eslint-disable-next-line no-console
+    console.log(`[CLS-DEBUG][cards.js] Swiper defined BEFORE loadCSS/loadScript:`, typeof Swiper !== 'undefined', debugTime());
+
+    // Load Swiper library (will skip if already loaded from head.html)
     await loadCSS('/scripts/swiperjs/swiper-bundle.min.css');
+    // eslint-disable-next-line no-console
+    console.log(`[CLS-DEBUG][cards.js] After loadCSS swiper`, debugTime());
     await loadScript('/scripts/swiperjs/swiper-bundle.min.js');
+    // eslint-disable-next-line no-console
+    console.log(`[CLS-DEBUG][cards.js] After loadScript swiper, Swiper defined:`, typeof Swiper !== 'undefined', debugTime());
 
     // Wait for Swiper to be available (script may need time to execute)
     const waitForSwiper = () => new Promise((resolve) => {
       if (typeof Swiper !== 'undefined') {
+        // eslint-disable-next-line no-console
+        console.log(`[CLS-DEBUG][cards.js] Swiper ALREADY available, no wait needed`, debugTime());
         resolve();
       } else {
+        // eslint-disable-next-line no-console
+        console.log(`[CLS-DEBUG][cards.js] Swiper NOT available, starting poll...`, debugTime());
         const checkInterval = setInterval(() => {
           if (typeof Swiper !== 'undefined') {
+            // eslint-disable-next-line no-console
+            console.log(`[CLS-DEBUG][cards.js] Swiper became available after poll`, debugTime());
             clearInterval(checkInterval);
             resolve();
           }
         }, 10);
         // Timeout after 2 seconds
         setTimeout(() => {
+          // eslint-disable-next-line no-console
+          console.log(`[CLS-DEBUG][cards.js] Swiper poll TIMEOUT`, debugTime());
           clearInterval(checkInterval);
           resolve();
         }, 2000);
       }
     });
     await waitForSwiper();
+    // eslint-disable-next-line no-console
+    console.log(`[CLS-DEBUG][cards.js] Adding .swiper class to block`, debugTime());
 
     // Add Swiper classes
     block.classList.add('swiper');
@@ -1162,4 +1190,7 @@ export default async function decorate(block) {
     const schema = generateTestimonialSchema(block);
     injectSchema(schema);
   }
+
+  // eslint-disable-next-line no-console
+  console.log(`[CLS-DEBUG][cards.js] decorate() COMPLETE for .${blockClasses}`, debugTime());
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -282,6 +282,7 @@
 @media (width >= 900px) {
   .hero {
     padding: 10px 60px 80px;
+    min-height: 500px; /* Prevent CLS from hero content resizing */
   }
 
   .hero-container .hero-wrapper {

--- a/head.html
+++ b/head.html
@@ -1,12 +1,8 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
-<script>
-  console.log('[CLS-DEBUG] head.html inline script executing', performance.now().toFixed(2) + 'ms');
-  window.__clsDebug = { start: performance.now() };
-</script>
-<link rel="stylesheet" href="/scripts/swiperjs/swiper-bundle.min.css" onload="console.log('[CLS-DEBUG] swiper-bundle.min.css LOADED', performance.now().toFixed(2) + 'ms')"/>
-<script src="/scripts/swiperjs/swiper-bundle.min.js" onload="console.log('[CLS-DEBUG] swiper-bundle.min.js LOADED, Swiper defined:', typeof Swiper !== 'undefined', performance.now().toFixed(2) + 'ms')"></script>
+<link rel="stylesheet" href="/scripts/swiperjs/swiper-bundle.min.css"/>
+<script src="/scripts/swiperjs/swiper-bundle.min.js"></script>
 <script src="/scripts/aem.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
-<link rel="stylesheet" href="/styles/styles.css" onload="console.log('[CLS-DEBUG] styles.css LOADED', performance.now().toFixed(2) + 'ms')"/>
+<link rel="stylesheet" href="/styles/styles.css"/>
 <meta name="urn:adobe:aue:config:preview" content="main--idfc-edge--aemsites.aem.page"/>
 <meta name="urn:adobe:aue:config:disable" content="aem-dev-login" />

--- a/head.html
+++ b/head.html
@@ -1,6 +1,12 @@
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
+<script>
+  console.log('[CLS-DEBUG] head.html inline script executing', performance.now().toFixed(2) + 'ms');
+  window.__clsDebug = { start: performance.now() };
+</script>
+<link rel="stylesheet" href="/scripts/swiperjs/swiper-bundle.min.css" onload="console.log('[CLS-DEBUG] swiper-bundle.min.css LOADED', performance.now().toFixed(2) + 'ms')"/>
+<script src="/scripts/swiperjs/swiper-bundle.min.js" onload="console.log('[CLS-DEBUG] swiper-bundle.min.js LOADED, Swiper defined:', typeof Swiper !== 'undefined', performance.now().toFixed(2) + 'ms')"></script>
 <script src="/scripts/aem.js" type="module"></script>
 <script src="/scripts/scripts.js" type="module"></script>
-<link rel="stylesheet" href="/styles/styles.css"/>
+<link rel="stylesheet" href="/styles/styles.css" onload="console.log('[CLS-DEBUG] styles.css LOADED', performance.now().toFixed(2) + 'ms')"/>
 <meta name="urn:adobe:aue:config:preview" content="main--idfc-edge--aemsites.aem.page"/>
 <meta name="urn:adobe:aue:config:disable" content="aem-dev-login" />

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -549,30 +549,19 @@ function buildBlock(blockName, content) {
  */
 async function loadBlock(block) {
   const status = block.dataset.blockStatus;
-  const debugTime = () => performance.now().toFixed(2) + 'ms';
   if (status !== 'loading' && status !== 'loaded') {
     block.dataset.blockStatus = 'loading';
     const { blockName } = block.dataset;
-    // eslint-disable-next-line no-console
-    console.log(`[CLS-DEBUG][aem.js] loadBlock START: ${blockName}`, debugTime());
     try {
-      // eslint-disable-next-line no-console
-      console.log(`[CLS-DEBUG][aem.js] Loading CSS for ${blockName}`, debugTime());
       const cssLoaded = loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`);
       const decorationComplete = new Promise((resolve) => {
         (async () => {
           try {
-            // eslint-disable-next-line no-console
-            console.log(`[CLS-DEBUG][aem.js] Importing JS for ${blockName}`, debugTime());
             const mod = await import(
               `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.js`
             );
             if (mod.default) {
-              // eslint-disable-next-line no-console
-              console.log(`[CLS-DEBUG][aem.js] Calling decorate() for ${blockName}`, debugTime());
               await mod.default(block);
-              // eslint-disable-next-line no-console
-              console.log(`[CLS-DEBUG][aem.js] decorate() DONE for ${blockName}`, debugTime());
             }
           } catch (error) {
             // eslint-disable-next-line no-console
@@ -586,8 +575,6 @@ async function loadBlock(block) {
       // eslint-disable-next-line no-console
       console.log(`failed to load block ${blockName}`, error);
     }
-    // eslint-disable-next-line no-console
-    console.log(`[CLS-DEBUG][aem.js] Setting blockStatus=loaded for ${blockName}`, debugTime());
     block.dataset.blockStatus = 'loaded';
   }
   return block;

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -549,19 +549,30 @@ function buildBlock(blockName, content) {
  */
 async function loadBlock(block) {
   const status = block.dataset.blockStatus;
+  const debugTime = () => performance.now().toFixed(2) + 'ms';
   if (status !== 'loading' && status !== 'loaded') {
     block.dataset.blockStatus = 'loading';
     const { blockName } = block.dataset;
+    // eslint-disable-next-line no-console
+    console.log(`[CLS-DEBUG][aem.js] loadBlock START: ${blockName}`, debugTime());
     try {
+      // eslint-disable-next-line no-console
+      console.log(`[CLS-DEBUG][aem.js] Loading CSS for ${blockName}`, debugTime());
       const cssLoaded = loadCSS(`${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.css`);
       const decorationComplete = new Promise((resolve) => {
         (async () => {
           try {
+            // eslint-disable-next-line no-console
+            console.log(`[CLS-DEBUG][aem.js] Importing JS for ${blockName}`, debugTime());
             const mod = await import(
               `${window.hlx.codeBasePath}/blocks/${blockName}/${blockName}.js`
             );
             if (mod.default) {
+              // eslint-disable-next-line no-console
+              console.log(`[CLS-DEBUG][aem.js] Calling decorate() for ${blockName}`, debugTime());
               await mod.default(block);
+              // eslint-disable-next-line no-console
+              console.log(`[CLS-DEBUG][aem.js] decorate() DONE for ${blockName}`, debugTime());
             }
           } catch (error) {
             // eslint-disable-next-line no-console
@@ -575,6 +586,8 @@ async function loadBlock(block) {
       // eslint-disable-next-line no-console
       console.log(`failed to load block ${blockName}`, error);
     }
+    // eslint-disable-next-line no-console
+    console.log(`[CLS-DEBUG][aem.js] Setting blockStatus=loaded for ${blockName}`, debugTime());
     block.dataset.blockStatus = 'loaded';
   }
   return block;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -864,12 +864,6 @@ async function loadThemeSpreadSheetConfig() {
  * @param {Element} doc The container element
  */
 async function loadEager(doc) {
-  const debugTime = () => performance.now().toFixed(2) + 'ms';
-  // eslint-disable-next-line no-console
-  console.log('[CLS-DEBUG][scripts.js] loadEager() START', debugTime());
-  // eslint-disable-next-line no-console
-  console.log('[CLS-DEBUG][scripts.js] Swiper available at loadEager:', typeof Swiper !== 'undefined', debugTime());
-
   document.documentElement.lang = 'en';
   decorateTemplateAndTheme();
   loadThemeSpreadSheetConfig();
@@ -889,20 +883,10 @@ async function loadEager(doc) {
     const categoryNavPath = getMetadata('category-nav');
     if (categoryNavPath) {
       document.body.classList.add('has-category-nav');
-      // eslint-disable-next-line no-console
-      console.log('[CLS-DEBUG][scripts.js] category-nav metadata found, added has-category-nav class', debugTime());
     }
 
-    // eslint-disable-next-line no-console
-    console.log('[CLS-DEBUG][scripts.js] header height:', getComputedStyle(doc.querySelector('header')).height, debugTime());
-    // eslint-disable-next-line no-console
-    console.log('[CLS-DEBUG][scripts.js] About to add body.appear', debugTime());
     document.body.classList.add('appear');
-    // eslint-disable-next-line no-console
-    console.log('[CLS-DEBUG][scripts.js] body.appear added, loading first section...', debugTime());
     await loadSection(main.querySelector('.section'), waitForFirstImage);
-    // eslint-disable-next-line no-console
-    console.log('[CLS-DEBUG][scripts.js] First section loaded', debugTime());
   }
 
   try {
@@ -949,19 +933,13 @@ async function loadCategoryNav(main) {
   const categoryNavWrapper = document.createElement('div');
   categoryNavWrapper.classList.add('category-nav-wrapper');
   categoryNavWrapper.setAttribute('data-nav-placeholder', 'true');
-  // eslint-disable-next-line no-console
-  console.log('[CLS-DEBUG][scripts.js] Creating category-nav-wrapper, header height BEFORE:', getComputedStyle(document.querySelector('header')).height, performance.now().toFixed(2) + 'ms');
 
   // Insert into header nav-wrapper (not main) to prevent layout shift
   if (navWrapper) {
     navWrapper.appendChild(categoryNavWrapper);
-    // eslint-disable-next-line no-console
-    console.log('[CLS-DEBUG][scripts.js] category-nav-wrapper appended to header, height AFTER:', getComputedStyle(document.querySelector('header')).height, performance.now().toFixed(2) + 'ms');
   } else {
     // Fallback: insert at top of main if header not found
     main.insertBefore(categoryNavWrapper, main.firstChild);
-    // eslint-disable-next-line no-console
-    console.log('[CLS-DEBUG][scripts.js] category-nav-wrapper appended to main (fallback)', performance.now().toFixed(2) + 'ms');
   }
 
   // Load CSS for the category nav
@@ -1321,8 +1299,6 @@ async function loadLazy(doc) {
 
   // Load header first so nav-wrapper is available for category navbar
   await loadHeader(doc.querySelector('header'));
-  // eslint-disable-next-line no-console
-  console.log('[CLS-DEBUG][scripts.js] header loaded, height:', getComputedStyle(doc.querySelector('header')).height, performance.now().toFixed(2) + 'ms');
 
   // Load breadcrumbs after header is available and insert as first element in main
   await loadBreadcrumbs(main);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -135,11 +135,16 @@
 body {
   display: none;
   margin: 0;
-  background-color: var(--background-color);
+  background-color: #000; /* Start with black to prevent white flash on dark-themed pages */
   color: var(--text-color);
   font-family: var(--body-font-family);
   font-size: var(--body-font-size-s);
   line-height: 1.6;
+}
+
+/* Restore default background after page is fully loaded */
+body.page-loaded {
+  background-color: var(--background-color);
 }
 
 body.appear {
@@ -148,6 +153,7 @@ body.appear {
 
 header {
   height: var(--nav-height);
+  background-color: #fff; /* Header always white to prevent black flash on nav */
 }
 
 header .header,
@@ -542,6 +548,57 @@ main img {
 
 .center {
   text-align: center;
+}
+
+/* =================================================================
+   CLS PREVENTION: Hide cards until fully decorated
+   These rules MUST be in styles.css (not cards.css) because styles.css
+   loads before body.appear, while cards.css loads much later.
+   ================================================================= */
+
+/* 1. Hide entire card SECTIONS (not just blocks) until loaded.
+      This prevents section expansion from causing CLS.
+      Use background: #000 to prevent white flash on dark-themed pages. */
+.section.cards-container:not([data-section-status="loaded"]),
+.section.columns-container:not([data-section-status="loaded"]) {
+  visibility: hidden;
+  height: 450px;
+  overflow: hidden;
+  background: #000;
+}
+
+/* Ensure all children of hidden sections also have black background */
+.section.cards-container:not([data-section-status="loaded"]) *,
+.section.columns-container:not([data-section-status="loaded"]) * {
+  background: transparent !important;
+}
+
+/* 2. Also hide the cards blocks and wrappers as a fallback.
+      Set background to transparent to inherit parent's black background. */
+.cards:not([data-block-status="loaded"]),
+.cards-wrapper:has(.cards:not([data-block-status="loaded"])),
+.columns-wrapper,
+.cards-wrapper {
+  background: transparent;
+}
+
+.cards:not([data-block-status="loaded"]) {
+  visibility: hidden;
+}
+
+/* 3. Once section is loaded, use min-height instead of fixed height.
+      Keep black background to prevent white body showing through during transitions. */
+.section.cards-container[data-section-status="loaded"],
+.section.columns-container[data-section-status="loaded"] {
+  min-height: 450px;
+  height: auto;
+  overflow: visible;
+}
+
+/* 4. Sections with dark-scheme children should have dark backgrounds to prevent flash.
+      This catches cases where inline styles haven't applied yet. */
+.section:has(.dark-scheme) {
+  background-color: #000;
 }
 
 /* sections */
@@ -996,6 +1053,32 @@ The height and width are set to 200 assuming the doodles won't be larger. */
 }
 
 @media (width >=900px) {
+  /* =================================================================
+     CLS PREVENTION: Desktop-specific layout guards
+     ================================================================= */
+  
+  /* Pre-style cards as 3-column grid before decoration completes.
+     This prevents the 4-column flash and vertical stack states.
+     Uses :not() with comma syntax for modern CSS compliance. */
+  .cards:not(.swiper, [data-block-status="loaded"]) > ul,
+  .cards:not(.swiper, [data-block-status="loaded"]) > div {
+    display: grid;
+    grid-template-columns: repeat(3, 1fr);
+    gap: 36px;
+    max-width: 1050px;
+    margin: 0 auto;
+  }
+
+  /* Hide overflow items that would show in 4th+ position */
+  .cards:not(.swiper, [data-block-status="loaded"]) > ul > li:nth-child(n+4),
+  .cards:not(.swiper, [data-block-status="loaded"]) > div > div:nth-child(n+4) {
+    display: none;
+  }
+
+  /* =================================================================
+     END CLS PREVENTION
+     ================================================================= */
+
   :root {
     /* body sizes */
     --body-font-size-m: 18px;
@@ -1019,18 +1102,12 @@ The height and width are set to 200 assuming the doodles won't be larger. */
     height: var(--nav-height); /* nav = 80px */
   }
 
+  /* Reserve space for category-nav BEFORE it loads to prevent CLS.
+     The has-category-nav class is added by scripts.js based on page metadata.
+     This runs BEFORE body.appear, ensuring correct header height from the start. */
+  body.has-category-nav header,
   header:has(.category-nav-wrapper) {
-    height: calc(var(--category-nav-height) + var(--nav-height)); /* nav + category-nav = 80px + 64px * = 144px */
-  }
-
-  /* CLS guard: reserve space for all-about cards before block CSS loads
-  .section.cards-container:has(.cards.all-about-card) {
-    min-height: 1412px;
-  }
-  */
-
-  .cards.all-about-card:not([data-block-status="loaded"]) {
-    visibility: hidden;
+    height: calc(var(--category-nav-height) + var(--nav-height)); /* nav + category-nav = 80px + 64px = 144px */
   }
 
   
@@ -1045,7 +1122,7 @@ The height and width are set to 200 assuming the doodles won't be larger. */
     background-color: rgb(232 232 232 / 90%);
     border-radius: 20px;
     box-shadow: 0 1px 3px rgb(0 0 0 / 10%);
-    min-height: 28px;
+    min-height: 28px; /* Reserve space to prevent CLS */
     opacity: 0; /* Start hidden */
     visibility: hidden; /* Hide but reserve space until lazy-styles loads */
     transition: opacity 0.5s ease-in, visibility 0.5s; /* Smooth fade-in */


### PR DESCRIPTION
Heavy debugging for performance tracking in head.html, cards.js, aem.js, and scripts.js. Updated styles.css to include CLS prevention rules, ensuring sections and cards are hidden until fully loaded. Adjusted hero.css to prevent content resizing. Improved loading behavior for category navigation to mitigate layout shifts. Removed debug code now in final commit. Should have a reduction in the min-height/height spam and odd values from the first attempt at improvements. 

The first commit contains all debug and changes, second one just removes all debug lines and leaves the fixes. 

Good performance improvements realized for both mobile and desktop scores:

<img width="2250" height="1221" alt="image (3)" src="https://github.com/user-attachments/assets/d4334994-0bb5-43cc-9c08-6d34e0e05b48" />


<img width="2252" height="1154" alt="image (4)" src="https://github.com/user-attachments/assets/1d7e1b0f-a03f-4256-960e-6645cdcd0cf5" />


Fix #217 and general performance scores

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://clsfixesround3--idfc--aemsites.aem.page/credit-card/rupay-credit-card

Additional Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://clsfixesround3--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
