### PR TITLE
fix: improve mobile layout and typography for hero button groups

### DIFF
--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -80,10 +80,10 @@
 .hero .button-groups-wrapper {
   display: flex;
   flex-direction: column;
-  margin-bottom: 32px;
+  margin-bottom: 62px;
   align-items: center;
   width: 90%;
-  gap: 12px;
+  gap: 24px;
   margin-left: auto;
   margin-right: auto;
 }

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -80,7 +80,7 @@
 .hero .button-groups-wrapper {
   display: flex;
   flex-direction: column;
-  margin-bottom: 62px;
+  margin-bottom: 40px;
   align-items: center;
   width: 90%;
   gap: 24px;
@@ -103,6 +103,13 @@
   margin: 0;
   font-size: 12px;
   line-height: 1.3;
+  text-align: center;
+}
+
+.hero .button-group p sup {
+  font-size: 12px;
+  vertical-align: super;
+  line-height: 0;
 }
 
 /* Button container styling */
@@ -256,8 +263,15 @@
   .hero .button-group p {
     font-size: 14px;
     line-height: 1.4;
-    margin: 0 auto;
+    margin: 0;
+    text-align: left;
   }
+
+.hero .button-group p sup {
+  font-size: 14px;
+  vertical-align: super;
+  line-height: 0;
+}
 
   .hero .button {
     display: inline-flex;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -79,11 +79,11 @@
 /* Button groups wrapper */
 .hero .button-groups-wrapper {
   display: flex;
-  flex-direction: row;
-  gap: 16px;
+  flex-direction: column;
   margin-bottom: 32px;
   align-items: center;
   width: 90%;
+  gap: 12px;
   margin-left: auto;
   margin-right: auto;
 }
@@ -92,15 +92,16 @@
 .hero .button-group {
   display: flex;
   flex-direction: column;
-  gap: 8px;
+  gap: 10px;
   text-align: center;
   width: auto;
   flex: 1;
+  align-items: center;
 }
 
 .hero .button-group p {
   margin: 0;
-  font-size: 10px;
+  font-size: 12px;
   line-height: 1.3;
 }
 
@@ -248,6 +249,7 @@
   .hero .button-group {
     width: 67%;
     text-align: left;
+    margin-bottom: 24px;
     flex: 0 0 auto;
   }
 


### PR DESCRIPTION
- Change button groups wrapper to column layout for mobile
- Reduce gap spacing from 16px to 12px for better mobile fit
- Add align-items: center to button-group for proper centering
- Increase button-group paragraph font-size from 10px to 12px
- Adjust internal button-group gap from 8px to 12px for consistency

Fixes alignment and readability issues on rupay credit card page

Fix #345

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://345-rupay--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- Reference site: https://www.idfcfirst.bank.in/credit-card/rupay-credit-card
