### PR TITLE
Update background handling for Universal Editor and improve section visibility

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -683,7 +683,9 @@ export default async function decorate(block) {
   const initialWrapperHeight = wrapper?.getBoundingClientRect().height;
   const initialSectionHeight = section?.getBoundingClientRect().height;
 
-  if (isDesktop && isAllAboutCard && section) {
+  // Skip CLS visibility hiding in Universal Editor
+  const isEditor = document.querySelector('main[data-aue-resource]');
+  if (isDesktop && isAllAboutCard && section && !isEditor) {
     section.style.minHeight = '1412px';
     if (wrapper) wrapper.style.minHeight = '1412px';
     block.style.minHeight = '1412px';
@@ -691,7 +693,8 @@ export default async function decorate(block) {
   }
 
   // Prevent temporary collapse while we rebuild the DOM for cards on desktop.
-  if (isDesktop && initialBlockHeight > 0) {
+  // Skip in Universal Editor to avoid layout issues.
+  if (isDesktop && initialBlockHeight > 0 && !isEditor) {
     block.style.minHeight = `${initialBlockHeight}px`;
     if (wrapper && initialWrapperHeight) {
       wrapper.style.minHeight = `${initialWrapperHeight}px`;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -142,6 +142,11 @@ body {
   display: none;
   margin: 0;
   background-color: #000; /* Start with black to prevent white flash on dark-themed pages */
+}
+
+/* In Universal Editor, use default background immediately */
+body:has(main[data-aue-resource]) {
+  background-color: var(--background-color);
   color: var(--text-color);
   font-family: var(--body-font-family);
   font-size: var(--body-font-size-s);
@@ -568,9 +573,10 @@ main img {
 
 /* 1. Hide entire card SECTIONS (not just blocks) until loaded.
       This prevents section expansion from causing CLS.
-      Use background: #000 to prevent white flash on dark-themed pages. */
-.section.cards-container:not([data-section-status="loaded"]),
-.section.columns-container:not([data-section-status="loaded"]) {
+      Use background: #000 to prevent white flash on dark-themed pages.
+      NOTE: Scoped to main:not([data-aue-resource]) to exclude Universal Editor. */
+main:not([data-aue-resource]) .section.cards-container:not([data-section-status="loaded"]),
+main:not([data-aue-resource]) .section.columns-container:not([data-section-status="loaded"]) {
   visibility: hidden;
   height: 450px;
   overflow: hidden;
@@ -578,8 +584,8 @@ main img {
 }
 
 /* Ensure all children of hidden sections also have black background */
-.section.cards-container:not([data-section-status="loaded"]) *,
-.section.columns-container:not([data-section-status="loaded"]) * {
+main:not([data-aue-resource]) .section.cards-container:not([data-section-status="loaded"]) *,
+main:not([data-aue-resource]) .section.columns-container:not([data-section-status="loaded"]) * {
   background: transparent !important;
 }
 
@@ -592,7 +598,7 @@ main img {
   background: transparent;
 }
 
-.cards:not([data-block-status="loaded"]) {
+main:not([data-aue-resource]) .cards:not([data-block-status="loaded"]) {
   visibility: hidden;
 }
 


### PR DESCRIPTION
- Set default background color for body in Universal Editor.
- Adjust visibility rules to exclude Universal Editor.
- Ensure all children of hidden sections maintain a transparent background.

This is a UE fix. 

Fix #377 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://377-UEFix--idfc--aemsites.aem.page/
