### PR TITLE
Table: Add left and right padding

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -7,6 +7,10 @@
   position: relative;
 }
 
+.table-wrapper{
+  padding: 0 16px;
+}
+
 .table-background-image {
   position: absolute;
   top: 0;

--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -7,7 +7,7 @@
   position: relative;
 }
 
-.table-wrapper{
+.modal-content .block-content.table-wrapper{
   padding: 0 16px;
 }
 


### PR DESCRIPTION
Fix #367 

Added 16px horizontal padding (left and right) to the table within the "Fees and Charges" popup window.

The remaining styling for the popup window will be addressed in a separate issue or PR.

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://367-table-padding--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
