### PR TITLE
fix: improve mobile spacing for Pay using UPI section

### DIFF
--- a/blocks/steps/steps.css
+++ b/blocks/steps/steps.css
@@ -117,16 +117,16 @@
 
 /* UPI red background variant - mobile */
 .upi-steps-red-bg .steps {
-  padding: 0 15px;
+  padding: 0;
 }
 
 .upi-steps-red-bg .steps-title {
   text-shadow: unset;
-  margin: 0 0 16px;
+  margin: 0 0 18px;
 }
 
 .upi-steps-red-bg .steps-subtitle {
-  width: 70%;
+  width: 100%;
   margin: 0 auto;
   font-size: 14px;
   font-family: var(--body-font-family);

--- a/blocks/steps/steps.css
+++ b/blocks/steps/steps.css
@@ -34,7 +34,8 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 40px;
-  max-width: 80%;
+
+  /* max-width: 80%; */
   list-style: none;
   padding: 0;
   margin: 0;
@@ -120,6 +121,11 @@
   padding: 0;
 }
 
+/* Override inherited padding from parent wrapper */
+.upi-steps-red-bg .steps-wrapper {
+  padding: 10px;
+}
+
 .upi-steps-red-bg .steps-title {
   text-shadow: unset;
   margin: 0 0 18px;
@@ -147,7 +153,9 @@
 }
 
 .upi-steps-red-bg .steps-item-body p {
-  width: 60%;
+  /* width: 60%; */
+  font-weight: 500;
+  line-height: normal;
 }
 
 .upi-steps-red-bg .grid-steps{

--- a/blocks/steps/steps.css
+++ b/blocks/steps/steps.css
@@ -34,8 +34,6 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 40px;
-
-  /* max-width: 80%; */
   list-style: none;
   padding: 0;
   margin: 0;
@@ -121,7 +119,6 @@
   padding: 0;
 }
 
-/* Override inherited padding from parent wrapper */
 .upi-steps-red-bg .steps-wrapper {
   padding: 10px;
 }
@@ -153,7 +150,6 @@
 }
 
 .upi-steps-red-bg .steps-item-body p {
-  /* width: 60%; */
   font-weight: 500;
   line-height: normal;
 }

--- a/blocks/steps/steps.css
+++ b/blocks/steps/steps.css
@@ -34,6 +34,7 @@
   flex-direction: column;
   align-items: flex-start;
   gap: 40px;
+  max-width: 80%;
   list-style: none;
   padding: 0;
   margin: 0;
@@ -154,8 +155,9 @@
   line-height: normal;
 }
 
-.upi-steps-red-bg .grid-steps{
+.upi-steps-red-bg .grid-steps {
   gap: 24px;
+  max-width: 100%;
 }
 
 /* ===== TABLET (600px - 899px) ===== */

--- a/blocks/tabs-upi-link/tabs-upi-link.css
+++ b/blocks/tabs-upi-link/tabs-upi-link.css
@@ -292,8 +292,16 @@
   box-shadow: 0 4px 12px rgb(128 28 30 / 30%);
 }
 
+.section.upi-steps-red-bg {
+  padding: 39px 8px;
+}
+
 /* Tablet and up: Button standard width (not full width), centered */
 @media (width >= 600px) {
+  .section.upi-steps-red-bg {
+  padding: 96px 0;
+  }
+
   .section:has(.tabs-upi-link) > div,
   .section.tabs-upi-link-container > div {
     max-width: 720px;


### PR DESCRIPTION
Reduce padding and expand subtitle width to prevent excessive text wrapping on mobile devices (below 600px). 

Fix #389 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://389-pay-mobile--idfc--aemsites.aem.page/credit-card/rupay-credit-card
