### PR TITLE
Fix desktop footer icon layout

### DIFF
--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -243,7 +243,6 @@ footer .footer>div .section>div {
 
 .footer>div>div:nth-child(2)>div>ul {
   display: flex;
-  flex-wrap: wrap;
 }
 
 .footer>div>div:nth-child(2)>div>ul>li {
@@ -282,8 +281,16 @@ footer .footer>div .section>div {
   letter-spacing: 0.5px;
 }
 
+.footer>div>div:nth-child(2)>div>ul>li:nth-child(2) p {
+  text-align: center;
+}
+
 .footer>div>div:nth-child(2)>div>ul>li>ul {
   display: flex;
+}
+
+.footer>div>div:nth-child(2)>div>ul>li:nth-child(2) ul {
+  justify-content: space-around;
 }
 
 .footer>div>div:nth-child(2)>div>ul>li:nth-child(2)>ul>li:nth-child(2) {
@@ -547,6 +554,14 @@ footer .footer>div .section>div {
     flex: 0 0 100%;
     max-width: 100%;
     padding: 0;
+  }
+
+  .footer>div>div:nth-child(2)>div>ul>li:nth-child(2) p {
+    text-align: left;
+  }
+
+  .footer>div>div:nth-child(2)>div>ul>li:nth-child(2) ul {
+    justify-content: left;
   }
 
   .footer>div>div .accordion-wrapper .accordion .accordion-item-body ul li {


### PR DESCRIPTION
Fix footer icon layout in desktop size, verify mobile layout remains the same.

Fix #397

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://397-footer-desktop--idfc--aemsites.aem.page/
