### PR TITLE
Fix category-nav visibility issues during editing.

### DIFF
--- a/blocks/category-nav/category-nav.css
+++ b/blocks/category-nav/category-nav.css
@@ -1,5 +1,47 @@
 /* stylelint-disable selector-class-pattern, no-descending-specificity */
 
+/* =================================================================
+   Framework Page & Universal Editor Support: 
+   Show raw content when editing/previewing framework pages.
+   The category-nav block's raw table content should be visible
+   so content authors can edit it directly.
+   
+   Applies to:
+   - Universal Editor (main[data-aue-resource])
+   - Direct framework page viewing (body.is-framework-page)
+   ================================================================= */
+main[data-aue-resource] .category-nav.block,
+body.is-framework-page .category-nav.block {
+  display: block !important;
+  visibility: visible !important;
+  min-height: 100px;
+  padding: 16px;
+  background: #f9f9f9;
+  border: 1px dashed #ccc;
+  border-radius: 8px;
+}
+
+main[data-aue-resource] .category-nav.block > div,
+body.is-framework-page .category-nav.block > div {
+  display: block !important;
+  visibility: visible !important;
+  padding: 8px;
+  margin-bottom: 8px;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 4px;
+}
+
+main[data-aue-resource] .category-nav.block > div > div,
+body.is-framework-page .category-nav.block > div > div {
+  display: inline-block;
+  padding: 4px 8px;
+  margin: 2px;
+  background: #f5f5f5;
+  border-radius: 3px;
+  font-size: 12px;
+}
+
 /* Category Nav Wrapper - full width gray background */
 .category-nav-wrapper {
   width: 100%;

--- a/blocks/category-nav/category-nav.js
+++ b/blocks/category-nav/category-nav.js
@@ -337,6 +337,20 @@ function isEditingFrameworkPage() {
   // The path could be /framework/* or /content/idfc-edge/framework/*
   const isFrameworkPath = window.location.pathname.includes('/framework/');
 
+  // In Universal Editor, the content is loaded via a proxy/canvas URL,
+  // so window.location.pathname doesn't reflect the actual page path.
+  // We need to check the data-aue-resource attribute on main element.
+  const mainElement = document.querySelector('main[data-aue-resource]');
+  const isInUniversalEditor = !!mainElement;
+
+  if (isInUniversalEditor) {
+    // Get the resource path from the data-aue-resource attribute
+    // Format: "urn:aemconnection:/content/idfc-edge/framework/ccnav.html/jcr:content"
+    const resourcePath = mainElement.getAttribute('data-aue-resource') || '';
+    const isUEFrameworkPath = resourcePath.includes('/framework/');
+    return isUEFrameworkPath;
+  }
+
   return isFrameworkPath;
 }
 

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -20,7 +20,23 @@ window.hlx.isEditor = true;
  * @returns {boolean} true if we should skip navigation building
  */
 function isEditingFrameworkPage() {
+  // Check if current path is in the framework folder
   const isFrameworkPath = window.location.pathname.includes('/framework/');
+
+  // In Universal Editor, the content is loaded via a proxy/canvas URL,
+  // so window.location.pathname doesn't reflect the actual page path.
+  // We need to check the data-aue-resource attribute on main element.
+  const mainElement = document.querySelector('main[data-aue-resource]');
+  const isInUniversalEditor = !!mainElement;
+
+  if (isInUniversalEditor) {
+    // Get the resource path from the data-aue-resource attribute
+    // Format: "urn:aemconnection:/content/idfc-edge/framework/ccnav.html/jcr:content"
+    const resourcePath = mainElement.getAttribute('data-aue-resource') || '';
+    const isUEFrameworkPath = resourcePath.includes('/framework/');
+    return isUEFrameworkPath;
+  }
+
   return isFrameworkPath;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -902,6 +902,11 @@ async function loadEager(doc) {
       document.body.classList.add('has-category-nav');
     }
 
+    // Mark framework pages so CSS can show raw content for editing/preview
+    if (isEditingFrameworkPage()) {
+      document.body.classList.add('is-framework-page');
+    }
+
     document.body.classList.add('appear');
     await loadSection(main.querySelector('.section'), waitForFirstImage);
   }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -868,15 +868,36 @@ main .section.upi-steps-red-bg {
  * layout shifts. The sections are removed after processing, so they should
  * never be visible in main.
  * The !important is required to override inline styles set by JS during loading.
+ * NOTE: Exceptions:
+ *   - Universal Editor (main[data-aue-resource]) - content must be visible for editing
+ *   - Framework pages (body.is-framework-page) - content must be visible for preview/editing
  */
-.section.category-nav-container,
-.section.category-nav-section {
+body:not(.is-framework-page) main:not([data-aue-resource]) .section.category-nav-container,
+body:not(.is-framework-page) main:not([data-aue-resource]) .section.category-nav-section {
   display: none !important; /* important's are required for these properties to override inline styles set by JS during loading */
   visibility: hidden !important;
   height: 0 !important;
   overflow: hidden !important;
   margin: 0 !important;
   padding: 0 !important;
+}
+
+/* In Universal Editor, show category-nav sections for editing */
+main[data-aue-resource] .section.category-nav-container,
+main[data-aue-resource] .section.category-nav-section {
+  display: block !important;
+  visibility: visible !important;
+  height: auto !important;
+  overflow: visible !important;
+}
+
+/* On framework pages, show category-nav sections for preview/editing */
+body.is-framework-page .section.category-nav-container,
+body.is-framework-page .section.category-nav-section {
+  display: block !important;
+  visibility: visible !important;
+  height: auto !important;
+  overflow: visible !important;
 }
 
 .section.banner-image .default-content-wrapper ol {


### PR DESCRIPTION
Make the raw cc-nav data display properly while in UE so that it's much easier to edit/update. 

<img width="3041" height="1303" alt="image" src="https://github.com/user-attachments/assets/a27db442-ffcf-4490-ba09-4d8059b7fbe0" />


Test URLs:
- Before: https://main--idfc--aemsites.aem.page/framework/ccnav
- After: https://ccnav-ue-display-fix--idfc--aemsites.aem.page/framework/ccnav
