### PR TITLE
Fix Hero-HeritageCC display in UE

### DIFF
--- a/blocks/hero-heritage-cc/_hero-heritage-cc.json
+++ b/blocks/hero-heritage-cc/_hero-heritage-cc.json
@@ -8,7 +8,7 @@
           "page": {
             "resourceType": "core/franklin/components/block/v1/block",
             "template": {
-              "name": "Hero - Heritage CC",
+              "name": "Hero Heritage CC",
               "model": "hero-heritage-cc"
             }
           }

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -753,8 +753,10 @@ main[data-aue-resource] .hero-heritage-cc-header-cta {
 
 main[data-aue-resource] .hero-heritage-cc-header-cta > div {
   display: flex;
-  flex-direction: column;
-  gap: 8px;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 16px;
   width: 100%;
 }
 

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -593,6 +593,28 @@
    When editing in Universal Editor, disable animations and show
    all content in a structured, editable layout.
    ================================================================= */
+
+/* DEBUG: Bright red border to confirm UE styles are loading */
+main[data-aue-resource] .hero-heritage-cc {
+  outline: 5px solid red !important;
+}
+
+main[data-aue-resource] .hero-heritage-cc::before {
+  content: 'DEBUG: UE styles ARE loading' !important;
+  display: block !important;
+  position: fixed !important;
+  top: 100px !important;
+  left: 50% !important;
+  transform: translateX(-50%) !important;
+  background: red !important;
+  color: white !important;
+  padding: 10px 20px !important;
+  font-size: 16px !important;
+  font-weight: bold !important;
+  z-index: 99999 !important;
+  border-radius: 8px !important;
+}
+
 main[data-aue-resource] .hero-heritage-cc-container {
   min-height: auto;
   height: auto;

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -594,25 +594,23 @@
    all content in a structured, editable layout.
    ================================================================= */
 
-/* DEBUG: Bright red border to confirm UE styles are loading */
-main[data-aue-resource] .hero-heritage-cc {
-  outline: 5px solid red !important;
-}
-
+/* UE editing mode indicator */
 main[data-aue-resource] .hero-heritage-cc::before {
-  content: 'DEBUG: UE styles ARE loading' !important;
+  content: 'Editing Block Overview' !important;
   display: block !important;
   position: fixed !important;
-  top: 100px !important;
+  top: 200px !important;
   left: 50% !important;
   transform: translateX(-50%) !important;
-  background: red !important;
-  color: white !important;
-  padding: 10px 20px !important;
-  font-size: 16px !important;
-  font-weight: bold !important;
+  background: #3a3a3a !important;
+  color: #fff !important;
+  padding: 8px 16px !important;
+  font-size: 12px !important;
+  font-weight: 600 !important;
   z-index: 99999 !important;
-  border-radius: 8px !important;
+  border-radius: 6px !important;
+  letter-spacing: 0.5px !important;
+  box-shadow: 0 2px 8px rgb(0 0 0 / 30%) !important;
 }
 
 main[data-aue-resource] .hero-heritage-cc-container {
@@ -725,9 +723,19 @@ main[data-aue-resource] .hero-heritage-cc-header-cta {
   display: flex;
   position: relative;
   height: auto;
-  min-height: 50px;
-  background: rgba(0 0 0 / 5%);
+  min-height: auto;
+  background: #fff;
   backdrop-filter: none;
+  padding: 12px 16px;
+  border-radius: 6px;
+  border: 1px solid #e0e0e0;
+}
+
+main[data-aue-resource] .hero-heritage-cc-header-cta > div {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  width: 100%;
 }
 
 /* Logo wrapper in UE - side by side layout */
@@ -737,6 +745,35 @@ main[data-aue-resource] .hero-heritage-cc-intro-logo-wrapper {
   gap: 16px;
   min-height: auto;
   align-items: center;
+}
+
+/* Show the intro background image as a thumbnail in UE */
+main[data-aue-resource] .hero-heritage-cc-intro-bg-preview-wrapper {
+  display: block !important;
+  position: relative;
+  flex: 0 0 auto;
+  order: -1;
+  margin-right: 8px;
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro-bg-preview-wrapper::before {
+  content: 'Intro Background';
+  display: block;
+  font-size: 9px;
+  color: #888;
+  margin-bottom: 4px;
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro-bg-preview {
+  max-width: 100px !important;
+  border-radius: 4px;
+  border: 1px solid #ddd;
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro-bg-preview img {
+  max-width: 100px !important;
+  height: auto !important;
+  border-radius: 4px;
 }
 
 main[data-aue-resource] .hero-heritage-cc-intro-logo-hindi,

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -600,8 +600,7 @@ main[data-aue-resource] .hero-heritage-cc::before {
   display: block !important;
   position: fixed !important;
   top: 200px !important;
-  left: 50% !important;
-  transform: translateX(-50%) !important;
+  right: 100px !important;
   background: #3a3a3a !important;
   color: #fff !important;
   padding: 8px 16px !important;
@@ -618,6 +617,7 @@ main[data-aue-resource] .hero-heritage-cc-container {
   height: auto;
   contain: none;
   overflow: visible;
+  margin-top: 100px;
 }
 
 main[data-aue-resource] .hero-heritage-cc-container .hero-heritage-cc-wrapper {
@@ -847,7 +847,7 @@ main[data-aue-resource] .hero-heritage-cc p {
   margin: 4px 0;
 }
 
-/* CTA buttons in UE - visible with labels */
+/* CTA buttons in UE - reset to default button styling */
 main[data-aue-resource] .hero-heritage-cc-banner-cta-group {
   flex-flow: row wrap;
   gap: 12px;
@@ -855,14 +855,17 @@ main[data-aue-resource] .hero-heritage-cc-banner-cta-group {
 }
 
 main[data-aue-resource] .hero-heritage-cc-banner-cta a.button {
-  padding: 8px 16px;
-  font-size: 12px;
-  background: #333;
-  color: #fff;
-  border-radius: 4px;
-  text-decoration: none;
+  color: unset;
+  font-size: unset;
+  font-weight: unset;
+  line-height: unset;
+  text-decoration-line: unset;
 }
 
 main[data-aue-resource] .hero-heritage-cc-banner-cta a.button.primary {
-  background: #c33;
+  background: unset;
+  padding: unset;
+  font-size: unset;
+  border: unset;
+  text-decoration: unset;
 }

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -625,6 +625,11 @@ main[data-aue-resource] .hero-heritage-cc-container {
   overflow: visible;
 }
 
+/* Decoration image (top right) - raise above header CTA in UE */
+main[data-aue-resource] .hero-heritage-cc-container::before {
+  z-index: 20;
+}
+
 main[data-aue-resource] .hero-heritage-cc-container .hero-heritage-cc-wrapper {
   height: auto;
   min-height: auto;

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -594,19 +594,24 @@
    all content in a structured, editable layout.
    ================================================================= */
 
-/* UE editing mode indicator */
+/* UE editing mode indicator - tab label style at top of block */
+main[data-aue-resource] .hero-heritage-cc {
+  position: relative;
+}
+
 main[data-aue-resource] .hero-heritage-cc::before {
   content: 'EDITING BLOCK OVERVIEW' !important;
   display: block !important;
-  position: fixed !important;
-  top: 250px !important;
-  right: 100px !important;
+  position: absolute !important;
+  top: 0 !important;
+  left: 50% !important;
+  transform: translate(-50%, -50%) !important;
   background: #3a3a3a !important;
   color: #fff !important;
   padding: 8px 16px !important;
   font-size: 11px !important;
   font-weight: 600 !important;
-  z-index: 99999 !important;
+  z-index: 10 !important;
   border-radius: 6px !important;
   letter-spacing: 1px !important;
   text-transform: uppercase !important;

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -756,8 +756,10 @@ main[data-aue-resource] .hero-heritage-cc-header-cta > div {
   flex-direction: row;
   flex-wrap: wrap;
   align-items: center;
+  justify-content: flex-end;
   gap: 16px;
   width: 100%;
+  padding-right: 100px;
 }
 
 /* Logo wrapper in UE - side by side layout */

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -617,12 +617,22 @@ main[data-aue-resource] .hero-heritage-cc-container {
   height: auto;
   contain: none;
   overflow: visible;
-  margin-top: 100px;
+  margin-top: 50px;
 }
 
 main[data-aue-resource] .hero-heritage-cc-container .hero-heritage-cc-wrapper {
   height: auto;
   min-height: auto;
+  display: flex;
+  flex-direction: column;
+}
+
+/* Move breadcrumbs above the block in UE mode */
+main[data-aue-resource] .hero-heritage-cc-container .hero-heritage-cc-wrapper .breadcrumbs {
+  position: static;
+  transform: none;
+  order: -1;
+  margin-bottom: 16px;
 }
 
 main[data-aue-resource] .hero-heritage-cc {

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -587,3 +587,223 @@
     display: block;
   }
 }
+
+/* =================================================================
+   Universal Editor Support:
+   When editing in Universal Editor, disable animations and show
+   all content in a structured, editable layout.
+   ================================================================= */
+main[data-aue-resource] .hero-heritage-cc-container {
+  min-height: auto;
+  height: auto;
+  contain: none;
+  overflow: visible;
+}
+
+main[data-aue-resource] .hero-heritage-cc-container .hero-heritage-cc-wrapper {
+  height: auto;
+  min-height: auto;
+}
+
+main[data-aue-resource] .hero-heritage-cc {
+  min-height: auto;
+  height: auto;
+  overflow: visible;
+  padding: 16px;
+  background: #f5f5f5;
+  border: 1px dashed #ccc;
+  border-radius: 8px;
+}
+
+/* Make block visible immediately in UE - override loaded check */
+main[data-aue-resource] .hero-heritage-cc:not([data-block-status="loaded"]) {
+  visibility: visible;
+}
+
+/* Disable all animations in UE */
+main[data-aue-resource] .hero-heritage-cc,
+main[data-aue-resource] .hero-heritage-cc *,
+main[data-aue-resource] .hero-heritage-cc::before,
+main[data-aue-resource] .hero-heritage-cc::after {
+  animation: none !important;
+  transition: none !important;
+}
+
+/* Section headers for UE clarity */
+main[data-aue-resource] .hero-heritage-cc > div {
+  position: relative;
+  margin-bottom: 16px;
+  padding: 12px;
+  background: #fff;
+  border: 1px solid #e0e0e0;
+  border-radius: 6px;
+}
+
+main[data-aue-resource] .hero-heritage-cc > div::before {
+  display: block;
+  font-size: 10px;
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+  color: #666;
+  margin-bottom: 8px;
+  padding: 4px 8px;
+  background: #eee;
+  border-radius: 3px;
+  width: fit-content;
+}
+
+main[data-aue-resource] .hero-heritage-cc-header-cta::before {
+  content: 'Header CTA Section';
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro::before {
+  content: 'Intro Section (Animated overlay)';
+}
+
+main[data-aue-resource] .hero-heritage-cc-banner::before {
+  content: 'Banner Section (Main content)';
+}
+
+/* Override absolute positioning in UE - make sections flow normally */
+main[data-aue-resource] .hero-heritage-cc-intro,
+main[data-aue-resource] .hero-heritage-cc-banner {
+  position: relative;
+  top: auto;
+  left: auto;
+  width: 100%;
+  height: auto;
+  opacity: 1 !important;
+  visibility: visible !important;
+  z-index: auto;
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro > div,
+main[data-aue-resource] .hero-heritage-cc-banner > div,
+main[data-aue-resource] .hero-heritage-cc .hero-heritage-cc-intro > div,
+main[data-aue-resource] .hero-heritage-cc .hero-heritage-cc-banner > div {
+  position: relative;
+  top: auto;
+  left: auto;
+  width: 100%;
+  height: auto;
+  max-width: 100%;
+  opacity: 1 !important;
+  visibility: visible !important;
+  padding: 0;
+}
+
+/* Hide the gradient overlay pseudo-element in UE */
+main[data-aue-resource] .hero-heritage-cc-intro::after {
+  display: none !important;
+}
+
+/* Show header CTA in UE regardless of viewport */
+main[data-aue-resource] .hero-heritage-cc-header-cta {
+  display: flex;
+  position: relative;
+  height: auto;
+  min-height: 50px;
+  background: rgba(0 0 0 / 5%);
+  backdrop-filter: none;
+}
+
+/* Logo wrapper in UE - side by side layout */
+main[data-aue-resource] .hero-heritage-cc-intro-logo-wrapper {
+  display: flex;
+  flex-direction: row;
+  gap: 16px;
+  min-height: auto;
+  align-items: center;
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro-logo-hindi,
+main[data-aue-resource] .hero-heritage-cc-intro-logo-english {
+  position: relative;
+  clip-path: none !important;
+  flex: 1;
+  padding: 8px;
+  background: #f9f9f9;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro-logo-hindi::before,
+main[data-aue-resource] .hero-heritage-cc-intro-logo-english::before {
+  content: 'Hindi Logo';
+  display: block;
+  font-size: 9px;
+  color: #888;
+  margin-bottom: 4px;
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro-logo-english::before {
+  content: 'English Logo';
+}
+
+/* Thumbnail images in UE */
+main[data-aue-resource] .hero-heritage-cc picture {
+  max-width: 200px;
+  margin: 8px auto;
+}
+
+main[data-aue-resource] .hero-heritage-cc img {
+  max-width: 100%;
+  max-height: 150px;
+  width: auto;
+  height: auto;
+  object-fit: contain;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  background: #fff;
+}
+
+/* Banner image specific - slightly larger preview */
+main[data-aue-resource] .hero-heritage-cc-banner-image picture {
+  max-width: 300px;
+}
+
+main[data-aue-resource] .hero-heritage-cc-banner-image img {
+  max-height: 200px;
+}
+
+/* Text styling in UE */
+main[data-aue-resource] .hero-heritage-cc h1,
+main[data-aue-resource] .hero-heritage-cc h2,
+main[data-aue-resource] .hero-heritage-cc h3,
+main[data-aue-resource] .hero-heritage-cc h4 {
+  color: #333;
+  font-size: 18px;
+  margin: 8px 0;
+  background: none;
+  /* stylelint-disable-next-line property-no-vendor-prefix */
+  -webkit-background-clip: unset;
+  background-clip: unset;
+  -webkit-text-fill-color: unset;
+}
+
+main[data-aue-resource] .hero-heritage-cc p {
+  color: #555;
+  font-size: 13px;
+  margin: 4px 0;
+}
+
+/* CTA buttons in UE - visible with labels */
+main[data-aue-resource] .hero-heritage-cc-banner-cta-group {
+  flex-flow: row wrap;
+  gap: 12px;
+  margin-top: 16px;
+}
+
+main[data-aue-resource] .hero-heritage-cc-banner-cta a.button {
+  padding: 8px 16px;
+  font-size: 12px;
+  background: #333;
+  color: #fff;
+  border-radius: 4px;
+  text-decoration: none;
+}
+
+main[data-aue-resource] .hero-heritage-cc-banner-cta a.button.primary {
+  background: #c33;
+}

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -600,7 +600,7 @@ main[data-aue-resource] .hero-heritage-cc {
 }
 
 main[data-aue-resource] .hero-heritage-cc::before {
-  content: 'EDITING BLOCK OVERVIEW' !important;
+  content: 'ANIMATED BLOCK EDITING OVERVIEW' !important;
   display: block !important;
   position: absolute !important;
   top: 0 !important;

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -596,19 +596,20 @@
 
 /* UE editing mode indicator */
 main[data-aue-resource] .hero-heritage-cc::before {
-  content: 'Editing Block Overview' !important;
+  content: 'EDITING BLOCK OVERVIEW' !important;
   display: block !important;
   position: fixed !important;
-  top: 200px !important;
+  top: 250px !important;
   right: 100px !important;
   background: #3a3a3a !important;
   color: #fff !important;
   padding: 8px 16px !important;
-  font-size: 12px !important;
+  font-size: 11px !important;
   font-weight: 600 !important;
   z-index: 99999 !important;
   border-radius: 6px !important;
-  letter-spacing: 0.5px !important;
+  letter-spacing: 1px !important;
+  text-transform: uppercase !important;
   box-shadow: 0 2px 8px rgb(0 0 0 / 30%) !important;
 }
 
@@ -617,7 +618,6 @@ main[data-aue-resource] .hero-heritage-cc-container {
   height: auto;
   contain: none;
   overflow: visible;
-  margin-top: 50px;
 }
 
 main[data-aue-resource] .hero-heritage-cc-container .hero-heritage-cc-wrapper {

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -698,7 +698,53 @@ main[data-aue-resource] .hero-heritage-cc-header-cta::before {
 }
 
 main[data-aue-resource] .hero-heritage-cc-intro::before {
-  content: 'Intro Section (Animated overlay)';
+  content: 'INTRO SECTION (ANIMATED OVERLAY)';
+  position: relative;
+  width: auto;
+  height: auto;
+  background: #3a3a3a;
+  color: #fff;
+  padding: 6px 12px;
+  font-size: 10px;
+  font-weight: 600;
+  letter-spacing: 0.5px;
+  border-radius: 4px;
+  z-index: 10;
+  animation: none;
+  display: inline-block;
+  margin: 8px auto;
+}
+
+/* Gradient color preview in UE */
+main[data-aue-resource] .hero-heritage-cc-intro-gradient-preview {
+  display: flex !important;
+  align-items: center;
+  gap: 12px;
+  padding: 8px 12px;
+  background: #f5f5f5;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  margin: 8px 0;
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro-gradient-preview::before {
+  content: 'Gradient Color:';
+  font-size: 10px;
+  color: #666;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.5px;
+}
+
+main[data-aue-resource] .hero-heritage-cc-intro-gradient-preview::after {
+  content: '';
+  display: block;
+  width: 40px;
+  height: 24px;
+  background: var(--hero-heritage-cc-intro-gradient);
+  border-radius: 4px;
+  border: 1px solid #ccc;
+  flex-shrink: 0;
 }
 
 main[data-aue-resource] .hero-heritage-cc-banner::before {
@@ -753,8 +799,7 @@ main[data-aue-resource] .hero-heritage-cc-header-cta {
 
 main[data-aue-resource] .hero-heritage-cc-header-cta > div {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
   align-items: center;
   justify-content: flex-end;
   gap: 16px;

--- a/blocks/hero-heritage-cc/hero-heritage-cc.js
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.js
@@ -325,7 +325,13 @@ export default function decorate(block) {
           // Store the value as a data attribute and CSS custom property
           block.dataset.gradientColor = normalizedValue;
           block.style.setProperty('--hero-heritage-cc-intro-gradient', normalizedValue);
-          p.remove(); // Remove the raw text element from DOM
+
+          // In UE mode, keep visible for editing; on live pages, remove
+          if (hasAueResource) {
+            p.classList.add('hero-heritage-cc-intro-gradient-preview');
+          } else {
+            p.remove();
+          }
         }
       });
 

--- a/blocks/hero-heritage-cc/hero-heritage-cc.js
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.js
@@ -213,40 +213,51 @@ export default function decorate(block) {
       // Get all pictures in intro (order follows model field order)
       const pictures = introContent.querySelectorAll('picture');
 
-      // First picture is the background image - apply to section container
+      // First picture is the background image
       if (pictures[0]) {
         const bgPicture = pictures[0];
         const bgPictureWrapper = bgPicture.closest('p');
         const bgImg = bgPicture.querySelector('img');
 
-        // Get WebP source for better compression (prefer mobile size for LCP)
-        const webpSource = bgPicture.querySelector('source[type="image/webp"]');
-        const bgUrl = webpSource?.srcset?.split(',')[0]?.trim()?.split(' ')[0]
-          || bgImg?.src;
+        // Check if we're in Universal Editor
+        const isInUE = !!document.querySelector('main[data-aue-resource]');
 
-        if (bgUrl) {
-          // Find the section container and set background image
-          const sectionContainer = block.closest('.section');
-          if (sectionContainer) {
-            sectionContainer.style.backgroundImage = `url(${bgUrl})`;
-            sectionContainer.style.backgroundSize = 'cover';
-            sectionContainer.style.backgroundRepeat = 'repeat';
-            sectionContainer.style.backgroundPosition = 'center center';
-            sectionContainer.style.backgroundAttachment = 'fixed';
-
-            // Add preload link for LCP optimization with WebP
-            const preloadLink = document.createElement('link');
-            preloadLink.rel = 'preload';
-            preloadLink.as = 'image';
-            preloadLink.href = bgUrl;
-            preloadLink.fetchPriority = 'high';
-            if (webpSource) preloadLink.type = 'image/webp';
-            document.head.appendChild(preloadLink);
+        if (isInUE) {
+          // In UE: Show as a clickable thumbnail for easy content authoring
+          bgPicture.classList.add('hero-heritage-cc-intro-bg-preview');
+          if (bgPictureWrapper) {
+            bgPictureWrapper.classList.add('hero-heritage-cc-intro-bg-preview-wrapper');
           }
+        } else {
+          // On live pages: Apply as section background and remove from DOM
+          const webpSource = bgPicture.querySelector('source[type="image/webp"]');
+          const bgUrl = webpSource?.srcset?.split(',')[0]?.trim()?.split(' ')[0]
+            || bgImg?.src;
+
+          if (bgUrl) {
+            const sectionContainer = block.closest('.section');
+            if (sectionContainer) {
+              sectionContainer.style.backgroundImage = `url(${bgUrl})`;
+              sectionContainer.style.backgroundSize = 'cover';
+              sectionContainer.style.backgroundRepeat = 'repeat';
+              sectionContainer.style.backgroundPosition = 'center center';
+              sectionContainer.style.backgroundAttachment = 'fixed';
+
+              // Add preload link for LCP optimization with WebP
+              const preloadLink = document.createElement('link');
+              preloadLink.rel = 'preload';
+              preloadLink.as = 'image';
+              preloadLink.href = bgUrl;
+              preloadLink.fetchPriority = 'high';
+              if (webpSource) preloadLink.type = 'image/webp';
+              document.head.appendChild(preloadLink);
+            }
+          }
+
+          // Remove from DOM on live pages
+          bgPicture.remove();
+          if (bgPictureWrapper) bgPictureWrapper.remove();
         }
-        // Remove the picture element and its wrapper from DOM
-        bgPicture.remove();
-        if (bgPictureWrapper) bgPictureWrapper.remove();
       }
 
       // Second picture is decoration image top-right

--- a/blocks/hero-heritage-cc/hero-heritage-cc.js
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.js
@@ -67,36 +67,9 @@ function normalizeCssColorValue(value) {
 }
 
 export default function decorate(block) {
-  // DEBUG: Universal Editor detection
+  // Check if we're in Universal Editor
   const mainElement = document.querySelector('main');
   const hasAueResource = mainElement?.hasAttribute('data-aue-resource');
-  const aueResourceValue = mainElement?.getAttribute('data-aue-resource');
-  const sectionContainer = block.closest('.section');
-  const sectionClasses = sectionContainer?.classList?.toString();
-
-  /* eslint-disable no-console */
-  console.group('🎨 hero-heritage-cc DEBUG');
-  console.log('Block element:', block);
-  console.log('Block classes:', block.classList.toString());
-  console.log('Main element:', mainElement);
-  console.log('Has data-aue-resource:', hasAueResource);
-  console.log('data-aue-resource value:', aueResourceValue);
-  console.log('Section container:', sectionContainer);
-  console.log('Section classes:', sectionClasses);
-  console.log('window.hlx:', window.hlx);
-  console.log('Is in UE iframe:', window.self !== window.top);
-
-  // Check if UE CSS selector would match
-  const wouldMatchUeSelector = !!document.querySelector('main[data-aue-resource] .hero-heritage-cc');
-  console.log('Would match "main[data-aue-resource] .hero-heritage-cc":', wouldMatchUeSelector);
-
-  // Check computed styles to see if UE overrides are applying
-  const computedStyle = window.getComputedStyle(block);
-  console.log('Computed animation:', computedStyle.animation);
-  console.log('Computed visibility:', computedStyle.visibility);
-  console.log('Computed min-height:', computedStyle.minHeight);
-  console.groupEnd();
-  /* eslint-enable no-console */
 
   // Set modal theme for any modal links within this block (e.g., fees link)
   // These match the styling used by the cards/key-benefits modals on Mayura pages

--- a/blocks/hero-heritage-cc/hero-heritage-cc.js
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.js
@@ -67,6 +67,37 @@ function normalizeCssColorValue(value) {
 }
 
 export default function decorate(block) {
+  // DEBUG: Universal Editor detection
+  const mainElement = document.querySelector('main');
+  const hasAueResource = mainElement?.hasAttribute('data-aue-resource');
+  const aueResourceValue = mainElement?.getAttribute('data-aue-resource');
+  const sectionContainer = block.closest('.section');
+  const sectionClasses = sectionContainer?.classList?.toString();
+
+  /* eslint-disable no-console */
+  console.group('🎨 hero-heritage-cc DEBUG');
+  console.log('Block element:', block);
+  console.log('Block classes:', block.classList.toString());
+  console.log('Main element:', mainElement);
+  console.log('Has data-aue-resource:', hasAueResource);
+  console.log('data-aue-resource value:', aueResourceValue);
+  console.log('Section container:', sectionContainer);
+  console.log('Section classes:', sectionClasses);
+  console.log('window.hlx:', window.hlx);
+  console.log('Is in UE iframe:', window.self !== window.top);
+
+  // Check if UE CSS selector would match
+  const wouldMatchUeSelector = !!document.querySelector('main[data-aue-resource] .hero-heritage-cc');
+  console.log('Would match "main[data-aue-resource] .hero-heritage-cc":', wouldMatchUeSelector);
+
+  // Check computed styles to see if UE overrides are applying
+  const computedStyle = window.getComputedStyle(block);
+  console.log('Computed animation:', computedStyle.animation);
+  console.log('Computed visibility:', computedStyle.visibility);
+  console.log('Computed min-height:', computedStyle.minHeight);
+  console.groupEnd();
+  /* eslint-enable no-console */
+
   // Set modal theme for any modal links within this block (e.g., fees link)
   // These match the styling used by the cards/key-benefits modals on Mayura pages
   block.dataset.modalTheme = 'modal-mayura-blue';

--- a/component-definition.json
+++ b/component-definition.json
@@ -342,7 +342,7 @@
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
-                  "name": "Hero - Heritage CC",
+                  "name": "Hero Heritage CC",
                   "model": "hero-heritage-cc"
                 }
               }


### PR DESCRIPTION
Fix Hero-HeritageCC display in UE, add new styling view to be able to understand and author a hero-heritage cc component and not have the entire thing barf out all of its components at the top of the page, or render the hero with infinite height which breaks authoring entirely. 

NOTE: Currently after fixing the component "name" property value in CRXDE so the block code loads instead of 404s, the height of that component in UE becomes infinite. As such, this PR should be merged as soon as possible. 

<img width="3159" height="1668" alt="image" src="https://github.com/user-attachments/assets/a581102a-4cca-4f5a-aaa8-cf77ea5a787b" />

<img width="1040" height="581" alt="image" src="https://github.com/user-attachments/assets/5aa59d89-6c35-4e7e-86e0-9eb3edd8b558" />


Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://hero-ue-display-fix--idfc--aemsites.aem.page/
