### PR TITLE
Add reward points table styles and improve table rendering logic

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -116,10 +116,60 @@
   background-color: var(--white);
 }
 
+/* Reward Points Table Specific Styles */
+.table.block#reward-points {
+  margin: 0;
+  padding: 0;
+}
+
+.table.block#reward-points table {
+  border: 1px solid var(--white);
+  border-radius: 8px;
+  overflow: hidden;
+  border-collapse: separate;
+  border-spacing: 0;
+}
+
+.table.block#reward-points table td {
+  padding: 10px 12px;
+  border: 1px solid var(--white);
+  color: var(--white);
+}
+
+.table.block#reward-points table tbody td:first-child {
+  text-align: left;
+  border-left: none;
+}
+
+.table.block#reward-points table tbody td:nth-child(2) {
+  text-align: left;
+  border-right: none;
+}
+
+.table.block#reward-points table tbody tr:first-child td {
+  border-top: none;
+}
+
+.table.block#reward-points table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.table.block#reward-points table td p {
+  margin: 0;
+}
+
+.table.block#reward-points table td p + p {
+  margin-top: 0.15em;
+}
+
 /* Media Queries */
 @media (width >= 600px) {
   .table.block table {
     font-size: var(--body-font-size-s);
+  }
+
+  .table.block#reward-points table td {
+    padding: 12px 14px;
   }
 }
 
@@ -144,5 +194,17 @@
   .table.block#fees-and-charges table tbody tr:not(:last-child)::after {
     left: 0;
     right: 0;
+  }
+
+  .table.block#reward-points {
+    width: 50%;
+  }
+
+  .table.block#reward-points table {
+    font-size: var(--body-font-size-m);
+  }
+
+  .table.block#reward-points table td {
+    padding: 14px 16px;
   }
 }


### PR DESCRIPTION
- Introduced specific CSS styles for the reward points table, including layout and padding adjustments.
- Updated JavaScript to conditionally create table headers and filter out empty rows for better data presentation.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #408

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://408-reward--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
