### PR TITLE
UE only -- changed fields to be separate

### DIFF
--- a/blocks/cta-sticky/_cta-sticky.json
+++ b/blocks/cta-sticky/_cta-sticky.json
@@ -23,14 +23,14 @@
         {
           "component": "richtext",
           "valueType": "string",
-          "name": "ctaText_desktop",
+          "name": "ctaText",
           "label": "CTA Text",
           "value": ""
         },
         {
           "component": "richtext",
           "valueType": "string",
-          "name": "ctaText_mobile",
+          "name": "ctaTextMobile",
           "label": "CTA Text (Mobile)",
           "value": ""
         },

--- a/component-models.json
+++ b/component-models.json
@@ -1212,14 +1212,14 @@
       {
         "component": "richtext",
         "valueType": "string",
-        "name": "ctaText_desktop",
+        "name": "ctaText",
         "label": "CTA Text",
         "value": ""
       },
       {
         "component": "richtext",
         "valueType": "string",
-        "name": "ctaText_mobile",
+        "name": "ctaTextMobile",
         "label": "CTA Text (Mobile)",
         "value": ""
       },


### PR DESCRIPTION
Using underscores in my last PR was a bad choice, because both mobile and desktop text was in the same cell.

<img width="1119" height="234" alt="image" src="https://github.com/user-attachments/assets/73ab51dc-c888-4056-8953-66ea5978dd55" />


Fix 428

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://428-stickynavredo--idfc--aemsites.aem.page/
