### PR TITLE
Add full search functionality

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -978,11 +978,8 @@ header nav .nav-sections .nav-h4-section-content p > a {
 
 .cs-dropdown-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.9);
+  inset: 0;
+  background-color: rgb(0 0 0 / 90%);
   z-index: 1000;
   visibility: hidden;
   opacity: 0;
@@ -1136,11 +1133,8 @@ header nav .nav-sections .nav-h4-section-content p > a {
 
 .search-dropdown-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.9);
+  inset: 0;
+  background-color: rgb(0 0 0 / 90%);
   z-index: 1000;
   visibility: hidden;
   opacity: 0;
@@ -1167,10 +1161,8 @@ header nav .nav-sections .nav-h4-section-content p > a {
 
   .columns > div {
     display: flex;
-    flex-direction: row;
+    flex-flow: row wrap;
     gap: 0 10px;
-    flex-wrap: wrap;
-    justify-items: flex-start;
 
   a.button.secondary:any-link, button.secondary {
     font-size: var(--body-font-size-xxs);
@@ -1251,6 +1243,140 @@ header nav .nav-sections .nav-h4-section-content p > a {
  }
 } /* end search-dropdown.open */
 
+/* Search Results Styles */
+.search-dropdown .search-results {
+  padding: 0;
+  background: var(--white);
+  border-radius: 20px;
+  border: 1px var(--gray) solid;
+  width: 100%;
+}
+
+.search-dropdown .search-results-header {
+  margin-bottom: 12px;
+  padding: 16px;
+}
+
+.search-dropdown .search-results-header h3 {
+  font-size: var(--body-font-size-s);
+  font-weight: 600;
+  color: var(--text-color);
+  margin: 0;
+}
+
+.search-dropdown .search-results-loading {
+  text-align: left;
+  padding: 16px;
+}
+
+.search-dropdown .search-results-loading p {
+  font-size: var(--body-font-size-s);
+  color: var(--secondary);
+  margin: 0;
+}
+
+.search-dropdown .search-results-empty {
+  text-align: left;
+  padding: 16px;
+}
+
+.search-dropdown .search-results-empty p {
+  font-size: var(--body-font-size-xs);
+  color: var(--gray);
+  margin: 0 0 8px;
+  line-height: 1.4;
+}
+
+.search-dropdown .search-results-empty p:last-child {
+  margin-bottom: 0;
+}
+
+.search-dropdown .search-results-list {
+  list-style: none;
+  padding: 0 16px;
+  margin: 0;
+}
+
+.search-dropdown .search-results-list li {
+  background: white;
+  border-radius: 20px;
+  padding: 5px 20px;
+  margin-bottom: 20px;
+  box-shadow: 3px 3px 8px rgba(0 0 0 / 20%);
+}
+
+.search-dropdown .search-results-list li:last-child {
+  background: white;
+  border-radius: 20px;
+  padding: 5px 20px;
+  margin-bottom: 20px;
+  box-shadow: 3px 3px 8px rgba(0 0 0 / 20%);
+}
+
+.search-dropdown .search-results-list li a {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: 10px 0;
+  text-decoration: none;
+  color: var(--text-color);
+  transition: background-color 0.3s ease-in-out;
+}
+
+.search-dropdown .search-results-list li:hover {
+  background: var(--gray-200);
+  transition: background-color 0.3s ease-in-out;
+}
+
+.search-dropdown .search-results-list .search-result-title {
+  font-size: var(--body-font-size-s);
+  font-weight: 400;
+  color: var(--secondary);
+  flex: 1;
+}
+
+.search-dropdown .search-results-list .search-result-type {
+  font-size: var(--body-font-size-xxs);
+  color: var(--dark-red-color);
+  background: var(--gray-200);
+  padding: 4px 8px;
+  border-radius: 12px;
+  margin-left: 12px;
+}
+
+.search-dropdown .search-results-footer {
+  padding: 16px;
+  border-top: 1px solid #f0f0f0;
+  margin-top: 8px;
+}
+
+.search-dropdown .search-results-footer .view-all-results {
+  display: inline-flex;
+  align-items: center;
+  gap: 8px;
+  font-size: var(--body-font-size-xs);
+  font-weight: 600;
+  color: var(--dark-red-link-color);
+  text-decoration: none;
+  transition: color 0.2s ease;
+}
+
+.search-dropdown .search-results-footer .view-all-results:hover {
+  color: var(--dark-red-color);
+  background: var(--gray-200);
+  transition: background-color 0.3s ease-in-out;
+}
+
+.search-dropdown .search-results-footer .icon {
+  width: 16px;
+  height: 16px;
+}
+
+/* Hide default content when showing search results */
+.search-dropdown .default-content[style*="display: none"] {
+  display: none !important;
+}
+
 /* Search box input styling */
 #search-box {
   cursor: pointer;
@@ -1290,11 +1416,8 @@ header nav .nav-sections .nav-h4-section-content p > a {
 
 .login-dropdown-overlay {
   position: fixed;
-  top: 0;
-  left: 0;
-  right: 0;
-  bottom: 0;
-  background-color: rgba(0, 0, 0, 0.9);
+  inset: 0;
+  background-color: rgb(0 0 0 / 90%);
   z-index: 1000;
   visibility: hidden;
   opacity: 0;
@@ -1747,7 +1870,6 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
 
   /* Desktop: Wrapper div inside section content - apply background and padding here */
   header nav .nav-sections .nav-fragment-section-content > li {
-
     padding: 0;
     margin: 0;
   }
@@ -2125,6 +2247,7 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
     background: #fff;
     box-shadow: 2px 2px 24px rgb(120 120 120 / 8%);
     z-index: 2;
+
     /* height: 518px; */
     max-height: 100%;
     overflow-y: auto;
@@ -2434,25 +2557,41 @@ border-radius: 0;
     display: none;
   }
 
-  .section:nth-child(2) {
+  /* Use more specific selectors instead of nth-child */
+  
+  /* Search results - when present (first section) */
+  .section.search-results[data-search-results="true"] {
+    grid-column: 2;
+    grid-row: 2 !important;
+  }
+
+  /* Most Searched - .columns-container (first or second section depending on search) */
+  .section.columns-container {
     grid-column: 2;
     grid-row: 2;
   }
 
-  .section:nth-child(3) {
+  /* All cards-container sections except openaccount - will be overridden below */
+  .section.cards-container:not(#openaccount) {
     grid-column: 2;
-    grid-row: 3;
   }
 
-  .section:nth-child(4) {
-    grid-column: 2;
-    grid-row: 4;
+  /* Top Products - first cards-container after columns-container */
+  .section.columns-container + .section.cards-container:not(#openaccount),
+  .section.search-results + .section.columns-container + .section.cards-container:not(#openaccount) {
+    grid-row: 3 !important;
   }
 
+  /* Accounts - second cards-container (comes after Top Products) */
+  .section.cards-container:not(#openaccount) + .section.cards-container:not(#openaccount) {
+    grid-row: 4 !important;
+  }
+
+  /* Right sidebar - always in same place */
   .section#openaccount {
     grid-column: 3;
-    grid-row: 2 / 5; /* Spans all three rows */
-    align-self: start; /* Aligns to top */
+    grid-row: 2 / 5;
+    align-self: start;
     display: unset;
   }
 
@@ -2560,7 +2699,6 @@ border-radius: 0;
   }
 
   .search-dropdown.open {
-
     > .section {
       max-width: unset;
     }
@@ -2573,7 +2711,12 @@ border-radius: 0;
       grid-template-columns: repeat(3, 1fr);
       gap: var(--spacing-xs);
   }
- }
+
+  /* Desktop search results - let them sit naturally in place of first section */
+  .search-dropdown.open .search-results {
+    /* Placeholder for future styling - No special grid positioning needed - it replaces the first section */
+  }
+  }
 }
 
 /* =================================================================

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -529,6 +529,253 @@ export default async function decorate(block) {
       closeDelay: 100,
     });
 
+    const searchInput = searchBox.querySelector('.search-input');
+    let searchTimeout = null;
+    let defaultDropdownContent = null;
+
+    // Store the default dropdown content (Most Searched, Top Products, Accounts)
+    const storeDefaultContent = () => {
+      if (!defaultDropdownContent && search.dropdown.querySelector('.default-content')) {
+        defaultDropdownContent = search.dropdown.querySelector('.default-content').cloneNode(true);
+      }
+    };
+
+    // Restore default dropdown content
+    const restoreDefaultContent = () => {
+      // Remove search results
+      const searchResults = search.dropdown.querySelector('.search-results');
+      if (searchResults) {
+        searchResults.remove();
+      }
+
+      // Show the first section again
+      const firstSection = search.dropdown.querySelector('.section');
+      if (firstSection && firstSection.style.display === 'none') {
+        firstSection.style.display = '';
+      }
+    };
+
+    // Get fallback suggestions based on query
+    const getFallbackSuggestions = (query) => {
+      const allSuggestions = [
+        // Popular Products & Services
+        { title: 'Personal Loan', url: '/personal-banking/loans/personal-loan', type: 'Loan' },
+        { title: 'Savings Account', url: '/personal-banking/accounts/savings-account', type: 'Account' },
+        { title: 'Fixed Deposit', url: '/personal-banking/deposits/fixed-deposit', type: 'Deposit' },
+        { title: 'Home Loan', url: '/personal-banking/loans/home-loan', type: 'Loan' },
+        { title: 'FASTag', url: '/personal-banking/fastag', type: 'Service' },
+        { title: 'Mutual Funds', url: '/wealth-management/mutual-funds', type: 'Investment' },
+        { title: 'Current Account', url: '/business-banking/current-account', type: 'Account' },
+        { title: 'Business Loan', url: '/business-banking/loans/business-loan', type: 'Loan' },
+        { title: 'NRI Account', url: '/nri-banking/nri-savings-account', type: 'Account' },
+
+        // Premium Metal Credit Cards
+        { title: 'Gaj Credit Card', url: '/credit-card/metal-credit-card/gaj', type: 'Premium Metal' },
+        { title: 'Ashva Credit Card', url: '/credit-card/metal-credit-card/ashva', type: 'Premium Metal' },
+        { title: 'Mayura Credit Card', url: '/credit-card/metal-credit-card/mayura', type: 'Premium Metal' },
+        { title: 'FIRST Private Credit Card', url: '/credit-card/FIRSTPrivateCreditCard', type: 'Premium Metal' },
+
+        // Travel Credit Cards
+        { title: 'Diamond Reserve Credit Card', url: '/credit-card/diamond-reserve-credit-card', type: 'Travel' },
+        { title: 'IndiGo Credit Card', url: '/credit-card/indigo-credit-card', type: 'Travel' },
+        { title: 'Club Vistara Credit Card', url: '/credit-card/vistara-credit-card', type: 'Travel' },
+        { title: 'FIRST WOW! Black Credit Card', url: '/credit-card/wow-black-credit-card', type: 'Travel' },
+
+        // Lifetime Free Credit Cards
+        { title: 'FIRST Classic Credit Card', url: '/credit-card/classic', type: 'Lifetime Free' },
+        { title: 'FIRST Millennia Credit Card', url: '/credit-card/millennia', type: 'Lifetime Free' },
+        { title: 'FIRST Select Credit Card', url: '/credit-card/select', type: 'Lifetime Free' },
+        { title: 'FIRST Wealth Credit Card', url: '/credit-card/wealth', type: 'Lifetime Free' },
+        { title: 'FIRST WOW! Credit Card', url: '/credit-card/wow', type: 'Lifetime Free' },
+        { title: 'LIC Classic Credit Card', url: '/credit-card/lic-classic-credit-card', type: 'Lifetime Free' },
+        { title: 'LIC Select Credit Card', url: '/credit-card/lic-credit-card', type: 'Lifetime Free' },
+
+        // UPI Credit Cards
+        { title: 'Hello Cashback Credit Card', url: '/credit-card/hello-cashback-credit-card', type: 'UPI Card' },
+        { title: 'FIRST Power Credit Card', url: '/credit-card/hpcl-power-fuel-credit-card', type: 'Fuel & UPI' },
+        { title: 'FIRST Power+ Credit Card', url: '/credit-card/hpcl-power-fuel-credit-card', type: 'Fuel & UPI' },
+        { title: 'FIRST EA₹N Credit Card', url: '/credit-card/secured-rupay-credit-card', type: 'UPI Card' },
+        { title: 'FIRST Digital RuPay Credit Card', url: '/credit-card/rupay-credit-card', type: 'UPI Card' },
+
+        // Special Features
+        { title: 'FIRST SWYP EMI Credit Card', url: '/credit-card/swyp-emi-credit-card', type: 'EMI Card' },
+        { title: 'CreditPro Balance Transfer', url: '/credit-card/credit-card-balance-transfer', type: 'Balance Transfer' },
+
+        // Business Credit Cards
+        { title: 'Business Credit Card', url: '/credit-card/business-credit-card-sme', type: 'Business' },
+        { title: 'Corporate Credit Card', url: '/credit-card/corporate-credit-card', type: 'Business' },
+        { title: 'Purchase Credit Card', url: '/credit-card/purchase-credit-card', type: 'Business' },
+
+        // Credit Card Services
+        { title: 'Credit Card Referral Program', url: '/credit-card/credit-card-referral-program', type: 'Service' },
+        { title: 'Add-on Credit Card', url: '/credit-card/add-on-credit-card', type: 'Service' },
+        { title: 'Personalised Credit Card', url: '/credit-card/image-card/apply', type: 'Service' },
+        { title: 'Credit Card', url: '/credit-card', type: 'Product' },
+      ];
+
+      const lowerQuery = query.toLowerCase();
+      return allSuggestions
+        .filter((item) => item.title.toLowerCase().includes(lowerQuery))
+        .slice(0, 10); // Increased to 10 results given the larger dataset
+    };
+
+    // Display search results
+    const displaySearchResults = (results, query, container) => {
+      const loadingEl = container.querySelector('.search-results-loading');
+      if (loadingEl) {
+        loadingEl.remove();
+      }
+
+      if (results.length === 0) {
+        container.innerHTML += `
+          <div class="search-results-empty">
+            <p>No results found for "${query}"</p>
+            <p>Try searching for something else or press Enter to see all results</p>
+          </div>
+        `;
+        return;
+      }
+
+      const resultsList = document.createElement('ul');
+      resultsList.classList.add('search-results-list');
+
+      results.forEach((result) => {
+        const li = document.createElement('li');
+        li.innerHTML = `
+          <a href="${result.url}">
+            <span class="search-result-title">${result.title}</span>
+            ${result.type ? `<span class="search-result-type">${result.type}</span>` : ''}
+          </a>
+        `;
+        resultsList.appendChild(li);
+      });
+
+      container.appendChild(resultsList);
+
+      // Add "View all results" link
+      const viewAllLink = document.createElement('div');
+      viewAllLink.classList.add('search-results-footer');
+      viewAllLink.innerHTML = `
+        <a href="https://www.idfcfirst.bank.in/search?skey=${encodeURIComponent(query)}" class="view-all-results">
+          View all results for "${query}" <span class="icon icon-arrow-right-alt"></span>
+        </a>
+      `;
+      container.appendChild(viewAllLink);
+      decorateIcons(viewAllLink);
+    };
+
+    // Fetch search results
+    const fetchSearchResults = async (query, container) => {
+      try {
+        // Try to fetch from the search page API
+        // Note: The actual API endpoint may vary - this is a best guess based on the site structure
+        const response = await fetch(`https://www.idfcfirst.bank.in/bin/idfcfirstbank/search?q=${encodeURIComponent(query)}&limit=10`);
+
+        let results = [];
+
+        if (response.ok) {
+          const data = await response.json();
+          results = data.results || [];
+        }
+
+        // If no results from API, show fallback suggestions
+        if (results.length === 0) {
+          results = getFallbackSuggestions(query);
+        }
+
+        displaySearchResults(results, query, container);
+      } catch (error) {
+        // If API fails, show fallback suggestions
+        const results = getFallbackSuggestions(query);
+        displaySearchResults(results, query, container);
+      }
+    };
+
+    // Create search results container
+    const createSearchResults = (query) => {
+      // Remove existing results
+      const existingResults = search.dropdown.querySelector('.search-results');
+      if (existingResults) {
+        existingResults.remove();
+      }
+
+      // Find the first section (Most Searched)
+      const firstSection = search.dropdown.querySelector('.section');
+      if (!firstSection) return;
+
+      // Hide the first section
+      firstSection.style.display = 'none';
+
+      // Create results container
+      const resultsContainer = document.createElement('div');
+      resultsContainer.classList.add('search-results');
+      resultsContainer.classList.add('section'); // Add section class so it fits in the layout
+      resultsContainer.setAttribute('data-search-results', 'true'); // Add marker for CSS
+
+      // Create loading state
+      resultsContainer.innerHTML = `
+        <div class="search-results-header">
+          <h3>Search results for "${query}"</h3>
+        </div>
+        <div class="search-results-loading">
+          <p>Searching...</p>
+        </div>
+      `;
+
+      // Insert the search results in place of the first section
+      firstSection.parentNode.insertBefore(resultsContainer, firstSection);
+
+      // Fetch search results (with fallback to client-side suggestions)
+      setTimeout(() => {
+        fetchSearchResults(query, resultsContainer);
+      }, 300);
+    };
+
+    // Handle search input
+    if (searchInput) {
+      // Handle input changes (real-time search)
+      searchInput.addEventListener('input', (e) => {
+        const query = e.target.value.trim();
+
+        // Clear existing timeout
+        if (searchTimeout) {
+          clearTimeout(searchTimeout);
+        }
+
+        if (query.length === 0) {
+          // Restore default content if search is empty
+          restoreDefaultContent();
+          return;
+        }
+
+        if (query.length >= 2) {
+          // Debounce search by 300ms
+          searchTimeout = setTimeout(() => {
+            createSearchResults(query);
+          }, 300);
+        }
+      });
+
+      // Handle Enter key to redirect to full search page
+      searchInput.addEventListener('keydown', (e) => {
+        if (e.key === 'Enter') {
+          e.preventDefault();
+          const query = e.target.value.trim();
+          if (query) {
+            window.location.href = `https://www.idfcfirst.bank.in/search?skey=${encodeURIComponent(query)}`;
+          }
+        }
+      });
+
+      // Focus search input when dropdown opens
+      const originalOpenDropdown = search.openDropdown;
+      search.openDropdown = async () => {
+        await originalOpenDropdown();
+        storeDefaultContent();
+        searchInput.focus();
+      };
+    }
+
     // Click to open
     searchBox.addEventListener('click', () => {
       search.openDropdown();
@@ -569,6 +816,11 @@ export default async function decorate(block) {
         && !search.overlay.contains(e.target);
       if (isOutsideClick && search.dropdown.classList.contains('open')) {
         search.closeDropdown();
+        // Restore default content when closing
+        if (searchInput) {
+          searchInput.value = '';
+          restoreDefaultContent();
+        }
       }
     });
   }


### PR DESCRIPTION
Add full search functionality with new results display and fallback suggestions until real API is hooked up.

- Update CSS for dropdown overlays and search results styling, ensuring a cohesive user experience.
- Refactor JavaScript to manage search input, results fetching, and default content restoration effectively.

Note that this is using placeholder link content (line 558-614) to populate the search results which I just generated from our top level nav and our ccnav category nav framework pages.

Upon pressing `enter` or clicking the `View all results for <term>`, the user is redirected to IDFCs current search page with a format of `https://www.idfcfirst.bank.in/search?skey=<term>`. This *should* work, however their search feature is broken and doesn't actually take in the query parameters to execute the search....so if they fix that in their code, our external "redirect" to full search will work. 

API integration will need some work, see lines 667-693, when/if we do have access to something from their SOLR search at some point. 

Fix #418

Some screenshots of empty search results, single result, multiple result output styling:
<img width="1494" height="535" alt="image" src="https://github.com/user-attachments/assets/55720c92-c9be-432a-97e0-3c7bd28b432a" />

<img width="1494" height="572" alt="image" src="https://github.com/user-attachments/assets/4e4d148f-dd96-43e0-b707-ea7f46ed5e17" />

<img width="1496" height="1234" alt="image" src="https://github.com/user-attachments/assets/cf34ca72-6115-4c50-a332-c650c788d680" />
Above image shows hover-over effect on one of the results (Ashva card). 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://418-search--idfc--aemsites.aem.page/credit-card/rupay-credit-card
