### PR TITLE
New block to replace sticky-cta

### DIFF
--- a/blocks/cta-sticky/_cta-sticky.json
+++ b/blocks/cta-sticky/_cta-sticky.json
@@ -25,14 +25,16 @@
           "valueType": "string",
           "name": "ctaText",
           "label": "CTA Text",
-          "value": ""
+          "value": "",
+          "description": "Only visible on desktop"
         },
         {
           "component": "richtext",
           "valueType": "string",
           "name": "ctaTextMobile",
           "label": "CTA Text (Mobile)",
-          "value": ""
+          "value": "",
+          "description": "Only visible on mobile"
         },
         {
           "component": "text",

--- a/blocks/cta-sticky/cta-sticky.css
+++ b/blocks/cta-sticky/cta-sticky.css
@@ -5,21 +5,15 @@ and outer background value (such asrgb(0 0 0 / 50%) */
 .section.cta-sticky-container {
   position: fixed;
   bottom: 0;
-  left: 0;
-  right: 0;
   width: 100%;
   backdrop-filter: blur(3.5px);
   z-index: 3;
-  font-family: var(--body-font-family);
   display: flex;
-  flex-direction: column;
   align-items: center;
   justify-content: center;
-  gap: 12px;
 }
 
 .cta-sticky {
-margin: var(--spacing-xs) 0;
 display: flex;
 position: relative;
 
@@ -51,6 +45,17 @@ p.button-container a.button.primary:any-link {
     background-color: var(--btn-color-red);
   }
 }
+
+div:empty {
+  margin: 0;
+}
+}
+
+.cta-sticky-mobile-content {
+
+  > div {
+  margin: var(--spacing-xs) 0;
+  }
 }
 
 .cta-sticky-desktop-content {
@@ -78,5 +83,9 @@ p.button-container a.button.primary:any-link {
 
   .cta-sticky-desktop-content {
     display: block;
+
+    > div {
+      margin: var(--spacing-xs) 0;
+    }
   }
 }

--- a/blocks/cta-sticky/cta-sticky.css
+++ b/blocks/cta-sticky/cta-sticky.css
@@ -1,1 +1,82 @@
-/* Sticky CTA Block Styles - Mobile First */
+/* set initial section configs in authoring, such as 
+style = center, dark-scheme, etc
+and outer background value (such asrgb(0 0 0 / 50%) */
+
+.section.cta-sticky-container {
+  position: fixed;
+  bottom: 0;
+  left: 0;
+  right: 0;
+  width: 100%;
+  backdrop-filter: blur(3.5px);
+  z-index: 3;
+  font-family: var(--body-font-family);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  gap: 12px;
+}
+
+.cta-sticky {
+margin: var(--spacing-xs) 0;
+display: flex;
+position: relative;
+
+p {
+  font-size: var(--body-font-size-xxs);
+  color: #fff;
+  text-shadow: 0 0 20px rgb(0 0 0 / 25%);
+}
+
+p + p {
+  margin-top: 0;
+}
+
+p.button-container a.button.primary:any-link {
+  background-color: var(--red-color);
+  border-color: var(--red-color);
+  color: var(--btn-color-white);
+  font-size: var(--body-font-size-xs);
+  box-shadow: 0 0 20px 0 rgb(0 0 0 / 25%);
+  margin: 0;
+  min-width: 234px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: var(--spacing-xxs);
+
+  &:hover {
+    border-color: var(--btn-color-red);
+    background-color: var(--btn-color-red);
+  }
+}
+}
+
+.cta-sticky-desktop-content {
+  display: none;
+}
+
+/* Desktop Styles */
+@media (width >= 990px) {
+
+  .cta-sticky {
+
+    p {
+      font-size: var(--body-font-size-xs);
+    }
+
+    p.button-container a.button.primary:any-link {
+      font-size: var(--body-font-size-s);
+      padding: var(--spacing-xs);
+    }
+  }
+
+  .cta-sticky-mobile-content {
+    display: none;
+  }
+
+  .cta-sticky-desktop-content {
+    display: block;
+  }
+}

--- a/blocks/cta-sticky/cta-sticky.js
+++ b/blocks/cta-sticky/cta-sticky.js
@@ -1,1 +1,27 @@
-/* js goes here */
+export default function decorate(block) {
+  // Get all direct child divs of the block
+  const children = Array.from(block.children);
+
+  // First child: CTA content
+  if (children[0]) {
+    children[0].classList.add('cta-sticky-desktop-content');
+  }
+
+  // secondchild: CTA Mobile content
+  if (children[1]) {
+    children[1].classList.add('cta-sticky-mobile-content');
+  }
+
+  // third child: CTA Tracking ID (extract and remove)
+  if (children[2]) {
+    const ctaId = children[2].textContent.trim();
+    if (ctaId) {
+      block.id = ctaId;
+    }
+    children[2].remove();
+  }
+
+  // const positionDiv = document.createElement('div');
+  // positionDiv.classList.add('position-absolute');
+  // block.prepend(positionDiv);
+}

--- a/blocks/cta-sticky/cta-sticky.js
+++ b/blocks/cta-sticky/cta-sticky.js
@@ -20,8 +20,4 @@ export default function decorate(block) {
     }
     children[2].remove();
   }
-
-  // const positionDiv = document.createElement('div');
-  // positionDiv.classList.add('position-absolute');
-  // block.prepend(positionDiv);
 }

--- a/component-filters.json
+++ b/component-filters.json
@@ -23,7 +23,6 @@
       "tabs",
       "category-nav",
       "cta-sticky",
-      "sticky-cta",
       "anchor-nav",
       "steps",
       "tabs-upi-link",

--- a/component-models.json
+++ b/component-models.json
@@ -1214,14 +1214,16 @@
         "valueType": "string",
         "name": "ctaText",
         "label": "CTA Text",
-        "value": ""
+        "value": "",
+        "description": "Only visible on desktop"
       },
       {
         "component": "richtext",
         "valueType": "string",
         "name": "ctaTextMobile",
         "label": "CTA Text (Mobile)",
-        "value": ""
+        "value": "",
+        "description": "Only visible on mobile"
       },
       {
         "component": "text",

--- a/models/_section.json
+++ b/models/_section.json
@@ -314,7 +314,6 @@
         "tabs",
         "category-nav",
         "cta-sticky",
-        "sticky-cta",
         "anchor-nav",
         "steps",
         "tabs-upi-link",

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -111,6 +111,7 @@
   --spacing-m: 36px;
   --spacing-s: 24px;
   --spacing-xs: 12px;
+  --spacing-xxs: 8px;
 }
 
 /* fallback fonts */
@@ -320,6 +321,7 @@ button.primary {
   background-color: var(--btn-color-red);
   color: var(--btn-color-white);
   border-color: transparent;
+  transition: background-color 0.2s ease;
 }
 
 a.button.primary:hover,


### PR DESCRIPTION
Once approved, we will need to re-author the 2 pages to use this block instead of "sticky-nav", and we can remove the old block code.

This block has 24 lines of JS, and 86 lines of CSS.
Old block has 64 lines of JS, and 146 lines of CSS!

Fix #428 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/cta-sticky
- After: https://428-stickynavredo--idfc--aemsites.aem.page/library/cta-sticky


Live pages for comparison:
https://www.idfcfirst.bank.in/credit-card/rupay-credit-card
https://www.idfcfirst.bank.in/credit-card/metal-credit-card/mayura (only in mobile)
