### PR TITLE
Fix the non-active testimonial card size

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1569,7 +1569,7 @@ main .cards.joining-perks .swiper-slide {
   height: auto;
   overflow: visible;
   transition: all 0.5s ease;
-  transform: scale(0.97);
+  transform: scale(0.9);
 }
 
 .cards.testimonial-card.swiper .swiper-slide .cards-card-body {


### PR DESCRIPTION
The inactive testimonial card is smaller than the active one. The inactive one was set at 97% of the active one. I changed that to be 90%, which looks closer to me. 
This size change makes it so you cannot see the sliver of the inactive card on mobile. This seems to be due to swipper.js dynamically setting the margin. I didn't modify this as it may impact more items. From Cursor:

> Swiper.js is setting margin-right as inline styles for all screen sizes, just with different values:
> Looking at the JavaScript configuration in cards.js lines 936-955:
> 
> - Mobile (default): spaceBetween: 16 → margin-right: 16px
> - Tablet (600px+): spaceBetween: 20 → margin-right: 20px
> - Desktop (900px+): spaceBetween: 36 → margin-right: 36px
> 
> So on mobile, each _li class="swiper-slide"_ would have inline styles like:
> `li class="swiper-slide" style="width: [calculated]; margin-right: 16px;"`
> On tablet:
> `li class="swiper-slide" style="width: [calculated]; margin-right: 20px;"`
> And on desktop (which you're seeing):
> `li class="swiper-slide" style="width: [calculated]; margin-right: 36px;"`
> All of these are dynamically calculated and applied by Swiper.js based on the viewport size and the spaceBetween configuration for each breakpoint.

Fix #440 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://440-testimonial-fix--idfc--aemsites.aem.page/credit-card/rupay-credit-card
