### PR TITLE
only changed section breakpoint

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1002,7 +1002,7 @@ header nav .nav-sections .default-content-wrapper>ul>li .nav-h4-section-content 
 
 .cs-dropdown.open {
   visibility: visible;
-  padding: 40px var(--spacing-xxs) var(--spacing-xxs);
+  padding: 40px var(--spacing-s) var(--spacing-xs);
   transform: translateY(0);
   display: grid;
 

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1162,7 +1162,7 @@ header nav .nav-sections .default-content-wrapper>ul>li .nav-h4-section-content 
   border-radius: 25px 25px 0 0;
 
   > .section {
-    max-width: 430px;
+    max-width: unset;
     padding: var(--spacing-xs);
   }
 
@@ -1586,6 +1586,17 @@ margin: 0;
 /* Mobile: Search input in expanded nav */
 header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
   flex: 1;
+}
+
+@media (width >= 600px) {
+.search-dropdown.open > .section {
+  max-width: 600px;
+  margin: 0 auto;
+
+  .cards.related-search .grid-cards {
+    grid-template-columns: repeat(3, 1fr);
+  }
+}
 }
 
 @media (width >= 990px) {
@@ -2584,6 +2595,10 @@ border-radius: 0;
 grid-template-rows: auto auto auto;
 padding: 30px;
 border-radius: 0;
+
+  > .section {
+    max-width: unset;
+  }
 
   .search-dropdown-close-btn {
     display: none;

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -1083,8 +1083,8 @@ header nav .nav-sections .default-content-wrapper>ul>li .nav-h4-section-content 
   text-align: left;
   
   img {
-    width: 58px;
-    height: 58px;
+    width: 42px;
+    height: 42px;
   }
 }
 
@@ -2459,6 +2459,11 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
       grid-column: 2;
       grid-row: 3;
       border-bottom: 0;
+
+      .cards .grid-cards li .cards-card-image img {
+        width: 58px;
+        height: 58px;
+      }
     }
   
     .section#download {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -17,11 +17,11 @@ import {
   toCamelCase,
 } from './aem.js';
 
-// Cached media query results for performance
+// Cached media query results for Section performance
 const MEDIA_QUERIES = {
   mobile: window.matchMedia('(max-width: 599px)'),
-  tablet: window.matchMedia('(min-width: 600px) and (max-width: 899px)'),
-  desktop: window.matchMedia('(min-width: 900px)'),
+  tablet: window.matchMedia('(min-width: 600px) and (max-width: 989px)'),
+  desktop: window.matchMedia('(min-width: 990px)'),
 };
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1028,13 +1028,7 @@ The height and width are set to 200 assuming the doodles won't be larger. */
     height: var(--nav-height); /* nav = 80px */
   }
 
-  /* Reserve space for category-nav BEFORE it loads to prevent CLS.
-     The has-category-nav class is added by scripts.js based on page metadata.
-     This runs BEFORE body.appear, ensuring correct header height from the start. */
-  body.has-category-nav header,
-  header:has(.category-nav-wrapper) {
-    height: calc(var(--category-nav-height) + var(--nav-height)); /* nav + category-nav = 80px + 64px = 144px */
-  }
+
 
   
   main .breadcrumbs {
@@ -1216,6 +1210,16 @@ The height and width are set to 200 assuming the doodles won't be larger. */
     padding-right: 0;
   }
 }
+
+@media (width >= 990px) {
+    /* Reserve space for category-nav BEFORE it loads to prevent CLS.
+     The has-category-nav class is added by scripts.js based on page metadata.
+     This runs BEFORE body.appear, ensuring correct header height from the start. */
+     body.has-category-nav header,
+     header:has(.category-nav-wrapper) {
+       height: calc(var(--category-nav-height) + var(--nav-height)); /* nav + category-nav = 80px + 64px = 144px */
+     }
+  }
 
 @media (width >= 1200px) {
   .section.grid .block-content {


### PR DESCRIPTION
I realized that the only thing causing a problem with the new 990px width breakpoint we added to the header were section backgrounds. And we're only using that feature in the "customer service" nav dropdown that I could find.

That "Download our App" section should look like this now from 0 - 989px wide:

<img width="966" height="980" alt="image" src="https://github.com/user-attachments/assets/c5813b07-c227-4d61-a3ec-bd2502c19834" />

I also fixed the width on this while I was in there.
<img width="933" height="362" alt="image" src="https://github.com/user-attachments/assets/7f811d7a-0d47-40e3-9353-aecf008cbbfa" />


Fix #402-990breakpoint

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://402-990breakpoint--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
