### PR TITLE
Fix card modal positioning

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -610,9 +610,8 @@ body.modal-open {
     max-height: fit-content;
     min-height: 0;
     border-radius: 25px 25px 0 0;
-    overscroll-behavior: none;
     overflow: visible;
-    padding: 38px 26px 0 30px;
+    padding: 38px 26px 30px;
     margin: 0;
     border: none;
     box-shadow: 0 8px 32px rgb(0 0 0 / 25%);

--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -587,7 +587,6 @@ body.modal-open {
 }
 
 @media (width < 768px) {
-
   .modal dialog.modal-auto-popup p {
     font-size: var(--body-font-size-xxs);
   }
@@ -610,6 +609,7 @@ body.modal-open {
     max-height: fit-content;
     min-height: 0;
     border-radius: 25px 25px 0 0;
+    overscroll-behavior: none;
     overflow: visible;
     padding: 38px 26px 30px;
     margin: 0;


### PR DESCRIPTION
Fix button on and overall positioning of the modal on the Rupay and Mayura pages. 

Fix #424 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://<branch>--idfc--aemsites.aem.page/credit-card/rupay-credit-card

Rupay (424 vs Main):
<img width="921" height="722" alt="image" src="https://github.com/user-attachments/assets/887e6140-a1d7-495e-bc40-90daaa8ae976" />

Mayura (424 vs Main):
<img width="914" height="679" alt="image" src="https://github.com/user-attachments/assets/35248d8a-400c-4e6c-89dc-6fc14b3c2839" />
