### PR TITLE
add get app banner

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -10,7 +10,6 @@ header .nav-wrapper {
   z-index: 2;
   position: fixed;
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
-  top: 0;
   left: 0;
 }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -986,7 +986,7 @@ function decorateGetAppBanner(container) {
  */
 async function loadGetAppBannerFragment() {
   // Skip loading fragments when viewing framework pages
-  if (isEditingFrameworkPage()) {
+  if (isEditingFrameworkPage() || MEDIA_QUERIES.desktop.matches) {
     return;
   }
 
@@ -996,7 +996,6 @@ async function loadGetAppBannerFragment() {
   }
 
   try {
-    // Load the fragment content
     const fragment = await loadFragment('/fragments/getappbanner');
 
     if (!fragment) {
@@ -1004,8 +1003,6 @@ async function loadGetAppBannerFragment() {
       console.error('[Get App Banner] Failed to load fragment from: /fragments/getappbanner');
       return;
     }
-
-    // Get the get app banner div from the fragment
     const getAppBanner = fragment.querySelector('#grnt-app-mob');
 
     if (!getAppBanner) {
@@ -1013,11 +1010,7 @@ async function loadGetAppBannerFragment() {
       console.error('[Get App Banner] No #grnt-app-mob found in fragment');
       return;
     }
-
-    // Append the banner to the header
     header.appendChild(getAppBanner);
-
-    // Decorate the banner after it's been added to the DOM
     decorateGetAppBanner(header);
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -940,6 +940,92 @@ async function loadEager(doc) {
 }
 
 /**
+ * Decorates the get app banner element
+ * @param {Element} container The container element (typically header)
+ */
+function decorateGetAppBanner(container) {
+  const getAppBanner = container.querySelector('#grnt-app-mob');
+  if (!getAppBanner) return;
+
+  getAppBanner.classList.add('grnt-app-mob-main');
+
+  // Get the header element to adjust its position
+  const header = document.querySelector('.header');
+
+  // Check sessionStorage - hide banner if previously closed
+  if (sessionStorage.getItem('getAppBanner')) {
+    getAppBanner.classList.add('d-none');
+    return;
+  }
+
+  // Show banner and add body class
+  document.body.classList.add('grnt-new-header-app-body');
+
+  // Set header top position to account for banner height
+  if (header) {
+    header.style.top = '77px';
+  }
+
+  // Close button - hide banner and save to sessionStorage
+  const closeBtn = getAppBanner.querySelector('.button-container > a:has(.icon-icon-plus)');
+  if (closeBtn) {
+    closeBtn.addEventListener('click', () => {
+      getAppBanner.classList.add('d-none');
+      sessionStorage.setItem('getAppBanner', 'true');
+      // Reset header position when banner is closed
+      if (header) {
+        header.style.top = '';
+      }
+    });
+  }
+}
+
+/**
+ * Load and inject get app banner fragment into header
+ * Loads the fragment from /fragments/getappbanner and appends to header
+ */
+async function loadGetAppBannerFragment() {
+  // Skip loading fragments when viewing framework pages
+  if (isEditingFrameworkPage()) {
+    return;
+  }
+
+  const header = document.querySelector('header');
+  if (!header) {
+    return;
+  }
+
+  try {
+    // Load the fragment content
+    const fragment = await loadFragment('/fragments/getappbanner');
+
+    if (!fragment) {
+      // eslint-disable-next-line no-console
+      console.error('[Get App Banner] Failed to load fragment from: /fragments/getappbanner');
+      return;
+    }
+
+    // Get the get app banner div from the fragment
+    const getAppBanner = fragment.querySelector('#grnt-app-mob');
+
+    if (!getAppBanner) {
+      // eslint-disable-next-line no-console
+      console.error('[Get App Banner] No #grnt-app-mob found in fragment');
+      return;
+    }
+
+    // Append the banner to the header
+    header.appendChild(getAppBanner);
+
+    // Decorate the banner after it's been added to the DOM
+    decorateGetAppBanner(header);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('[Get App Banner] Error loading fragment:', error);
+  }
+}
+
+/**
  * Create category navbar wrapper at top of page
  * The actual navigation will be built by category-nav.js which collects all category-nav blocks
  *
@@ -1339,6 +1425,9 @@ async function loadLazy(doc) {
 
   // Load header first so nav-wrapper is available for category navbar
   await loadHeader(doc.querySelector('header'));
+
+  // Load get app banner fragment and append to header
+  await loadGetAppBannerFragment();
 
   // Load breadcrumbs after header is available and insert as first element in main
   await loadBreadcrumbs(main);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1269,10 +1269,6 @@ The height and width are set to 200 assuming the doodles won't be larger. */
      header:has(.category-nav-wrapper) {
        height: calc(var(--category-nav-height) + var(--nav-height)); /* nav + category-nav = 80px + 64px = 144px */
      }
-
-     .section#grnt-app-mob {
-      display: none;
-     }
   }
 
 @media (width >= 1200px) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -770,6 +770,56 @@ main>.section:first-of-type {
       --section-container-width: var(--grid-container-width);
     }
 }
+
+&#grnt-app-mob {
+  z-index: 4;
+  position: fixed;
+  top: 0;
+  left: 0;
+  width: 100%;
+  border-bottom: 1px solid var(--gray-300);
+
+  .columns > div {
+    background-color: var(--white);
+    flex-direction: row;
+      flex: 1;
+
+      > div {
+        order: unset;
+        align-content: center;
+      }
+
+      .columns-img-col img {
+        width: auto;
+        height: 60px;
+      }
+      
+      a.button:has(span.icon-icon-plus) {
+        padding: var(--spacing-xs);
+      }
+
+      a.button.primary {
+        font-weight: 300;
+        font-size: var(--body-font-size-s);
+        padding: var(--spacing-xs) var(--spacing-s);
+      }
+  }
+
+  .icon-icon-plus {
+
+    img {
+      filter: invert(100%);
+      transform: rotate(45deg);
+      padding: 4px;
+      border: 1px solid var(--gray-300);
+      border-radius: 50%;
+    }
+  }
+}
+}
+
+.d-none {
+  display: none;
 }
 
 .has-bg-images {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1269,6 +1269,10 @@ The height and width are set to 200 assuming the doodles won't be larger. */
      header:has(.category-nav-wrapper) {
        height: calc(var(--category-nav-height) + var(--nav-height)); /* nav + category-nav = 80px + 64px = 144px */
      }
+
+     .section#grnt-app-mob {
+      display: none;
+     }
   }
 
 @media (width >= 1200px) {


### PR DESCRIPTION
Adds session storage value if banner is closed so it doesn't open again.
This is using loadFragment from /fragments/getappbanner and adding a "top=77px" inline value for the rest of the header if the banner is supposed to appear. 

Amazingly, the CLS hit is very tiny. (we have bigger CLS violators).
<img width="1030" height="626" alt="image" src="https://github.com/user-attachments/assets/7ab32deb-c818-4bb4-952a-024588b555ea" />


Fix #427-getapp

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://427-getapp--idfc--aemsites.aem.page/

- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://427-getapp--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

To test:
See the banner only in mobile size. Close it. There will be a session storage value. Now refresh, you won't see it again.
Open the same link in incognito, banner comes back.
<img width="892" height="277" alt="image" src="https://github.com/user-attachments/assets/ae4b712f-f661-4cb8-a82b-f40f00bbfba0" />

