### PR TITLE
Adjust modal background height for mobile width

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -981,5 +981,7 @@ body.modal-open {
     justify-self: center;
   }
   
-
+  .modal .modal-page-background > img:first-child {
+    top: var(--nav-height);
+  }
 }


### PR DESCRIPTION
Removes background image gap caused by hidden secondary nav menu at mobile width.

Fixes #459 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://459-modal-backdrop-height--idfc--aemsites.aem.page/
