### PR TITLE
Adding the robots.txt file

### DIFF
--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,4 @@
+User-agent: *
+Disallow: /
+
+Sitemap: https://www.idfcfirst.bank.in/sitemap.xml


### PR DESCRIPTION
Fix #487

- robots.txt file that disallows everything and points to the customer's existing sitemap.

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/robots.txt
- After: https://487-robots--idfc--aemsites.aem.page/robots.txt
