### PR TITLE
fixed cutoff bottom nav with GetAppBanner

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -7,7 +7,7 @@ header .nav-wrapper {
   -webkit-font-smoothing: antialiased;
   background-color: #f9f9f9;
   width: 100%;
-  z-index: 2;
+  z-index: 4;
   position: fixed;
   box-shadow: 0 2px 4px rgb(0 0 0 / 10%);
   left: 0;

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -960,10 +960,9 @@ function decorateGetAppBanner(container) {
 
   // Show banner and add body class
   document.body.classList.add('grnt-new-header-app-body');
-
   // Set header top position to account for banner height
   if (header) {
-    header.style.top = '77px';
+    header.parentElement.style.height = `${header.clientHeight + getAppBanner.clientHeight}px`;
   }
 
   // Close button - hide banner and save to sessionStorage
@@ -974,7 +973,7 @@ function decorateGetAppBanner(container) {
       sessionStorage.setItem('getAppBanner', 'true');
       // Reset header position when banner is closed
       if (header) {
-        header.style.top = '';
+        header.parentElement.style.height = '80px';
       }
     });
   }
@@ -1010,7 +1009,7 @@ async function loadGetAppBannerFragment() {
       console.error('[Get App Banner] No #grnt-app-mob found in fragment');
       return;
     }
-    header.appendChild(getAppBanner);
+    header.firstChild.prepend(getAppBanner);
     decorateGetAppBanner(header);
   } catch (error) {
     // eslint-disable-next-line no-console

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -773,7 +773,6 @@ main>.section:first-of-type {
 
 &#grnt-app-mob {
   z-index: 4;
-  position: fixed;
   top: 0;
   left: 0;
   width: 100%;
@@ -816,6 +815,10 @@ main>.section:first-of-type {
     }
   }
 }
+}
+
+header:has(nav[aria-expanded="true"]) #grnt-app-mob {
+    display: none;
 }
 
 .d-none {


### PR DESCRIPTION
Fixed the problem of cutting off the very bottom of the open hamburger nav; it starts at the top like the live site.
Also fixed the problem of the top of the main content being covered by the header nav.

Fix #488 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://455-mobilepadding--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
