### PR TITLE
feat(modal): add padding to modal sections

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -229,6 +229,18 @@ body.modal-open {
   padding: 0;
 }
 
+/* Add padding to modal sections that commonly need spacing */
+.modal dialog .section.table-container,
+.modal dialog .section.grid,
+.modal dialog .section.cards-container,
+.modal dialog .section.columns-container,
+.modal dialog .section.dark-scheme,
+.modal dialog .section.light-scheme,
+.modal dialog .section[class*="grid-"],
+.modal dialog .section[class*="-container"] {
+  padding: 16px;
+}
+
 .modal.block:has(.section[data-id="mayura-card-modal"]) {
 	display: block;
 }
@@ -589,6 +601,18 @@ body.modal-open {
 @media (width < 768px) {
   .modal dialog.modal-auto-popup p {
     font-size: var(--body-font-size-xxs);
+  }
+
+  /* Responsive padding for modal sections on mobile */
+  .modal dialog .section.table-container,
+  .modal dialog .section.grid,
+  .modal dialog .section.cards-container,
+  .modal dialog .section.columns-container,
+  .modal dialog .section.dark-scheme,
+  .modal dialog .section.light-scheme,
+  .modal dialog .section[class*="grid-"],
+  .modal dialog .section[class*="-container"] {
+    padding: var(--spacing-s);
   }
 	
   .modal .modal-page-background .modal-decoration-top-right {

--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -612,7 +612,7 @@ body.modal-open {
   .modal dialog .section.light-scheme,
   .modal dialog .section[class*="grid-"],
   .modal dialog .section[class*="-container"] {
-    padding: var(--spacing-s);
+    padding: var(--spacing-xs);
   }
 	
   .modal .modal-page-background .modal-decoration-top-right {


### PR DESCRIPTION
Fix #354

Add padding to modal sections

Add 16px padding to common modal section types (grid, containers, schemes) with responsive mobile padding. Maintains zero padding default for sections.

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://354-padding--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
