### PR TITLE
CLS related fixes for 1st main section with getAppBanner

### DIFF
--- a/blocks/cta-sticky/cta-sticky.css
+++ b/blocks/cta-sticky/cta-sticky.css
@@ -11,6 +11,28 @@ and outer background value (such as rgb(0 0 0 / 60%) */
   display: flex;
   align-items: center;
   justify-content: center;
+  transform: translateY(0);
+  transition: transform 0.3s ease-in-out, opacity 0.3s ease-in-out;
+  opacity: 1;
+}
+
+.section.cta-sticky-container.hidden {
+  display: none;
+}
+
+.section.cta-sticky-container.slide-in {
+  animation: slideUp 0.3s ease-in-out;
+}
+
+@keyframes slideUp {
+  from {
+    transform: translateY(100%);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
 .cta-sticky {

--- a/blocks/cta-sticky/cta-sticky.js
+++ b/blocks/cta-sticky/cta-sticky.js
@@ -20,4 +20,27 @@ export default function decorate(block) {
     }
     children[2].remove();
   }
+
+  // Hide the CTA initially
+  const stickyContainer = block.closest('.cta-sticky-container');
+  if (stickyContainer) {
+    stickyContainer.classList.add('hidden');
+  }
+
+  // Show CTA after user starts scrolling
+  let hasScrolled = false;
+  const showCtaOnScroll = () => {
+    if (!hasScrolled && window.scrollY > 50) {
+      hasScrolled = true;
+      if (stickyContainer) {
+        stickyContainer.classList.remove('hidden');
+        stickyContainer.classList.add('slide-in');
+      }
+      // Remove the listener once shown to improve performance
+      window.removeEventListener('scroll', showCtaOnScroll);
+    }
+  };
+
+  // Add scroll listener
+  window.addEventListener('scroll', showCtaOnScroll, { passive: true });
 }

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -205,7 +205,6 @@
 
 .hero-heritage-cc .hero-heritage-cc-intro> div {
   position: absolute;
-  top: 0;
   left: 0;
   width: 100%;
   height: 100%;
@@ -279,7 +278,6 @@
 }
 
 .hero-heritage-cc .hero-heritage-cc-banner > div {
-  position: absolute;
   opacity: 0;
   visibility: hidden;
   display: flex;
@@ -507,7 +505,6 @@
   width: 100%;
   max-width: 1200px;
   height: 100%;
-  margin: 0 auto;
 }
 
 .hero-heritage-cc-header-cta-link .icon-arrow-right-white {
@@ -543,11 +540,6 @@
 
 /* Tablet: 600px and up */
 @media (width >= 600px) {
-  .hero-heritage-cc-header-cta {
-    padding: 0 18px;
-    display: flex;
-  }
-
   .hero-heritage-cc-banner-cta-group {
     flex-flow: row wrap;
     gap: 52px;
@@ -568,6 +560,11 @@
 
   .hero-heritage-cc h2 {
     font-size: var(--heading-font-size-m);
+  }
+
+  .hero-heritage-cc-header-cta {
+    padding: 0 18px;
+    display: flex;
   }
 
   .hero-heritage-cc .hero-heritage-cc-banner-cta-group {

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -48,7 +48,7 @@
 .hero-heritage-cc-container .hero-heritage-cc-wrapper {
   position: relative;
   max-width: unset;
-  padding: var(--nav-height) 0 0;
+  padding: 0;
   height: 100vh;
   height: 100dvh;
   min-height: 100vh;

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -48,7 +48,7 @@
 .hero-heritage-cc-container .hero-heritage-cc-wrapper {
   position: relative;
   max-width: unset;
-  padding: 0;
+  padding: var(--nav-height) 0 0;
   height: 100vh;
   height: 100dvh;
   min-height: 100vh;
@@ -188,7 +188,7 @@
 
 .hero-heritage-cc-intro > div {
   position: relative;
-  padding-top: var(--spacing-xxl);
+
   z-index: 2;
   display: flex;
   flex-direction: column;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -2,7 +2,6 @@
 .hero-container .hero-wrapper {
   min-height: 600px;
   max-width: unset;
-  padding-top: var(--nav-height);
 }
 
 .hero {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -2,6 +2,7 @@
 .hero-container .hero-wrapper {
   min-height: 600px;
   max-width: unset;
+  padding-top: var(--nav-height);
 }
 
 .hero {

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -1,13 +1,11 @@
 /* Mobile-first base styles */
 .hero-container .hero-wrapper {
+  min-height: 600px;
   max-width: unset;
-  padding: 0;
 }
 
 .hero {
   position: relative;
-  padding: 40px var(--spacing-s);
-  min-height: 400px;
   background-color: #000;
   overflow: hidden;
   display: flex;
@@ -30,29 +28,16 @@
   font-size: var(--heading-font-size-l);
   font-weight: 700;
   line-height: 1.1;
-  margin-bottom: 40px;
+
   text-align: center;
 }
 
 .hero p {
   color: #fff;
   font-size: var(--body-font-size-xs);
-  line-height: 1.2;
   margin-bottom: 0;
   margin-top: 0;
   text-align: center;
-}
-
-.hero p strong {
-  font-weight: 700;
-  font-size: var(--body-font-size-s);
-  margin-top: 0;
-}
-
-.hero p em {
-  font-weight: 700;
-  font-size: var(--body-font-size-s);
-  margin-top: 0;
 }
 
 .hero picture {
@@ -60,24 +45,40 @@
   z-index: 1;
   width: 100%;
   height: auto;
-  margin: -30px auto 0;
   display: block;
   order: 1;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 16 / 9;
 }
 
 .hero img {
   object-fit: contain;
   width: 100%;
   height: auto;
-  aspect-ratio: 4 / 3;
+  aspect-ratio: 16 / 9;
+}
+
+.dark-scheme .hero a.button.primary:any-link,
+.dark-scheme .hero a.button.primary:any-link:hover,
+ .dark-scheme button.primary,
+ .dark-scheme button.primary:hover {
+background-color: var(--red-color);
+color: var(--btn-color-white);
+border-color: transparent;
+}
+
+.dark-scheme .hero a.button.secondary:any-link,
+.dark-scheme .hero a.button.secondary:any-link:hover,
+ .dark-scheme button.secondary,
+ .dark-scheme button.secondary:hover {
+background-color: transparent;
+color: var(--btn-color-white);
+border-color: var(--btn-color-white);
 }
 
 /* Button groups wrapper */
 .hero .button-groups-wrapper {
   display: flex;
   flex-direction: column;
-  margin-bottom: 40px;
   align-items: center;
   width: 90%;
   gap: var(--spacing-s);
@@ -87,120 +88,21 @@
 
 /* Individual button group */
 .hero .button-group {
-  display: flex;
-  flex-direction: column;
-  text-align: center;
-  width: auto;
-  flex: 1;
   align-items: center;
-  margin: 16px;
+
+  .button-container a {
+    padding: 1em 1.2em;
+  }
 }
 
 .hero .button-group p {
-  margin: 0;
-  font-size: var(--body-font-size-xs);
-  line-height: 1.3;
-  text-align: center;
-}
-
-.hero .button-group p sup {
-  font-size: var(--body-font-size-xs);
-  vertical-align: super;
-  line-height: 0;
-}
-
-/* Button container styling */
-.hero .button-container {
-  margin: 0;
-}
-
-.hero .button {
-  display: block;
-  width: 100%;
-  padding: var(--spacing-xs) 16px;
-  font-size: var(--body-font-size-xs);
-  font-weight: 500;
-  text-decoration: none;
-  text-align: center;
-  border-radius: 50px;
-  transition: all 0.3s ease;
-  white-space: nowrap;
-  height: auto;
-  line-height: 1.3;
-}
-
-.hero a.button.primary {
-  background-color: var(--red-color);
-  color: #fff;
-  border: 1px solid var(--red-color);
-  padding: var(--spacing-xs) 16px;
-  margin: 0;
-  font-weight: 700;
-}
-
-.hero .button.primary:hover {
-  background-color: var(--dark-red-color);
-  border-color: var(--dark-red-color);
-}
-
-.hero a.button.secondary:any-link,
-.hero .button.secondary {
-  background-color: transparent;
-  color: #fff;
-  border: 1px solid #fff;
-  font-weight: 700;
-  font-style: normal;
-  overflow: hidden;
-  margin: 0;
-}
-
-.hero .button.secondary:hover {
-  background-color: var(--dark-red-color);
-  border-color: var(--dark-red-color);
-}
-
-/* Override dark-scheme global styles to maintain hero button consistency */
-.dark-scheme .hero a.button.primary:any-link,
-.dark-scheme .hero a.button.secondary:any-link {
-  padding: 14px 18px;
-  height: 52px;
-  line-height: 1;
-  box-sizing: border-box;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.dark-scheme .hero a.button.primary:any-link {
-  background-color: var(--red-color);
-  color: var(--btn-color-white);
-  border: 1px solid transparent;
-}
-
-.dark-scheme .hero a.button.primary:hover,
-.dark-scheme .hero a.button.primary:focus {
-  background-color: var(-red-color);
-  color: var(--btn-color-white);
-  border: 1px solid transparent;
-}
-
-.dark-scheme .hero a.button.secondary:any-link {
-  background-color: transparent;
-  color: #fff;
-  border: 1px solid #fff;
-}
-
-.dark-scheme .hero a.button.secondary:hover,
-.dark-scheme .hero a.button.secondary:focus {
-  background-color: transparent;
-  color: #fff;
-  border: 1px solid #fff;
+  font-size: var(--body-font-size-s);
 }
 
 /* Tablet: 600px and up */
 @media (width >= 600px) {
   .hero {
-    padding: var(--spacing-xl) var(--spacing-s);
+    padding-left: var(--spacing-s);
     display: block;
   }
 
@@ -210,33 +112,28 @@
   }
 
   .hero h1,
-  .hero h2,
-  .hero h3,
-  .hero h4,
-  .hero h5,
-  .hero h6 {
-    font-size: var(--heading-font-size-xxl);
+  .hero h2 {
+    font-size: var(--heading-font-size-l);
     text-align: left;
+    margin-bottom: var(--spacing-m);
   }
 
   .hero p {
-    font-size: var(--body-font-size-m);
+    font-size: var(--body-font-size-s);
     text-align: left;
-    line-height: 1.4;
   }
 
   .hero p strong {
-    font-size: var(--body-font-size-m);
+    font-size: var(--body-font-size-s);
   }
 
   .hero picture {
     position: absolute;
     right: 0;
-    top: 50%;
     transform: translateY(-50%);
     width: 50%;
     max-width: 600px;
-    margin: 0;
+    margin-top: 50%;
     order: unset;
     animation: slide-in-right 0.5s cubic-bezier(0.25, 0.46, 0.45, 0.94) both;
   }
@@ -265,65 +162,45 @@
   }
 
 .hero .button-group p sup {
-  font-size: var(--body-font-size-s);
-  vertical-align: super;
-  line-height: 0;
+  font-size: var(--body-font-size-xs);
 }
 
   .hero .button {
     display: inline-flex;
     align-items: center;
     justify-content: center;
-    width: auto;
     padding: 14px 18px;
     font-size: var(--body-font-size-s);
     height: 52px;
-    line-height: 1;
-    box-sizing: border-box;
-  }
-
-  .hero a.button.primary,
-  .hero a.button.secondary {
-    padding: 14px 18px;
-    height: 52px;
-    line-height: 1;
-    box-sizing: border-box;
   }
 }
 
 /* Desktop: 900px and up */
 @media (width >= 900px) {
   .hero {
-    padding: 10px var(--spacing-xl) 80px;
-    min-height: 500px; /* Prevent CLS from hero content resizing */
+    padding: 0 var(--spacing-s) var(--spacing-xl);
   }
 
   .hero-container .hero-wrapper {
+    min-height: 500px; /* Prevent CLS from hero content resizing */
     max-width: 1200px;
+    padding-top: 0;
   }
 
   .hero > div {
     max-width: 700px;
   }
 
-  .hero h1,
-  .hero h2,
-  .hero h3,
-  .hero h4,
-  .hero h5,
-  .hero h6 {
-    font-size: var(--heading-font-size-xl);
-    margin-top: 0;
-  }
-
   .hero picture {
     width: 50%;
     max-width: 650px;
+    margin-top: 0;
+    top: 40%;
   }
 
   .hero .button-groups-wrapper {
     flex-direction: row;
-    gap: 20px;
+    gap: var(--spacing-xs);
     align-items: flex-end;
   }
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -903,6 +903,12 @@ async function loadEager(doc) {
   decorateTemplateAndTheme();
   loadThemeSpreadSheetConfig();
 
+  const getAppBanner = sessionStorage.getItem('getAppBanner');
+  const header = doc.querySelector('header');
+  if (getAppBanner && header) {
+    header.style.height = 'var(--nav-height)';
+  }
+
   const templateName = getMetadata('template');
   if (templateName) {
     await loadTemplate(doc, templateName);
@@ -980,10 +986,10 @@ function decorateGetAppBanner(container) {
     closeBtn.addEventListener('click', () => {
       getAppBanner.classList.add('d-none');
       sessionStorage.setItem('getAppBanner', 'true');
-      // Reset first section padding when banner is closed
-      const firstSection = document.querySelector('body > main > .section:first-of-type');
-      if (firstSection) {
-        firstSection.style.paddingTop = 'unset';
+      // Remove height style on header when banner is closed
+      const header = document.querySelector('header');
+      if (header) {
+        header.style.height = 'var(--nav-height)';
       }
     });
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -923,12 +923,12 @@ async function loadEager(doc) {
     // Early detection of getAppBanner to prevent CLS
     // Check sessionStorage - if banner should be shown (not closed), set header height immediately
     // This prevents layout shift when banner loads later
-    if (MEDIA_QUERIES.mobile.matches && !sessionStorage.getItem('getAppBanner')) {
-      const header = doc.querySelector('.header');
-      if (header) {
-        header.parentElement.style.height = '157px';
-      }
-    }
+    // if (MEDIA_QUERIES.mobile.matches && !sessionStorage.getItem('getAppBanner')) {
+    //   const header = doc.querySelector('.header');
+    //   if (header) {
+    //     header.parentElement.style.height = '157px';
+    //   }
+    // }
 
     // Mark framework pages so CSS can show raw content for editing/preview
     if (isEditingFrameworkPage()) {
@@ -959,9 +959,6 @@ function decorateGetAppBanner(container) {
 
   getAppBanner.classList.add('grnt-app-mob-main');
 
-  // Get the header element to adjust its position
-  const header = document.querySelector('.header');
-
   // Check sessionStorage - hide banner if previously closed
   if (sessionStorage.getItem('getAppBanner')) {
     getAppBanner.classList.add('d-none');
@@ -972,10 +969,10 @@ function decorateGetAppBanner(container) {
   document.body.classList.add('grnt-new-header-app-body');
   // Set header top position to account for banner height
   // This may have already been set in loadEager to prevent CLS, but we ensure it's correct
-  if (header) {
-    const calculatedHeight = header.clientHeight + getAppBanner.clientHeight;
-    header.parentElement.style.height = `${calculatedHeight}px`;
-  }
+  // if (header) {
+  //   const calculatedHeight = header.clientHeight + getAppBanner.clientHeight;
+  //   header.parentElement.style.height = `${calculatedHeight}px`;
+  // }
 
   // Close button - hide banner and save to sessionStorage
   const closeBtn = getAppBanner.querySelector('.button-container > a:has(.icon-icon-plus)');
@@ -983,9 +980,10 @@ function decorateGetAppBanner(container) {
     closeBtn.addEventListener('click', () => {
       getAppBanner.classList.add('d-none');
       sessionStorage.setItem('getAppBanner', 'true');
-      // Reset header position when banner is closed
-      if (header) {
-        header.parentElement.style.height = '80px';
+      // Reset first section padding when banner is closed
+      const firstSection = document.querySelector('body > main > .section:first-of-type');
+      if (firstSection) {
+        firstSection.style.paddingTop = 'unset';
       }
     });
   }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -209,6 +209,37 @@ function decorateButtonGroups(element) {
   });
 }
 
+function prepareHeroForCLS(main) {
+  if (!window.matchMedia('(min-width: 900px)').matches) {
+    return;
+  }
+  main.querySelectorAll('.hero').forEach((block) => {
+    if (block.dataset.heroPrepared === 'true') return;
+
+    const picture = block.querySelector('picture');
+    if (picture) {
+      const pictureParent = picture.parentElement;
+      if (pictureParent) {
+        pictureParent.remove();
+        block.appendChild(picture);
+      }
+    }
+
+    const buttonGroups = block.querySelectorAll('.button-group');
+    if (buttonGroups.length > 0 && !block.querySelector('.button-groups-wrapper')) {
+      const buttonGroupsWrapper = document.createElement('div');
+      buttonGroupsWrapper.className = 'button-groups-wrapper';
+      const firstGroup = buttonGroups[0];
+      firstGroup.parentElement.insertBefore(buttonGroupsWrapper, firstGroup);
+      buttonGroups.forEach((group) => {
+        buttonGroupsWrapper.appendChild(group);
+      });
+    }
+
+    block.dataset.heroPrepared = 'true';
+  });
+}
+
 /**
  * Check if we're viewing a framework page (either in Universal Editor or directly)
  * Framework pages are template/fragment pages and should display their raw content
@@ -886,6 +917,7 @@ async function loadEager(doc) {
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);
+    prepareHeroForCLS(main);
 
     // Early detection of category-nav to prevent CLS
     // Check page metadata for category-nav path - if present, add class to body

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -920,6 +920,16 @@ async function loadEager(doc) {
       document.body.classList.add('has-category-nav');
     }
 
+    // Early detection of getAppBanner to prevent CLS
+    // Check sessionStorage - if banner should be shown (not closed), set header height immediately
+    // This prevents layout shift when banner loads later
+    if (MEDIA_QUERIES.mobile.matches && !sessionStorage.getItem('getAppBanner')) {
+      const header = doc.querySelector('.header');
+      if (header) {
+        header.parentElement.style.height = '157px';
+      }
+    }
+
     // Mark framework pages so CSS can show raw content for editing/preview
     if (isEditingFrameworkPage()) {
       document.body.classList.add('is-framework-page');
@@ -961,8 +971,10 @@ function decorateGetAppBanner(container) {
   // Show banner and add body class
   document.body.classList.add('grnt-new-header-app-body');
   // Set header top position to account for banner height
+  // This may have already been set in loadEager to prevent CLS, but we ensure it's correct
   if (header) {
-    header.parentElement.style.height = `${header.clientHeight + getAppBanner.clientHeight}px`;
+    const calculatedHeight = header.clientHeight + getAppBanner.clientHeight;
+    header.parentElement.style.height = `${calculatedHeight}px`;
   }
 
   // Close button - hide banner and save to sessionStorage

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -810,6 +810,7 @@ main>.section:first-of-type {
         font-weight: 300;
         font-size: var(--body-font-size-s);
         padding: var(--spacing-xs) var(--spacing-s);
+        margin-right: var(--spacing-xs);
       }
   }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -658,7 +658,6 @@ main>.section>div {
 
 main>.section:first-of-type {
   margin-top: 0;
-  padding-top: var(--nav-height);
 }
 
 /* stylelint-disable-next-line no-descending-specificity */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -108,7 +108,7 @@
   /* nav height */
   --nav-height: 80px;
   --category-nav-height: 52px;
-  --get-app-and-nav-height: 157px;
+  --get-app-banner-height: 77px;
 
   /* grid */
   --grid-container-width: 1160px;
@@ -170,8 +170,8 @@ body.appear {
 }
 
 header {
-  height: var(--get-app-and-nav-height);
-  background-color: #fff; /* Header always white to prevent black flash on nav */
+  height: calc(var(--get-app-banner-height) + var(--nav-height));
+  background-color: var(--background-color); /* Header always white to prevent black flash on nav */
 }
 
 header .header,
@@ -1035,9 +1035,6 @@ The height and width are set to 200 assuming the doodles won't be larger. */
 }
 
 @media (width >=900px) {
-  main>.section:first-of-type {
-    padding-top: unset;
-  }
   /* =================================================================
      CLS PREVENTION: Desktop-specific layout guards
      ================================================================= */
@@ -1088,10 +1085,6 @@ The height and width are set to 200 assuming the doodles won't be larger. */
 
   main>.section>div {
     padding: 0 32px;
-  }
-
-  header {
-    height: var(--nav-height); /* nav = 80px */
   }
   
   main .breadcrumbs {
@@ -1276,9 +1269,6 @@ The height and width are set to 200 assuming the doodles won't be larger. */
 }
 
 @media (width >= 990px) {
-  main>.section:first-of-type {
-    padding-top: unset;
-}
     /* Reserve space for category-nav BEFORE it loads to prevent CLS.
      The has-category-nav class is added by scripts.js based on page metadata.
      This runs BEFORE body.appear, ensuring correct header height from the start. */

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -108,6 +108,7 @@
   /* nav height */
   --nav-height: 80px;
   --category-nav-height: 52px;
+  --get-app-and-nav-height: 157px;
 
   /* grid */
   --grid-container-width: 1160px;
@@ -169,7 +170,7 @@ body.appear {
 }
 
 header {
-  height: var(--nav-height);
+  height: var(--get-app-and-nav-height);
   background-color: #fff; /* Header always white to prevent black flash on nav */
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -306,7 +306,6 @@ button.button {
   border: 2px solid transparent;
   border-radius: 2.4em;
   padding: 0.5em 1.2em;
-  
   font-style: normal;
   font-weight: 700;
   line-height: 1.25;
@@ -531,12 +530,16 @@ a.button:has(span.icon) {
 .button-group {
   display: flex;
   flex-direction: column;
-  gap: 0.5em;
   align-items: flex-start;
-}
+  margin: var(--spacing-xs);
 
-.button-group p {
-  margin: 0;
+  p {
+    margin: 0;
+  }
+
+  sup {
+    vertical-align: text-bottom;
+  }
 }
 
 .button-group .button-container {
@@ -655,6 +658,7 @@ main>.section>div {
 
 main>.section:first-of-type {
   margin-top: 0;
+  padding-top: var(--nav-height);
 }
 
 /* stylelint-disable-next-line no-descending-specificity */
@@ -786,6 +790,11 @@ main>.section:first-of-type {
       > div {
         order: unset;
         align-content: center;
+      }
+
+      > div:last-child {
+        flex: 2;
+        text-align: right;
       }
 
       .columns-img-col img {
@@ -1025,6 +1034,9 @@ The height and width are set to 200 assuming the doodles won't be larger. */
 }
 
 @media (width >=900px) {
+  main>.section:first-of-type {
+    padding-top: unset;
+  }
   /* =================================================================
      CLS PREVENTION: Desktop-specific layout guards
      ================================================================= */
@@ -1080,16 +1092,12 @@ The height and width are set to 200 assuming the doodles won't be larger. */
   header {
     height: var(--nav-height); /* nav = 80px */
   }
-
-
-
   
   main .breadcrumbs {
     display: inline-block;
-    margin: 10px 40px 0;
+    margin: var(--spacing-xxs) var(--spacing-s);
     padding: 6px 20px;
     font-size: var(--body-font-size-xxs);
-    font-family: var(--body-font-family-semibold);
     position: relative;
     z-index: 3;
     background-color: rgb(232 232 232 / 90%);
@@ -1152,10 +1160,6 @@ The height and width are set to 200 assuming the doodles won't be larger. */
     font-weight: 400;
   }
 
-  main:has(.hero-wrapper) .breadcrumbs {
-    margin-left: 60px;
-  }
-
   .section {
     &.grid-4 .block-content,
     &.grid-6 .block-content {
@@ -1185,6 +1189,12 @@ The height and width are set to 200 assuming the doodles won't be larger. */
   
     &.spacing-xxl {
       --top-bottom-spacing: calc(var(--spacing-xxl) * 2);
+    }
+
+    &#grnt-app-mob {
+      .columns > div > div {
+        flex: 0;
+      }
     }
   }
 
@@ -1265,6 +1275,9 @@ The height and width are set to 200 assuming the doodles won't be larger. */
 }
 
 @media (width >= 990px) {
+  main>.section:first-of-type {
+    padding-top: unset;
+}
     /* Reserve space for category-nav BEFORE it loads to prevent CLS.
      The has-category-nav class is added by scripts.js based on page metadata.
      This runs BEFORE body.appear, ensuring correct header height from the start. */


### PR DESCRIPTION
Since we are using a sessionStorage to determine if the app banner shows (and needs to push down the main content), I'm looking for that in the Eager phase and setting a new nav height accordingly. That, plus not showing the bottom sticky banner until someone starts scrolling seems to be doing the trick.

I also fixed a bunch of hero things; I know the desktop buttons aren't vertically centered but I will fix that in the big "Button Refactor" ticket.

Fix #498 , #477

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://455-mobilepadding--idfc--aemsites.aem.page/credit-card/rupay-credit-card

- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://455-mobilepadding--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

Full reports looking great, 99+ for all.
https://pagespeed.web.dev/analysis/https-455-mobilepadding--idfc--aemsites-aem-page-credit-card-rupay-credit-card/0rvu7kc7fq?utm_source=psi&utm_medium=redirect&form_factor=mobile

https://pagespeed.web.dev/analysis/https-455-mobilepadding--idfc--aemsites-aem-page-credit-card-metal-credit-card-mayura/l3og3du8ut?utm_source=psi&utm_medium=redirect&form_factor=desktop
