### PR TITLE
important document cards touch targets

### DIFF
--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -871,7 +871,7 @@ export default async function decorate(block) {
 
     // Setup interactivity for all card types (links, modals)
     // Skip for blog-posts - uses standard link behavior
-    if (!isBlogPosts) {
+    if (!isBlogPosts || !isImportantDocuments) {
       // Add arrow icons for key-benefits, experience-life, reward-points variants
       const shouldAddArrow = supportsSemanticElements;
       const modalTheme = block.dataset.modalTheme || '';

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -870,8 +870,8 @@ export default async function decorate(block) {
     }
 
     // Setup interactivity for all card types (links, modals)
-    // Skip for blog-posts - uses standard link behavior
-    if (!isBlogPosts || !isImportantDocuments) {
+    // Skip for blog-posts and important-documents - they use standard link behavior
+    if (!isBlogPosts && !isImportantDocuments) {
       // Add arrow icons for key-benefits, experience-life, reward-points variants
       const shouldAddArrow = supportsSemanticElements;
       const modalTheme = block.dataset.modalTheme || '';


### PR DESCRIPTION
we already were handling it for Blog cards, just had to add important docs cards to it.

Fix #501 
Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://501-touchtargets--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

Before:
<img width="1009" height="737" alt="image" src="https://github.com/user-attachments/assets/620eb058-2d1a-4f2d-84f6-1cee39a31ece" />


After:
<img width="1002" height="760" alt="image" src="https://github.com/user-attachments/assets/6b371ab5-dab1-44e8-b2fa-7c2db02e0ad2" />

