### PR TITLE
added missing margin to Mayura banner

### DIFF
--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -505,6 +505,7 @@
   width: 100%;
   max-width: 1200px;
   height: 100%;
+  margin: auto;
 }
 
 .hero-heritage-cc-header-cta-link .icon-arrow-right-white {


### PR DESCRIPTION
Mayura credit card image should be center aligned now.

Fix #503 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://503-margin--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
