### PR TITLE
Add H1 to main then hide with CSS

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -811,6 +811,12 @@ export function decorateMain(main) {
   decorateBlocks(main);
   buildEmbedBlocks(main);
   decorateLinkedPictures(main);
+  const h1Title = getMetadata('h1-title');
+  if (h1Title) {
+    const h1 = document.createElement('h1');
+    h1.textContent = h1Title;
+    main.insertBefore(h1, main.firstChild);
+  }
 }
 
 function addOverlayRule(ruleSet, selector, property, value) {

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -811,12 +811,6 @@ export function decorateMain(main) {
   decorateBlocks(main);
   buildEmbedBlocks(main);
   decorateLinkedPictures(main);
-  const h1Title = getMetadata('h1-title');
-  if (h1Title) {
-    const h1 = document.createElement('h1');
-    h1.textContent = h1Title;
-    main.insertBefore(h1, main.firstChild);
-  }
 }
 
 function addOverlayRule(ruleSet, selector, property, value) {
@@ -923,6 +917,12 @@ async function loadEager(doc) {
   const main = doc.querySelector('main');
   if (main) {
     decorateMain(main);
+    const h1Title = getMetadata('h1-title');
+    if (h1Title) {
+      const h1 = document.createElement('h1');
+      h1.textContent = h1Title;
+      main.insertBefore(h1, main.firstChild);
+    }
     prepareHeroForCLS(main);
 
     // Early detection of category-nav to prevent CLS

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -249,7 +249,7 @@ pre {
   white-space: pre;
 }
 
-main > h1:first-child {
+main > h1:first-of-type {
   display: none;
 }
 

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -249,6 +249,10 @@ pre {
   white-space: pre;
 }
 
+main > h1:first-child {
+  display: none;
+}
+
 main>div {
   margin: 40px 16px;
 }


### PR DESCRIPTION
To address Google complaint of missing H1.

Fix #378 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://378-make-hide-h1--idfc--aemsites.aem.page/credit-card/rupay-credit-card
