### PR TITLE
Remove line-height property from mayura-card-modal section in modal.css

### DIFF
--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -571,7 +571,6 @@ body.modal-open {
 
 .modal .section[data-id="mayura-card-modal"] > div > div:nth-child(3) > div > div p:first-child {
   font-size: var(--body-font-size-xs);
-  line-height: 18px;
   margin: 0 0 6px;
   font-weight: 500;
   color: var(--color-gray-900);


### PR DESCRIPTION
Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #511 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://511-rupay-popup-lineheight-button--idfc--aemsites.aem.page/credit-card/rupay-credit-card

Iustin added the line I just removed three weeks ago. 

Line 574 line-height was set at 18px