### PR TITLE
Center Span Icons

### DIFF
--- a/styles/styles.css
+++ b/styles/styles.css
@@ -516,6 +516,14 @@ a.button:has(span.icon) {
   justify-content: center;
 }
 
+/* Align icons within headings (similar to button icon alignment above) */
+h3:has(span.icon) {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  gap: 0.25em;
+}
+
 /* button groups - wraps text (typically superscript) and button together for responsive layouts */
 .button-group {
   display: flex;


### PR DESCRIPTION
Center the sparkle icons horizontally with the included text. 

Fix #394 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://394-spakleAlignment--idfc--aemsites.aem.page/credit-card/rupay-credit-card


Main:
<img width="1156" height="281" alt="image" src="https://github.com/user-attachments/assets/701db397-187c-4caa-918a-1e015b387d2b" />

Branch:
<img width="1147" height="254" alt="image" src="https://github.com/user-attachments/assets/571ee958-d727-454e-a379-27000f2730c9" />
