### PR TITLE
category-nav: move bell section to bottom of main

### DIFF
--- a/blocks/category-nav/category-nav.js
+++ b/blocks/category-nav/category-nav.js
@@ -823,14 +823,20 @@ export default function decorate(block) {
 
         if (hasCardsBlock && !hasCategoryNav && hasIcon) {
           sectionsWithCardsData.push({ section, textElements });
-        }
-      });
 
-      // Move bell-outline section to bottom of main to prevent CLS
-      sectionsWithCardsData.forEach(({ section }) => {
-        if (section.id === 'bell-outline' || section.getAttribute('data-category-id')?.includes('bell')) {
-          if (main && section.parentElement === main) {
-            main.appendChild(section);
+          // Move bell notification sections to bottom immediately upon detection to prevent CLS
+          // Only move sections with EXACT bell icon names (bell or bell-outline)
+          // AND cards-container class for maximum safety
+          // This happens BEFORE processing, as early as possible in the execution
+          const iconElement = textElements.find((el) => el.querySelector('span.icon'))?.querySelector('span.icon');
+          const iconName = iconElement?.classList[1]?.replace('icon-', '') || '';
+          const isCardsContainer = section.classList.contains('cards-container');
+
+          // Only match exact bell icons: 'bell' or 'bell-outline' + must be cards-container
+          if ((iconName === 'bell' || iconName === 'bell-outline') && isCardsContainer) {
+            if (main && section.parentElement === main) {
+              main.appendChild(section);
+            }
           }
         }
       });

--- a/blocks/category-nav/category-nav.js
+++ b/blocks/category-nav/category-nav.js
@@ -825,6 +825,15 @@ export default function decorate(block) {
           sectionsWithCardsData.push({ section, textElements });
         }
       });
+
+      // Move bell-outline section to bottom of main to prevent CLS
+      sectionsWithCardsData.forEach(({ section }) => {
+        if (section.id === 'bell-outline' || section.getAttribute('data-category-id')?.includes('bell')) {
+          if (main && section.parentElement === main) {
+            main.appendChild(section);
+          }
+        }
+      });
     }
   }
 


### PR DESCRIPTION
Fix #543 

Move #bell-outline section to end of main element before processing to eliminate Cumulative Layout Shift issues on desktop. Section is still hidden by CSS until moved to header navigation.

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://543-move-bell--idfc--aemsites.aem.page/credit-card/rupay-credit-card
