### PR TITLE
Section Title fixes

### DIFF
--- a/blocks/section-title/section-title.js
+++ b/blocks/section-title/section-title.js
@@ -1,0 +1,51 @@
+/**
+ * Section Title block: apply author-selected text size and alignment as classes.
+ * EDS DOM order: row0=title, row1=textSize, row2=alignment.
+ */
+const SIZE_CLASSES = {
+  xxl: 'size-xxl',
+  xl: 'size-xl',
+  l: 'size-l',
+  m: 'size-m',
+  s: 'size-s',
+  xs: 'size-xs',
+};
+
+function toSizeClass(val) {
+  if (!val || typeof val !== 'string') return '';
+  const n = val.trim().toLowerCase();
+  if (!n) return '';
+  if (n.startsWith('size-')) {
+    const key = n.slice(5).split(/\s/)[0];
+    return SIZE_CLASSES[key] || '';
+  }
+  if (SIZE_CLASSES[n]) return SIZE_CLASSES[n];
+  if (n.includes('xxl')) return 'size-xxl';
+  if (n.includes('xs')) return 'size-xs';
+  if (n.includes('xl')) return 'size-xl';
+  return '';
+}
+
+function cellText(row) {
+  if (!row) return '';
+  const col = row.children.length >= 2 ? row.children[1] : row;
+  return (col.textContent || '').trim();
+}
+
+export default function decorate(block) {
+  const rows = block.querySelectorAll(':scope > div');
+  if (rows.length >= 2) {
+    const sizeClass = toSizeClass(cellText(rows[1]));
+    if (sizeClass) block.classList.add(sizeClass);
+  }
+  if (rows.length >= 3) {
+    const align = cellText(rows[2]).toLowerCase();
+    if (align === 'center' || align === 'right') block.classList.add(align);
+  }
+
+  const heading = block.querySelector('h1, h2, h3, h4, h5, h6, p');
+  if (heading && block.children.length > 1) {
+    block.innerHTML = '';
+    block.appendChild(heading);
+  }
+}


### PR DESCRIPTION
Configurations for the section title which allows us to author titles and specify the header type and font size. This allows authors to continue to follow semantic HTML best practices, but control the size of the text rendered.

Fix #535 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/section-title
- After: https://535-sectionTitle--idfc--aemsites.aem.page/library/section-title

Main:
<img width="1331" height="774" alt="image" src="https://github.com/user-attachments/assets/aa58308b-dfe9-40d9-82b2-0864d4d36d72" />

Branch:
<img width="1228" height="463" alt="image" src="https://github.com/user-attachments/assets/b25c0fea-4a77-4593-838b-ffae34d2bde8" />
