### PR TITLE
add testimonial card to  section menu

### DIFF
--- a/component-filters.json
+++ b/component-filters.json
@@ -34,7 +34,8 @@
       "banner",
       "overview",
       "section-title",
-      "hotspot"
+      "hotspot",
+      "testimonial-card"
     ]
   },
   {

--- a/models/_section.json
+++ b/models/_section.json
@@ -325,7 +325,8 @@
         "banner",
         "overview",
         "section-title",
-        "hotspot"
+        "hotspot",
+        "testimonial-card"
       ]
     }
   ]


### PR DESCRIPTION
Adding testimonial card block to the section authoring menu. I forgot that in the previous PR. 

Fix #133 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://133-testimonialEnhancement--idfc--aemsites.aem.page/
