### PR TITLE
Distinguishing different card items for UE

### DIFF
--- a/blocks/cards-testimonial/_cards-testimonial.json
+++ b/blocks/cards-testimonial/_cards-testimonial.json
@@ -17,15 +17,15 @@
       }
     },
     {
-      "title": "Card",
-      "id": "card",
+      "title": "Testimonial Card",
+      "id": "card-testimonial",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/franklin/components/block/v1/block/item",
             "template": {
-              "name": "Card",
-              "model": "card"
+              "name": "Testimonial Card",
+              "model": "card-testimonial"
             }
           }
         }
@@ -64,7 +64,7 @@
       ]
     },
     {
-      "id": "card",
+      "id": "card-testimonial",
       "fields": [
         {
           "component": "reference",
@@ -134,7 +134,7 @@
     {
       "id": "cards-testimonial",
       "components": [
-        "card"
+        "card-testimonial"
       ]
     }
   ]

--- a/component-definition.json
+++ b/component-definition.json
@@ -198,15 +198,15 @@
           }
         },
         {
-          "title": "Card",
-          "id": "card",
+          "title": "Testimonial Card",
+          "id": "card-testimonial",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block/item",
                 "template": {
-                  "name": "Card",
-                  "model": "card"
+                  "name": "Testimonial Card",
+                  "model": "card-testimonial"
                 }
               }
             }

--- a/component-filters.json
+++ b/component-filters.json
@@ -59,7 +59,7 @@
   {
     "id": "cards-testimonial",
     "components": [
-      "card"
+      "card-testimonial"
     ]
   },
   {

--- a/component-models.json
+++ b/component-models.json
@@ -745,7 +745,7 @@
     ]
   },
   {
-    "id": "card",
+    "id": "card-testimonial",
     "fields": [
       {
         "component": "reference",


### PR DESCRIPTION
I had card as an item for testimonial-cards. This only allows the selection of the standard card item in the UE. I am renaming the testimonial card item to distinguish it. 

Fix #133 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://133-testimonialEnhancement--idfc--aemsites.aem.page/
