### PR TITLE
Testimonial Card Config

### DIFF
--- a/blocks/cards-testimonial/_cards-testimonial.json
+++ b/blocks/cards-testimonial/_cards-testimonial.json
@@ -96,6 +96,14 @@
           ]
         },
         {
+          "component": "richtext",
+          "name": "text",
+          "value": "",
+          "label": "Text",
+          "valueType": "string",
+          "description": "Review or testimonial content"
+        },
+        {
           "component": "text",
           "name": "person-name",
           "label": "Person Name",

--- a/component-models.json
+++ b/component-models.json
@@ -777,6 +777,14 @@
         ]
       },
       {
+        "component": "richtext",
+        "name": "text",
+        "value": "",
+        "label": "Text",
+        "valueType": "string",
+        "description": "Review or testimonial content"
+      },
+      {
         "component": "text",
         "name": "person-name",
         "label": "Person Name",


### PR DESCRIPTION
One more UE fix. In the changes I lost the field for the actual testimonial. This is adding that back in. 

Fix #133 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://133-testimonialEnhancement--idfc--aemsites.aem.page/credit-card/rupay-credit-card
