### PR TITLE
UE only: add regular section properties to tab-section

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -20,10 +20,12 @@ module.exports = {
     'no-param-reassign': [2, { props: false }], // allow modifying properties of param
     'xwalk/max-cells': ['error', {
       section: 30, // section is a key-value block and over 4 is OK
+      'tab-section': 30,
       accordion: 5, // the rest of these need adjustments per https://www.aem.live/developer/component-model-definitions#type-inference
       'banner-item': 6,
       cards: 8,
       card: 7,
+      'category-nav-item': 10,
       'cc-hero-slider-item': 5,
       steps: 5,
       table: 6,

--- a/component-models.json
+++ b/component-models.json
@@ -582,6 +582,175 @@
         "component": "text",
         "name": "content",
         "label": "Heading"
+      },
+      {
+        "component": "text",
+        "name": "id",
+        "label": "ID",
+        "description": "Adds an ID value to the section"
+      },
+      {
+        "component": "multiselect",
+        "name": "style",
+        "label": "Style",
+        "options": [
+          {
+            "name": "Center",
+            "value": "center"
+          },
+          {
+            "name": "Light scheme",
+            "value": "light-scheme"
+          },
+          {
+            "name": "Dark scheme",
+            "value": "dark-scheme"
+          },
+          {
+            "name": "Hide in mobile",
+            "value": "hide-mobile"
+          },
+          {
+            "name": "Hide in desktop",
+            "value": "hide-desktop"
+          },
+          {
+            "name": "UPI steps red background",
+            "value": "upi-steps-red-bg"
+          },
+          {
+            "name": "Entrance Animation",
+            "value": "entrance-animation"
+          }
+        ]
+      },
+      {
+        "component": "text",
+        "name": "spacing",
+        "label": "Spacing top and bottom of section (xs, s, m, l, xl, xxl)",
+        "valueType": "string"
+      },
+      {
+        "component": "container",
+        "label": "Optional outer background properties",
+        "name": "container",
+        "valueType": "string",
+        "collapsible": true,
+        "fields": [
+          {
+            "component": "text",
+            "name": "backgroundColor",
+            "label": "Background Color/gradient",
+            "value": "",
+            "valueType": "string",
+            "description": "Use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) or CSS color values (e.g. var(--gradient-silver)"
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "sectionBackgroundImage",
+            "label": "Background Image",
+            "description": "Background image of the section, displayed on top of the background color if specified",
+            "multi": false
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "sectionBackgroundImageMobile",
+            "label": "Background Image Mobile",
+            "description": "Background image for mobile",
+            "multi": false
+          },
+          {
+            "component": "select",
+            "valueType": "string",
+            "name": "object-fit",
+            "label": "Background Fit",
+            "value": "cover",
+            "options": [
+              {
+                "name": "cover",
+                "value": "cover"
+              },
+              {
+                "name": "contain",
+                "value": "contain"
+              },
+              {
+                "name": "none",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "component": "select",
+            "valueType": "string",
+            "name": "object-position",
+            "label": "Background Image Position",
+            "value": "center",
+            "options": [
+              {
+                "name": "center",
+                "value": "center"
+              },
+              {
+                "name": "top left",
+                "value": "top left"
+              },
+              {
+                "name": "top right",
+                "value": "top right"
+              },
+              {
+                "name": "bottom left",
+                "value": "bottom left"
+              },
+              {
+                "name": "bottom right",
+                "value": "bottom right"
+              }
+            ]
+          },
+          {
+            "component": "text",
+            "name": "height",
+            "label": "Desktop Height",
+            "value": "",
+            "valueType": "string",
+            "description": "optional minimum height when in desktop, e.g. 400px"
+          },
+          {
+            "component": "text",
+            "name": "heightmobile",
+            "label": "Mobile Height",
+            "value": "",
+            "valueType": "string",
+            "description": "optional minimum height when in mobile, e.g. 400px"
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "doodle-image-top",
+            "label": "Background accessory image - top",
+            "description": "Displayed at top left of the section",
+            "multi": false
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "doodle-image-bottom",
+            "label": "Background accessory image - bottom",
+            "description": "Displayed at bottom right of the section",
+            "multi": false
+          },
+          {
+            "component": "boolean",
+            "valueType": "boolean",
+            "name": "doodle-reverse",
+            "label": "Reverse background accessory images",
+            "description": "Display at top right and bottom left of the section"
+          }
+        ]
       }
     ]
   },

--- a/models/_tab-section.json
+++ b/models/_tab-section.json
@@ -33,6 +33,175 @@
             "component": "text",
             "name": "content",
             "label": "Heading"
+          },
+          {
+            "component": "text",
+            "name": "id",
+            "label": "ID",
+            "description": "Adds an ID value to the section"
+          },
+          {
+            "component": "multiselect",
+            "name": "style",
+            "label": "Style",
+            "options": [
+              {
+                "name": "Center",
+                "value": "center"
+              },
+              {
+                "name": "Light scheme",
+                "value": "light-scheme"
+              },
+              {
+                "name": "Dark scheme",
+                "value": "dark-scheme"
+              },
+              {
+                "name": "Hide in mobile",
+                "value": "hide-mobile"
+              },
+              {
+                "name": "Hide in desktop",
+                "value": "hide-desktop"
+              },
+              {
+                "name": "UPI steps red background",
+                "value": "upi-steps-red-bg"
+              },
+              {
+                "name": "Entrance Animation",
+                "value": "entrance-animation"
+              }
+            ]
+          },
+          {
+            "component": "text",
+            "name": "spacing",
+            "label": "Spacing top and bottom of section (xs, s, m, l, xl, xxl)",
+            "valueType": "string"
+          },
+          {
+            "component": "container",
+            "label": "Optional outer background properties",
+            "name": "container",
+            "valueType": "string",
+            "collapsible": true,
+            "fields": [
+          {
+            "component": "text",
+            "name": "backgroundColor",
+            "label": "Background Color/gradient",
+            "value": "",
+            "valueType": "string",
+            "description": "Use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) or CSS color values (e.g. var(--gradient-silver)"
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "sectionBackgroundImage",
+            "label": "Background Image",
+            "description": "Background image of the section, displayed on top of the background color if specified",
+            "multi": false
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "sectionBackgroundImageMobile",
+            "label": "Background Image Mobile",
+            "description": "Background image for mobile",
+            "multi": false
+          },
+          {
+            "component": "select",
+            "valueType": "string",
+            "name": "object-fit",
+            "label": "Background Fit",
+            "value": "cover",
+            "options": [
+              {
+                "name": "cover",
+                "value": "cover"
+              },
+              {
+                "name": "contain",
+                "value": "contain"
+              },
+              {
+                "name": "none",
+                "value": "none"
+              }
+            ]
+          },
+          {
+            "component": "select",
+            "valueType": "string",
+            "name": "object-position",
+            "label": "Background Image Position",
+            "value": "center",
+            "options": [
+              {
+                "name": "center",
+                "value": "center"
+              },
+              {
+                "name": "top left",
+                "value": "top left"
+              },
+              {
+                "name": "top right",
+                "value": "top right"
+              },
+              {
+                "name": "bottom left",
+                "value": "bottom left"
+              },
+              {
+                "name": "bottom right",
+                "value": "bottom right"
+              }
+            ]
+          },
+          {
+            "component": "text",
+            "name": "height",
+            "label": "Desktop Height",
+            "value": "",
+            "valueType": "string",
+            "description": "optional minimum height when in desktop, e.g. 400px"
+          },
+          {
+            "component": "text",
+            "name": "heightmobile",
+            "label": "Mobile Height",
+            "value": "",
+            "valueType": "string",
+            "description": "optional minimum height when in mobile, e.g. 400px"
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "doodle-image-top",
+            "label": "Background accessory image - top",
+            "description": "Displayed at top left of the section",
+            "multi": false
+          },
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "doodle-image-bottom",
+            "label": "Background accessory image - bottom",
+            "description": "Displayed at bottom right of the section",
+            "multi": false
+          },
+          {
+            "component": "boolean",
+            "valueType": "boolean",
+            "name": "doodle-reverse",
+            "label": "Reverse background accessory images",
+            "description": "Display at top right and bottom left of the section"
+          }
+            ]
           }
         ]
       }


### PR DESCRIPTION
UE only
Forgot to add some of the usual section background properties

#563 
Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://563-tabsection--idfc--aemsites.aem.page/
