### PR TITLE
Multi section for accordions and tabs

### DIFF
--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -30,6 +30,10 @@
   font-weight: 600;
 }
 
+.multi .accordion details summary {
+  padding: 20px 30px 20px var(--spacing-s);
+}
+
 .accordion details summary::after {
   content: '';
   position: absolute;

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -3,6 +3,7 @@
   gap: var(--spacing-xs);
   max-width: 100%;
   overflow-x: auto;
+  padding: var(--spacing-xs) 0;
 }
 
 .tabs .tabs-tab {
@@ -45,7 +46,6 @@
 
 .tabs .tabs-panel {
   border: none;
-  padding: var(--spacing-s) 0;
   overflow: hidden; /* Needed for swiper cards inside tabs */
 }
 
@@ -53,36 +53,61 @@
   display: none;
 }
 
-.tabs.blue-white-text .tabs-tab {
+.tabs-container.blue-white-text .tabs-tab {
   background: var(--gradient-silver);
 }
 
-.tabs.silver-blue-text .tabs-tab {
+.tabs-container.silver-blue-text .tabs-tab {
   background: rgb(255 255 255 / 70%);
 }
 
-.tabs.silver-blue-text .tabs-list .tabs-tab p {
+.tabs-container.silver-blue-text .tabs-list .tabs-tab p {
   color: #08133C;
 }
 
-.tabs.blue-white-text .tabs-tab[aria-selected='true'] {
+.tabs-container.blue-white-text .tabs-tab[aria-selected='true'] {
   background: var(--gradient-blue);
   color: var(--color-white);
 }
 
-.tabs.silver-blue-text .tabs-list {
+.tabs-container.silver-blue-text .tabs-list {
   padding: 0;
   margin-bottom: 0;
 }
 
-.tabs.silver-blue-text .tabs-tab[aria-selected='true'] {
+.tabs-container.silver-blue-text .tabs-tab[aria-selected='true'] {
   background: linear-gradient(138deg, #999 -15.44%, #EFEFEF 0.15%, #CACACA 18.04%, #EFEFEF 37.09%, #CACACA 58.44%, #999 76.91%, #EFEFEF 87.3%);
   color: #08133C;
+}
+
+/* new tab-section styles */
+.section.tabs-container div.tabs-wrapper {
+
+  .tabs-list, .section-title {
+    max-width: var(--grid-container-width);
+    margin: 0 auto;
+    justify-content: center;
+  }
+
+  .tabs.vertical .tabs-list {
+    display: flex;
+    flex-direction: column;
+    width: 100%;
+  }
 }
 
 @media (width >= 900px) {
   .tabs .tabs-list .tabs-tab {
     font-size: var(--body-font-size-m);
+  }
+
+  .tabs-tab[aria-selected='true'] {
+    background: var(--gradient-silver);
+    color: var(--color-white);
+  }
+
+  .tabs-panel {
+    padding: 0;
   }
 
   .tabs.silver-blue-text .tabs-list {
@@ -92,4 +117,28 @@
   .tabs.silver-blue-text .tabs-tab {
     flex: 0 1 auto;
   }
+
+  /* new tab-section styles */
+.section.tabs-container div.tabs-wrapper {
+
+  .tabs.vertical {
+    display: flex;
+    flex-direction: row;
+    flex-wrap: wrap;
+    align-items: flex-start;
+    gap: var(--spacing-s);
+
+    > div {
+      flex: 0 0 100%;
+    }
+
+    .tabs-list {
+      flex: 0 0 150px;
+    }
+
+    .tabs-panel {
+      flex: 1 1 calc(100% - 200px);
+    }
+  }
+}
 }

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -1,52 +1,97 @@
 // eslint-disable-next-line import/no-unresolved
 import { toClassName } from '../../scripts/aem.js';
-import { moveInstrumentation } from '../../scripts/scripts.js';
+import { getBlockId, moveInstrumentation } from '../../scripts/scripts.js';
+
+function fetchTabName(tab) {
+  const tabTextWrapper = document.createElement('div');
+  const tabName = tab.getAttribute('data-tabname');
+  if (tabName) {
+    const tabText = document.createElement('p');
+    tabText.textContent = tabName;
+    tabTextWrapper.append(tabText);
+  }
+  return tabTextWrapper;
+}
+
+function createTabButton(block, tab, tabpanel, tablist, index, isInEditor = false) {
+  const button = document.createElement('button');
+  button.className = 'tabs-tab';
+  button.id = `${block.id}_tab_${index}`;
+  button.innerHTML = fetchTabName(tab).innerHTML;
+  button.setAttribute('aria-controls', tabpanel.id);
+  // In editor, all tabs start unselected; otherwise first tab is selected
+  button.setAttribute('aria-selected', isInEditor ? 'false' : !index);
+  button.setAttribute('role', 'tab');
+  button.setAttribute('type', 'button');
+  button.addEventListener('click', () => {
+    block.querySelectorAll('[role=tabpanel]').forEach((panel) => {
+      panel.setAttribute('aria-hidden', true);
+    });
+    tablist.querySelectorAll('button').forEach((btn) => {
+      btn.setAttribute('aria-selected', false);
+    });
+    tabpanel.setAttribute('aria-hidden', false);
+    button.setAttribute('aria-selected', true);
+  });
+  return button;
+}
 
 export default async function decorate(block) {
+  block.id = getBlockId('tabs');
+
+  // Check if we're in Universal Editor
+  const isInUniversalEditor = window.hlx?.isEditor === true
+    || !!document.querySelector('main[data-aue-resource]');
+
   // build tablist
   const tablist = document.createElement('div');
   tablist.className = 'tabs-list';
   tablist.setAttribute('role', 'tablist');
 
   // decorate tabs and tabpanels
-  const tabs = [...block.children].map((child) => child.firstElementChild);
-  tabs.forEach((tab, i) => {
-    const id = toClassName(tab.textContent);
-
-    // decorate tabpanel
-    const tabpanel = block.children[i];
-    tabpanel.className = 'tabs-panel';
-    tabpanel.id = `tabpanel-${id}`;
-    tabpanel.setAttribute('aria-hidden', !!i);
-    tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
-    tabpanel.setAttribute('role', 'tabpanel');
-
-    // build tab button
-    const button = document.createElement('button');
-    button.className = 'tabs-tab';
-    button.id = `tab-${id}`;
-
-    moveInstrumentation(tab.parentElement, tabpanel.lastElementChild);
-    button.innerHTML = tab.innerHTML;
-
-    button.setAttribute('aria-controls', `tabpanel-${id}`);
-    button.setAttribute('aria-selected', !i);
-    button.setAttribute('role', 'tab');
-    button.setAttribute('type', 'button');
-    button.addEventListener('click', () => {
-      block.querySelectorAll('[role=tabpanel]').forEach((panel) => {
-        panel.setAttribute('aria-hidden', true);
+  const tabs = [...block.children];
+  const sectionTitles = [];
+  if (tabs.length > 0) {
+    // Collect all .tab-section-title elements from all tabs
+    tabs.forEach((tab) => {
+      const titles = tab.querySelectorAll('.tab-section-title');
+      titles.forEach((title) => {
+        if (!sectionTitles.includes(title)) {
+          sectionTitles.push(title);
+        }
       });
-      tablist.querySelectorAll('button').forEach((btn) => {
-        btn.setAttribute('aria-selected', false);
-      });
-      tabpanel.setAttribute('aria-hidden', false);
-      button.setAttribute('aria-selected', true);
     });
-    tablist.append(button);
-    tab.remove();
-    moveInstrumentation(button.querySelector('p'), null);
-  });
 
+    // add tab style (horizontal or vertical)
+    const headers = tabs[0];
+    const tabStyle = headers.getAttribute('data-category');
+    if (tabStyle) {
+      block.classList.add(tabStyle);
+    }
+
+    tabs.forEach((tab, i) => {
+      const id = toClassName(tab.getAttribute('data-tabname'));
+      // decorate tabpanel
+      const tabpanel = block.children[i];
+      tabpanel.classList.add('tabs-panel');
+      tabpanel.id = `${block.id}_tabPane_${i}`;
+      // In Universal Editor, collapse all tabs initially; otherwise show first tab
+      tabpanel.setAttribute('aria-hidden', isInUniversalEditor ? 'true' : !!i);
+      tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
+      tabpanel.setAttribute('role', 'tabpanel');
+
+      // Move Universal Editor instrumentation from original tab to tabpanel
+      moveInstrumentation(tab, tabpanel);
+
+      // build tab button
+      const button = createTabButton(block, tab, tabpanel, tablist, i, isInUniversalEditor);
+      tablist.append(button);
+    });
+  }
   block.prepend(tablist);
+  // Prepend all sectionTitles after tablist so they appear first
+  // Reverse order to maintain original DOM order when prepending
+  sectionTitles.reverse().forEach((sectionTitle) => {
+    block.prepend(sectionTitle);
+  });
 }

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -1,6 +1,6 @@
 // eslint-disable-next-line import/no-unresolved
 import { toClassName } from '../../scripts/aem.js';
-import { getBlockId, moveInstrumentation } from '../../scripts/scripts.js';
+import { getBlockId } from '../../scripts/scripts.js';
 
 function fetchTabName(tab) {
   const tabTextWrapper = document.createElement('div');

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -13,14 +13,13 @@ function fetchTabName(tab) {
   return tabTextWrapper;
 }
 
-function createTabButton(block, tab, tabpanel, tablist, index, isInEditor = false) {
+function createTabButton(block, tab, tabpanel, tablist, index) {
   const button = document.createElement('button');
   button.className = 'tabs-tab';
   button.id = `${block.id}_tab_${index}`;
   button.innerHTML = fetchTabName(tab).innerHTML;
   button.setAttribute('aria-controls', tabpanel.id);
-  // In editor, all tabs start unselected; otherwise first tab is selected
-  button.setAttribute('aria-selected', isInEditor ? 'false' : !index);
+  button.setAttribute('aria-selected', !index);
   button.setAttribute('role', 'tab');
   button.setAttribute('type', 'button');
   button.addEventListener('click', () => {
@@ -38,10 +37,6 @@ function createTabButton(block, tab, tabpanel, tablist, index, isInEditor = fals
 
 export default async function decorate(block) {
   block.id = getBlockId('tabs');
-
-  // Check if we're in Universal Editor
-  const isInUniversalEditor = window.hlx?.isEditor === true
-    || !!document.querySelector('main[data-aue-resource]');
 
   // build tablist
   const tablist = document.createElement('div');
@@ -75,16 +70,12 @@ export default async function decorate(block) {
       const tabpanel = block.children[i];
       tabpanel.classList.add('tabs-panel');
       tabpanel.id = `${block.id}_tabPane_${i}`;
-      // In Universal Editor, collapse all tabs initially; otherwise show first tab
-      tabpanel.setAttribute('aria-hidden', isInUniversalEditor ? 'true' : !!i);
+      tabpanel.setAttribute('aria-hidden', !!i);
       tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
       tabpanel.setAttribute('role', 'tabpanel');
 
-      // Move Universal Editor instrumentation from original tab to tabpanel
-      moveInstrumentation(tab, tabpanel);
-
       // build tab button
-      const button = createTabButton(block, tab, tabpanel, tablist, i, isInUniversalEditor);
+      const button = createTabButton(block, tab, tabpanel, tablist, i);
       tablist.append(button);
     });
   }

--- a/component-models.json
+++ b/component-models.json
@@ -754,29 +754,6 @@
             "value": "",
             "valueType": "string",
             "description": "optional minimum height when in mobile, e.g. 400px"
-          },
-          {
-            "component": "reference",
-            "valueType": "string",
-            "name": "doodle-image-top",
-            "label": "Background accessory image - top",
-            "description": "Displayed at top left of the section",
-            "multi": false
-          },
-          {
-            "component": "reference",
-            "valueType": "string",
-            "name": "doodle-image-bottom",
-            "label": "Background accessory image - bottom",
-            "description": "Displayed at bottom right of the section",
-            "multi": false
-          },
-          {
-            "component": "boolean",
-            "valueType": "boolean",
-            "name": "doodle-reverse",
-            "label": "Reverse background accessory images",
-            "description": "Display at top right and bottom left of the section"
           }
         ]
       }

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -180,29 +180,6 @@
             "value": "",
             "valueType": "string",
             "description": "optional minimum height when in mobile, e.g. 400px"
-          },
-          {
-            "component": "reference",
-            "valueType": "string",
-            "name": "doodle-image-top",
-            "label": "Background accessory image - top",
-            "description": "Displayed at top left of the section",
-            "multi": false
-          },
-          {
-            "component": "reference",
-            "valueType": "string",
-            "name": "doodle-image-bottom",
-            "label": "Background accessory image - bottom",
-            "description": "Displayed at bottom right of the section",
-            "multi": false
-          },
-          {
-            "component": "boolean",
-            "valueType": "boolean",
-            "name": "doodle-reverse",
-            "label": "Reverse background accessory images",
-            "description": "Display at top right and bottom left of the section"
           }
             ]
           }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -386,6 +386,9 @@ function wrapTextNodes(block) {
   };
 
   block.querySelectorAll(':scope > div > div').forEach((blockColumn) => {
+    if (blockColumn.classList.contains('block-content') || blockColumn.classList.contains('default-content')) {
+      return; // skip re-wrapping block-content created via groupChildren in scripts.js
+    }
     if (blockColumn.hasChildNodes()) {
       const hasWrapper = !!blockColumn.firstElementChild
         && validWrappers.some((tagName) => blockColumn.firstElementChild.tagName === tagName);

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -242,14 +242,16 @@ async function applyChanges(event) {
           const [newSection] = newElements;
           newSection.style.display = 'none';
           element.insertAdjacentElement('afterend', newSection);
+          decorateSections(parentElement);
+
+          // added for multi-section blocks
+          if (element.closest('.tabs')) {
+            moveAllAttributes(element, newSection);
+          }
+          decorateBlocks(newSection);
           decorateButtons(newSection);
           decorateIcons(newSection);
           decorateRichtext(newSection);
-          decorateSections(parentElement);
-          if (element.closest('.tabs') || element.closest('.accordion')) {
-            moveAllAttributes(element, newSection);
-          }
-          decorateBlocks(parentElement);
           await loadSections(parentElement);
           element.remove();
           newSection.style.display = null;

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -242,16 +242,16 @@ async function applyChanges(event) {
           const [newSection] = newElements;
           newSection.style.display = 'none';
           element.insertAdjacentElement('afterend', newSection);
-          decorateSections(parentElement);
-
-          // added for multi-section blocks
-          if (element.closest('.tabs')) {
-            moveAllAttributes(element, newSection);
-          }
-          decorateBlocks(newSection);
           decorateButtons(newSection);
           decorateIcons(newSection);
           decorateRichtext(newSection);
+          decorateSections(parentElement);
+
+          // added for multi-section blocks
+          // if (element.closest('.tabs')) {
+          //   moveAllAttributes(element, newSection);
+          // }
+          decorateBlocks(parentElement);
           await loadSections(parentElement);
           element.remove();
           newSection.style.display = null;

--- a/scripts/editor-support.js
+++ b/scripts/editor-support.js
@@ -248,9 +248,9 @@ async function applyChanges(event) {
           decorateSections(parentElement);
 
           // added for multi-section blocks
-          // if (element.closest('.tabs')) {
-          //   moveAllAttributes(element, newSection);
-          // }
+          if (element.closest('.tabs')) {
+            moveAllAttributes(element, newSection);
+          }
           decorateBlocks(parentElement);
           await loadSections(parentElement);
           element.remove();


### PR DESCRIPTION
### New "multi-tab" section for content and blocks to be view inside tabs or accordions.

This takes multi-sections with the same name and gathers them together as tab or accordion content. The background options are reduced here but the styles that are used on SECTION ONE are used as the multi-section styles. 

The UE json was merged already, you can see it at https://github.com/aemsites/idfc/blob/main/models/_multi-section.json .

Once this is approved, the tabbed cards and accordions on Mayura will need to be reauthored.
There will no longer be a standalone tabs block that authors can use, but you can use standalone accordions.

Getting great scores.

To do: I wasn't really able to optimize what is going on in the UE yet, it seems I can't test my change to editor-support without merging.


Fix #563 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/tab-section
- After: https://563-tabsection--idfc--aemsites.aem.page/library/tab-section