### PR TITLE
Add entrance animation for sections on viewport entry

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -787,7 +787,7 @@ export function decorateSections(parent, isDoc) {
 }
 
 /**
- * swapna: Observes .section.entrance-animation and adds .is-visible when section enters viewport.
+ * Observes .section.entrance-animation and adds .is-visible when section enters viewport.
  * @param {Element} container - Element to search for sections (e.g. main)
  */
 function initEntranceAnimationObserver(container) {
@@ -798,7 +798,7 @@ function initEntranceAnimationObserver(container) {
       entries.forEach((entry) => {
         if (entry.isIntersecting) {
           entry.target.classList.add('is-visible');
-          observer.unobserve(entry.target); /* swapna: stop observing once animated */
+          observer.unobserve(entry.target); /* stop observing once animated */
         }
       });
     },
@@ -868,7 +868,7 @@ export function decorateMain(main) {
   decorateIcons(main);
   buildAutoBlocks(main);
   decorateSections(main);
-  /* swapna: Init entrance-animation observer (animate when in viewport) */
+  /* Init entrance-animation observer (animate when in viewport) */
   initEntranceAnimationObserver(main);
   decorateBlocks(main);
   buildEmbedBlocks(main);

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -786,6 +786,27 @@ export function decorateSections(parent, isDoc) {
   });
 }
 
+/**
+ * swapna: Observes .section.entrance-animation and adds .is-visible when section enters viewport.
+ * @param {Element} container - Element to search for sections (e.g. main)
+ */
+function initEntranceAnimationObserver(container) {
+  const sections = container?.querySelectorAll('.section.entrance-animation') || [];
+  if (sections.length === 0) return;
+  const observer = new IntersectionObserver(
+    (entries) => {
+      entries.forEach((entry) => {
+        if (entry.isIntersecting) {
+          entry.target.classList.add('is-visible');
+          observer.unobserve(entry.target); /* swapna: stop observing once animated */
+        }
+      });
+    },
+    { rootMargin: '0px 0px -50px 0px', threshold: 0 },
+  );
+  sections.forEach((section) => observer.observe(section));
+}
+
 export function buildTabSection(main) {
   const tabItems = main.querySelectorAll('div[data-tabSection]');
   if (tabItems.length > 0) {
@@ -847,6 +868,8 @@ export function decorateMain(main) {
   decorateIcons(main);
   buildAutoBlocks(main);
   decorateSections(main);
+  /* swapna: Init entrance-animation observer (animate when in viewport) */
+  initEntranceAnimationObserver(main);
   decorateBlocks(main);
   buildEmbedBlocks(main);
   decorateLinkedPictures(main);

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -967,6 +967,19 @@ body.is-framework-page .section.category-nav-section {
   overflow: visible !important;
 }
 
+/* swapna: Entrance animation - section starts off-screen and fades/slides in when in viewport */
+.section.entrance-animation {
+  opacity: 0;
+  transform: translateY(50px);
+  transition: opacity 2s, transform 2s;
+}
+
+/* swapna: Visible state when section has entered viewport (triggered by IntersectionObserver) */
+.section.entrance-animation.is-visible {
+  opacity: 1;
+  transform: translateY(0);
+}
+
 /* Base styles for sections with doodles */
 .section.has-doodles {
   position: relative;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -967,14 +967,14 @@ body.is-framework-page .section.category-nav-section {
   overflow: visible !important;
 }
 
-/* swapna: Entrance animation - section starts off-screen and fades/slides in when in viewport */
+/* Entrance animation - section starts off-screen and fades/slides in when in viewport */
 .section.entrance-animation {
   opacity: 0;
   transform: translateY(50px);
   transition: opacity 2s, transform 2s;
 }
 
-/* swapna: Visible state when section has entered viewport (triggered by IntersectionObserver) */
+/* Visible state when section has entered viewport (triggered by IntersectionObserver) */
 .section.entrance-animation.is-visible {
   opacity: 1;
   transform: translateY(0);


### PR DESCRIPTION
Implemented an IntersectionObserver to add a visibility class to sections with the 'entrance-animation' class when they enter the viewport. Updated CSS for initial hidden state and visible state transitions.

Fix #584

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://584-secanim--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
