### PR TITLE
Testimonial Cards Redux

### DIFF
--- a/blocks/cards-testimonial/cards-testimonial.css
+++ b/blocks/cards-testimonial/cards-testimonial.css
@@ -1,0 +1,364 @@
+/* stylelint-disable no-descending-specificity */
+
+/* =================================================================
+   TESTIMONIAL CARDS - aligned with old .cards.testimonial-card DOM
+   ================================================================= */
+
+.cards-testimonial > .grid-cards {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+}
+
+.cards-testimonial .grid-cards {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 2rem;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+/* Grid mode (no Swiper): same card look and dimensions as old testimonial cards */
+.cards-testimonial .grid-cards > .cards-card {
+  max-width: 326px;
+  background-color: var(--color-gray-300);
+  border-radius: 20px;
+  box-shadow: 0 4px 8px 2px rgb(37 36 59 / 15%);
+  padding: 34px 20px;
+  box-sizing: border-box;
+  color: var(--color-white);
+}
+
+.cards-testimonial .grid-cards > .cards-card:first-child {
+  background-color: var(--color-purple-400);
+  box-shadow: 0 8px 16px 4px rgb(37 36 59 / 25%);
+}
+
+.cards-testimonial .cards-card-body {
+  margin: 0;
+  color: var(--color-white);
+}
+
+.cards-testimonial .cards-card-image {
+  line-height: 0;
+}
+
+.cards-testimonial .grid-cards > .cards-card img {
+  width: 100%;
+  object-fit: cover;
+  border-radius: 6px;
+}
+
+/* Grid mode: card body text and icons (match Swiper slide styling) */
+.cards-testimonial .grid-cards .cards-card-body .testimonial-person-name,
+.cards-testimonial .grid-cards .cards-card-body .testimonial-date,
+.cards-testimonial .grid-cards .cards-card-body .testimonial-product-name,
+.cards-testimonial .grid-cards .cards-card-body h5,
+.cards-testimonial .grid-cards .cards-card-body h6,
+.cards-testimonial .grid-cards .cards-card-body p {
+  color: var(--color-white);
+}
+
+.cards-testimonial .grid-cards .cards-card-body .testimonial-person-name,
+.cards-testimonial .grid-cards .cards-card-body h5 {
+  font-size: var(--body-font-size-l);
+  font-weight: 500;
+  margin: 36px 0 11px;
+}
+
+.cards-testimonial .grid-cards .cards-card-body .testimonial-person-name + p,
+.cards-testimonial .grid-cards .cards-card-body h5 + p {
+  font-size: var(--body-font-size-s);
+  margin: 0 0 var(--spacing-xxs);
+}
+
+.cards-testimonial .grid-cards .cards-card-body .testimonial-product-name,
+.cards-testimonial .grid-cards .cards-card-body .testimonial-product-name u,
+.cards-testimonial .grid-cards .cards-card-body p u {
+  font-size: var(--body-font-size-s);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+/* Review text only; exclude person name, product, date */
+.cards-testimonial .grid-cards .cards-card-body p:not(
+  .testimonial-person-name,
+  .testimonial-product-name,
+  .testimonial-date,
+  :has(.icon-inverted-commas),
+  :has(.icon-star),
+  :has(u)
+) {
+  font-size: var(--body-font-size-m);
+  font-weight: 600;
+  line-height: normal;
+  margin: 0;
+}
+
+/* Person name: match old cards testimonial h5 (cards.css:1667) */
+.cards-testimonial .grid-cards .cards-card-body .testimonial-person-name {
+  font-size: var(--body-font-size-l);
+  font-weight: 500;
+  margin: 36px 0 11px;
+}
+
+.cards-testimonial .grid-cards .cards-card-body p:has(.icon-inverted-commas) {
+  margin: 0 0 16px;
+  line-height: 0;
+}
+
+.cards-testimonial .grid-cards .icon-inverted-commas img {
+  width: 20px;
+  height: 16.75px;
+}
+
+.cards-testimonial .grid-cards .cards-card-body p:has(.icon-star) {
+  display: flex;
+  margin: 0 0 var(--spacing-xs);
+}
+
+.cards-testimonial .grid-cards .icon-star,
+.cards-testimonial .grid-cards .icon-star-white,
+.cards-testimonial .grid-cards .icon-star-yellow {
+  display: inline-block;
+  width: auto;
+  height: 12px;
+  padding-right: 4px;
+}
+
+.cards-testimonial .grid-cards .cards-card-body .testimonial-date,
+.cards-testimonial .grid-cards .cards-card-body h6 {
+  font-size: var(--body-font-size-xs);
+  line-height: 1.5;
+  text-align: left;
+}
+
+.cards-testimonial .grid-cards .cards-card-body p:has(.icon-star) .icon-star:last-child,
+.cards-testimonial .grid-cards .cards-card-body h6:has(.icon-star) .icon-star:last-child {
+  padding-right: 16px;
+}
+
+/* Section: black background, white centered title (like old .cards-container) */
+.section:has(.cards-testimonial),
+.section:has(.testimonial-cards),
+.section.cards-testimonial-container {
+  background-color: var(--color-black);
+  margin: 0;
+  padding: 40px 0;
+}
+
+/* Center section content: use same container width as rest of site (main>.section>div) so section isn’t smaller and cards keep 326px. */
+.section:has(.cards-testimonial) .block-content.cards-testimonial-wrapper,
+.section:has(.testimonial-cards) .block-content.cards-testimonial-wrapper,
+.section.cards-testimonial-container .block-content.cards-testimonial-wrapper {
+  max-width: var(--grid-container-width);
+  margin-left: auto;
+  margin-right: auto;
+  padding-left: var(--grid-gutter-width);
+  padding-right: var(--grid-gutter-width);
+}
+
+.section:has(.cards-testimonial) h2,
+.section:has(.testimonial-cards) h2,
+.section.cards-testimonial-container h2 {
+  color: var(--color-white);
+  font-weight: 700;
+  text-align: center;
+}
+
+/* =================================================================
+   SWIPER - TESTIMONIAL
+   ================================================================= */
+
+.cards-testimonial.swiper {
+  width: 100%;
+  height: auto;
+  padding-bottom: var(--spacing-xl);
+  padding-top: var(--spacing-s);
+  position: relative;
+  overflow: hidden;
+}
+
+/* Match old .cards.testimonial-card.swiper: 1050px at 900px (same as .cards.swiper in cards.css) */
+@media (width >= 900px) {
+  .cards-testimonial.swiper {
+    max-width: 1050px;
+    margin-left: auto;
+    margin-right: auto;
+  }
+
+  .cards-testimonial.swiper .swiper-slide {
+    max-width: 326px;
+  }
+}
+
+/* Match old .cards.testimonial-card.swiper wrapper/slide styling */
+.cards-testimonial.swiper .swiper-wrapper {
+  display: flex;
+  flex-wrap: nowrap;
+  overflow: visible;
+  gap: 0;
+  scroll-behavior: smooth;
+  -webkit-overflow-scrolling: touch;
+  align-items: stretch;
+  cursor: grab;
+}
+
+/* Match old cards testimonial slide (no max-width on mobile; 326px only at 900px+) */
+.cards-testimonial.swiper .swiper-slide {
+  flex: 0 0 auto;
+  height: auto;
+  display: flex;
+  background-color: var(--color-gray-300);
+  border-radius: 20px;
+  box-shadow: 0 4px 8px 2px rgb(37 36 59 / 15%);
+  padding: 34px 20px;
+  flex-direction: column;
+  margin-right: 0;
+  box-sizing: border-box;
+  overflow: visible;
+  transition: all 0.5s ease;
+  transform: scale(0.9);
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card {
+  width: 100%;
+  margin-bottom: 0;
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card-body {
+  margin: 0;
+  color: var(--color-white);
+  position: relative;
+  z-index: 10;
+}
+
+.cards-testimonial.swiper .swiper-slide-active {
+  background-color: var(--color-purple-400);
+  transform: scale(1);
+  z-index: 10;
+  box-shadow: 0 8px 16px 4px rgb(37 36 59 / 25%);
+  transition: all 0.5s ease;
+}
+
+.cards-testimonial .swiper-pagination {
+  bottom: 20px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  gap: var(--spacing-xxs);
+}
+
+.cards-testimonial .swiper-pagination-bullet {
+  width: 10px;
+  height: 10px;
+  background: rgba(255 255 255 / 50%);
+  opacity: 1;
+  transition: all 0.3s ease;
+  border-radius: 50%;
+}
+
+.cards-testimonial .swiper-pagination-bullet-active {
+  width: 14px;
+  height: 14px;
+  background: var(--color-white);
+  border-radius: 50%;
+}
+
+.cards-testimonial.swiper .swiper-slide-active .cards-card-body {
+  z-index: 10;
+}
+
+/* Testimonial card text */
+.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-person-name,
+.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-date,
+.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-product-name,
+.cards-testimonial.swiper .swiper-slide .cards-card-body h5,
+.cards-testimonial.swiper .swiper-slide .cards-card-body h6,
+.cards-testimonial.swiper .swiper-slide .cards-card-body p {
+  color: var(--color-white);
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-person-name,
+.cards-testimonial.swiper .swiper-slide .cards-card-body h5 {
+  font-size: var(--body-font-size-l);
+  font-weight: 500;
+  margin: 36px 0 11px;
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-person-name + p,
+.cards-testimonial.swiper .swiper-slide .cards-card-body h5 + p {
+  font-size: var(--body-font-size-s);
+  margin: 0 0 var(--spacing-xxs);
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-product-name,
+.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-product-name u,
+.cards-testimonial.swiper .swiper-slide .cards-card-body p u {
+  font-size: var(--body-font-size-s);
+  text-decoration: none;
+  font-weight: 700;
+}
+
+/* Review text paragraph only (exclude person name, product, date so their margins apply) */
+.cards-testimonial.swiper .swiper-slide .cards-card-body p:not(
+  .testimonial-person-name,
+  .testimonial-product-name,
+  .testimonial-date,
+  :has(.icon-inverted-commas),
+  :has(.icon-star),
+  :has(u)
+) {
+  font-size: var(--body-font-size-m);
+  font-weight: 600;
+  line-height: normal;
+  margin: 0;
+}
+
+/* Person name: match old cards testimonial h5 (cards.css:1667) */
+.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-person-name {
+  font-size: var(--body-font-size-l);
+  font-weight: 500;
+  margin: 36px 0 11px;
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card-body p:has(.icon-inverted-commas) {
+  margin: 0 0 16px;
+  line-height: 0;
+}
+
+.cards-testimonial.swiper .swiper-slide .icon-inverted-commas img {
+  width: 20px;
+  height: 16.75px;
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card-body p:has(.icon-star) {
+  display: flex;
+  margin: 0 0 var(--spacing-xs);
+}
+
+.cards-testimonial.swiper .swiper-slide .icon-star,
+.cards-testimonial.swiper .swiper-slide .icon-star-white,
+.cards-testimonial.swiper .swiper-slide .icon-star-yellow {
+  display: inline-block;
+  width: auto;
+  height: 12px;
+  padding-right: 4px;
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-date,
+.cards-testimonial.swiper .swiper-slide .cards-card-body h6 {
+  font-size: var(--body-font-size-xs);
+  line-height: 1.5;
+  text-align: left;
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card-body p:has(.icon-star) .icon-star:last-child,
+.cards-testimonial.swiper .swiper-slide h6:has(.icon-star) .icon-star:last-child {
+  padding-right: 16px;
+}
+
+.cards-testimonial.swiper .swiper-slide .cards-card-body:empty {
+  display: none;
+}

--- a/blocks/cards-testimonial/cards-testimonial.js
+++ b/blocks/cards-testimonial/cards-testimonial.js
@@ -1,0 +1,722 @@
+import {
+  createOptimizedPicture, loadScript, loadCSS, getMetadata,
+} from '../../scripts/aem.js';
+import { moveInstrumentation } from '../../scripts/scripts.js';
+
+function sanitizeText(text) {
+  if (!text) return '';
+  return (
+    String(text)
+      // eslint-disable-next-line no-control-regex
+      .replace(/[\x00-\x1F\x7F-\x9F]/g, '')
+      .replace(/\s+/g, ' ')
+      .replace(/[\u2018\u2019]/g, "'")
+      .replace(/[\u201C\u201D]/g, '"')
+      .replace(/[\u2013\u2014]/g, '-')
+      .replace(/\u2026/g, '...')
+      .trim()
+  );
+}
+
+function parseReviewDateToISO(dateText) {
+  if (!dateText || !String(dateText).trim()) return '';
+  const trimmed = String(dateText).trim();
+  if (/^\d{4}-\d{2}-\d{2}$/.test(trimmed)) return trimmed;
+  const dateOnlyMatch = trimmed.match(/^(\d{4}-\d{2}-\d{2})/);
+  if (dateOnlyMatch) return dateOnlyMatch[1];
+  try {
+    const parsed = new Date(trimmed);
+    if (!Number.isNaN(parsed.getTime()) && parsed.getFullYear() > 2000) {
+      return parsed.toISOString().split('T')[0];
+    }
+  } catch (e) { /* ignore */ }
+  return '';
+}
+
+function formatDateForDisplay(isoDate) {
+  if (!isoDate || !/^\d{4}-\d{2}-\d{2}$/.test(String(isoDate).trim())) return isoDate || '';
+  try {
+    const d = new Date(`${String(isoDate).trim()}T12:00:00`);
+    if (Number.isNaN(d.getTime())) return isoDate;
+    return d.toLocaleDateString('en-US', { year: 'numeric', month: 'long', day: 'numeric' });
+  } catch (e) { return isoDate; }
+}
+
+function generateTestimonialSchema(block) {
+  const testimonials = [];
+  const cards = block.querySelectorAll('.cards-card');
+  cards.forEach((card) => {
+    const cardBody = card.querySelector('.cards-card-body');
+    if (!cardBody) return;
+    let authorName = sanitizeText(card.getAttribute('data-person-name') || '');
+    let productName = sanitizeText(card.getAttribute('data-product-name') || 'IDFC FIRST Bank Credit Card');
+    let ratingValue = parseInt(card.getAttribute('data-author-rating'), 10) || 0;
+    let datePublished = parseReviewDateToISO(card.getAttribute('data-review-date') || '');
+    if (!authorName) {
+      const authorEl = cardBody.querySelector('.testimonial-person-name') || cardBody.querySelector('h5');
+      authorName = sanitizeText(authorEl ? authorEl.textContent : '');
+    }
+    if (!productName || productName === 'IDFC FIRST Bank Credit Card') {
+      const productEl = cardBody.querySelector('.testimonial-product-name u') || cardBody.querySelector('p u');
+      productName = sanitizeText(productEl ? productEl.textContent : 'IDFC FIRST Bank Credit Card');
+    }
+    if (ratingValue <= 0) {
+      const starIcons = cardBody.querySelectorAll('[class*="icon-star"]');
+      ratingValue = starIcons.length;
+    }
+    const paragraphs = cardBody.querySelectorAll('p');
+    let reviewText = '';
+    paragraphs.forEach((p, index) => {
+      if (p.classList.contains('testimonial-person-name') || p.classList.contains('testimonial-date')
+          || p.classList.contains('testimonial-product-name')) return;
+      if (index > 0 && !p.querySelector('u') && !p.querySelector('.icon-inverted-commas')
+          && !p.querySelector('[class*="icon-star"]')) {
+        reviewText += p.textContent.trim();
+      }
+    });
+    reviewText = sanitizeText(reviewText);
+    if (!datePublished) {
+      const dateEl = cardBody.querySelector('.testimonial-date') || cardBody.querySelector('h6');
+      const dateText = dateEl ? dateEl.textContent : '';
+      const dateParts = dateText.split('|');
+      const dateString = dateParts.length > 1 ? dateParts[1].trim() : dateText.trim();
+      datePublished = parseReviewDateToISO(dateString);
+    }
+    if (!datePublished) {
+      [datePublished] = new Date().toISOString().split('T');
+    }
+    if (reviewText && authorName && ratingValue > 0) {
+      testimonials.push({
+        '@type': 'Review',
+        reviewBody: reviewText,
+        reviewRating: { '@type': 'Rating', ratingValue: ratingValue.toString(), bestRating: '5' },
+        author: { '@type': 'Person', name: authorName },
+        datePublished,
+        itemReviewed: { '@type': 'Product', name: productName },
+      });
+    }
+  });
+  if (testimonials.length === 0) return null;
+  const totalRating = testimonials.reduce(
+    (sum, t) => sum + parseInt(t.reviewRating.ratingValue, 10),
+    0,
+  );
+  const avgRating = (totalRating / testimonials.length).toFixed(1);
+  const pageTitle = document.title || 'IDFC FIRST Bank Credit Card';
+  const pageDescription = getMetadata('description')
+    || getMetadata('og:description')
+    || 'Apply for Credit Card at IDFC FIRST Bank with exclusive benefits and rewards.';
+  const canonicalLink = document.querySelector('link[rel="canonical"]');
+  const pageUrl = canonicalLink?.href || getMetadata('og:url') || window.location.href;
+  const pageImage = getMetadata('og:image');
+  const publishedTime = getMetadata('published-time');
+  const modifiedTime = getMetadata('modified-time');
+  const category = getMetadata('breadcrumbstitle');
+  let brandName = 'IDFC FIRST Bank';
+  if (pageTitle.includes('IDFC')) {
+    const titleParts = pageTitle.split('|');
+    if (titleParts.length > 1) brandName = titleParts[1].trim();
+  }
+  let schemaProductName = pageTitle;
+  if (pageTitle.includes('|')) {
+    [schemaProductName] = pageTitle.split('|');
+    schemaProductName = schemaProductName.trim();
+  }
+  const schema = {
+    '@context': 'https://schema.org',
+    '@type': 'Product',
+    name: schemaProductName,
+    description: pageDescription,
+    brand: { '@type': 'Brand', name: brandName },
+    aggregateRating: {
+      '@type': 'AggregateRating',
+      ratingValue: avgRating,
+      ratingCount: testimonials.length.toString(),
+      reviewCount: testimonials.length.toString(),
+    },
+    review: testimonials,
+  };
+  if (pageUrl) schema.url = pageUrl;
+  if (pageImage) schema.image = pageImage;
+  if (publishedTime) schema.datePublished = publishedTime;
+  if (modifiedTime) schema.dateModified = modifiedTime;
+  if (category) schema.category = category;
+  return schema;
+}
+
+function injectSchema(schema) {
+  if (!schema) return;
+  document.querySelectorAll(
+    'script[type="application/ld+json"][data-schema-type="testimonial"], script[type="application/ld+json"][data-error]',
+  ).forEach((script) => script.remove());
+  if (window.testimonialSchemaInjected) return;
+  try {
+    const jsonString = JSON.stringify(schema, null, 2);
+    JSON.parse(jsonString);
+    const script = document.createElement('script');
+    script.type = 'application/ld+json';
+    script.setAttribute('data-schema-type', 'testimonial');
+    script.text = jsonString;
+    document.head.appendChild(script);
+    window.testimonialSchemaInjected = true;
+    setTimeout(() => {
+      document.querySelectorAll('script[type="application/ld+json"][data-error]').forEach((s) => s.remove());
+    }, 500);
+  } catch (error) {
+    // eslint-disable-next-line no-console
+    console.error('Failed to inject JSON-LD schema:', error);
+  }
+}
+
+const PROPERTY_FIELDS = ['swipable', 'autoplayEnabled', 'startingCard'];
+const DEFAULT_PRODUCT = 'IDFC FIRST Bank Credit Card';
+
+function parsePropertyValue(fieldName, text) {
+  const t = String(text).trim();
+  if (fieldName === 'swipable' || fieldName === 'autoplayEnabled') {
+    return (t === 'true' || t === 'false') ? t : null;
+  }
+  if (fieldName === 'startingCard') {
+    return (t !== '' && !Number.isNaN(Number(t))) ? t : null;
+  }
+  return null;
+}
+
+/**
+ * Extracts block-level Swiper settings from placeholder cards (config rows).
+ */
+function extractBlockProperties(block, cardsContainer) {
+  const propertyValues = {};
+  const itemsToRemove = [];
+  const items = [...cardsContainer.querySelectorAll('.cards-card')];
+  let cardIndex = 0;
+  let propertyIndex = 0;
+
+  while (cardIndex < items.length && propertyIndex < PROPERTY_FIELDS.length) {
+    const cardItem = items[cardIndex];
+    const fieldName = PROPERTY_FIELDS[propertyIndex];
+    const isEmpty = !cardItem.textContent.trim() && !cardItem.querySelector('picture, img');
+
+    if (isEmpty) {
+      itemsToRemove.push(cardItem);
+      cardIndex += 1;
+      propertyIndex += 1;
+    } else {
+      const paragraphs = cardItem.querySelectorAll('p');
+      const hasPicture = cardItem.querySelector('picture');
+      const hasHeading = cardItem.querySelector('h1, h2, h3, h4, h5, h6');
+      const isTextOnly = paragraphs.length === 1 && !hasPicture && !hasHeading;
+
+      if (isTextOnly) {
+        const value = parsePropertyValue(fieldName, paragraphs[0].textContent);
+        if (value != null) {
+          propertyValues[fieldName] = value;
+          itemsToRemove.push(cardItem);
+          cardIndex += 1;
+          propertyIndex += 1;
+        } else {
+          propertyIndex += 1;
+        }
+      } else if (paragraphs.length >= 3 && !hasPicture && !hasHeading) {
+        const texts = [...paragraphs].slice(0, 3).map((p) => p.textContent.trim());
+        const allValid = PROPERTY_FIELDS.slice(0, 3).every(
+          (name, i) => parsePropertyValue(name, texts[i]),
+        );
+        if (allValid) {
+          const [swipableVal, autoplayVal, startingVal] = texts;
+          propertyValues.swipable = swipableVal;
+          propertyValues.autoplayEnabled = autoplayVal;
+          propertyValues.startingCard = startingVal;
+          itemsToRemove.push(cardItem);
+          cardIndex += 1;
+          propertyIndex = PROPERTY_FIELDS.length;
+        }
+        break;
+      } else {
+        break;
+      }
+    }
+  }
+
+  Object.keys(propertyValues).forEach((key) => {
+    block.dataset[key] = propertyValues[key];
+  });
+  itemsToRemove.forEach((cardItem) => cardItem.remove());
+}
+
+function createQuoteIconElement() {
+  const p = document.createElement('p');
+  const span = document.createElement('span');
+  span.className = 'icon icon-inverted-commas';
+  const img = document.createElement('img');
+  img.setAttribute('data-icon-name', 'inverted-commas');
+  img.src = '/icons/inverted-commas.svg';
+  img.alt = '';
+  img.loading = 'lazy';
+  img.width = 18;
+  img.height = 15;
+  span.appendChild(img);
+  p.appendChild(span);
+  return p;
+}
+
+function createStarRatingElement(rating, formattedDate = '') {
+  const p = document.createElement('p');
+  const count = Math.min(5, Math.max(0, parseInt(Number(rating), 10) || 0));
+  for (let i = 0; i < count; i += 1) {
+    const span = document.createElement('span');
+    span.className = 'icon icon-star icon-star-yellow';
+    const img = document.createElement('img');
+    img.setAttribute('data-icon-name', 'star-yellow');
+    img.src = '/icons/star-yellow.svg';
+    img.alt = '';
+    img.loading = 'lazy';
+    img.width = 12;
+    img.height = 11;
+    span.appendChild(img);
+    p.appendChild(span);
+  }
+  if (formattedDate) {
+    p.appendChild(document.createTextNode(` | ${formattedDate}`));
+  }
+  return p;
+}
+
+const looksLikeQuoteColumn = (text) => {
+  const t = String(text).trim().toLowerCase();
+  return t === '' || t === 'inverted-commas' || t === 'none';
+};
+
+/** Layout configs for 7/6/5 body-div structures. Indices into bodyDivs. */
+const STRUCTURED_LAYOUTS = [
+  {
+    length: 7,
+    hasContent: (d) => d[1].textContent.trim() || d[2].textContent.trim()
+      || d[3].textContent.trim(),
+    quoteIdx: 1,
+    reviewIdx: 2,
+    personIdx: 3,
+    productIdx: 4,
+    ratingIdx: 5,
+    dateIdx: 6,
+  },
+  {
+    length: 6,
+    hasContent: (d) => d[0].textContent.trim() || d[1].textContent.trim()
+      || d[2].textContent.trim(),
+    quoteIdx: 0,
+    reviewIdx: 1,
+    personIdx: 2,
+    productIdx: 3,
+    ratingIdx: 4,
+    dateIdx: 5,
+  },
+  {
+    length: 5,
+    hasContent: (d) => !looksLikeQuoteColumn(d[0].textContent)
+      && (d[0].textContent.trim() || d[1].textContent.trim()),
+    quoteVal: 'none',
+    reviewIdx: 0,
+    personIdx: 1,
+    productIdx: 2,
+    ratingIdx: 3,
+    dateIdx: 4,
+  },
+  {
+    length: 5,
+    hasContent: (d) => looksLikeQuoteColumn(d[0].textContent)
+      && (d[1].textContent.trim() || d[2].textContent.trim()),
+    quoteIdx: 0,
+    reviewIdx: null,
+    personIdx: 1,
+    productIdx: 2,
+    ratingIdx: 3,
+    dateIdx: 4,
+  },
+];
+
+function applyLegacyNormalization(cardItem, mainBody) {
+  if (!mainBody.querySelector('.icon-inverted-commas')) {
+    cardItem.setAttribute('data-quote-icon', 'none');
+  }
+  const authorEl = mainBody.querySelector('h5');
+  if (authorEl) {
+    const name = sanitizeText(authorEl.textContent);
+    const p = document.createElement('p');
+    p.className = 'testimonial-person-name';
+    p.textContent = name;
+    authorEl.replaceWith(p);
+    cardItem.setAttribute('data-person-name', name);
+  }
+  const dateEl = mainBody.querySelector('h6');
+  if (dateEl) {
+    const dt = sanitizeText(dateEl.textContent);
+    const p = document.createElement('p');
+    p.className = 'testimonial-date';
+    p.textContent = dt;
+    dateEl.replaceWith(p);
+    cardItem.setAttribute('data-review-date', dt);
+  }
+  const productEl = mainBody.querySelector('p u');
+  if (productEl) {
+    const name = sanitizeText(productEl.textContent);
+    const parentP = productEl.closest('p');
+    if (parentP && !parentP.classList.contains('testimonial-product-name')) {
+      parentP.classList.add('testimonial-product-name');
+    }
+    cardItem.setAttribute('data-product-name', name);
+  }
+  const starIcons = mainBody.querySelectorAll('[class*="icon-star"]');
+  if (starIcons.length > 0) {
+    cardItem.setAttribute('data-author-rating', String(starIcons.length));
+  }
+}
+
+/**
+ * Normalizes testimonial card structure to match old .cards.testimonial-card DOM.
+ */
+function normalizeTestimonialCard(cardItem) {
+  const bodyDivs = [...cardItem.querySelectorAll('.cards-card-body')];
+  if (bodyDivs.length === 0) return;
+
+  const mainBody = bodyDivs[0];
+  const layout = STRUCTURED_LAYOUTS.find(
+    (l) => bodyDivs.length === l.length && l.hasContent(bodyDivs),
+  );
+
+  let quoteIconVal;
+
+  if (!layout) {
+    applyLegacyNormalization(cardItem, mainBody);
+    return;
+  }
+
+  if (layout.quoteVal !== undefined) {
+    quoteIconVal = layout.quoteVal;
+  } else {
+    quoteIconVal = bodyDivs[layout.quoteIdx].textContent.trim().toLowerCase();
+  }
+  const reviewHtml = layout.reviewIdx != null ? bodyDivs[layout.reviewIdx].innerHTML : '';
+  const personName = sanitizeText(bodyDivs[layout.personIdx].textContent);
+  const productName = sanitizeText(bodyDivs[layout.productIdx].textContent) || DEFAULT_PRODUCT;
+  const ratingRaw = bodyDivs[layout.ratingIdx].textContent.trim();
+  const dateText = bodyDivs[layout.dateIdx].textContent.trim();
+
+  const quoteIcon = (quoteIconVal === 'inverted-commas') ? 'inverted-commas' : 'none';
+  const ratingNum = parseInt(ratingRaw, 10);
+  const authorRating = (Number.isNaN(ratingNum) || ratingNum < 1 || ratingNum > 5) ? 5 : ratingNum;
+  const isoDate = /^\d{4}-\d{2}-\d{2}$/.test(dateText.trim())
+    ? dateText.trim() : parseReviewDateToISO(dateText) || dateText;
+  const formattedDate = formatDateForDisplay(isoDate) || dateText;
+
+  const newBody = document.createElement('div');
+  newBody.className = 'cards-card-body';
+  if (quoteIcon === 'inverted-commas') {
+    newBody.appendChild(createQuoteIconElement());
+  }
+  cardItem.setAttribute('data-quote-icon', quoteIcon);
+  if (reviewHtml && reviewHtml.trim()) {
+    const reviewWrapper = document.createElement('div');
+    reviewWrapper.innerHTML = reviewHtml;
+    newBody.append(...reviewWrapper.childNodes);
+  }
+  const pPerson = document.createElement('p');
+  pPerson.className = 'testimonial-person-name';
+  pPerson.textContent = personName;
+  newBody.appendChild(pPerson);
+  const pProduct = document.createElement('p');
+  pProduct.className = 'testimonial-product-name';
+  const u = document.createElement('u');
+  u.textContent = productName;
+  pProduct.appendChild(u);
+  newBody.appendChild(pProduct);
+  newBody.appendChild(createStarRatingElement(authorRating, formattedDate));
+  cardItem.setAttribute('data-person-name', personName);
+  cardItem.setAttribute('data-product-name', productName);
+  cardItem.setAttribute('data-author-rating', String(authorRating));
+  cardItem.setAttribute('data-review-date', isoDate);
+
+  bodyDivs.forEach((div) => div.remove());
+  const imageDiv = cardItem.querySelector('.cards-card-image');
+  if (imageDiv) {
+    cardItem.insertBefore(newBody, imageDiv.nextSibling);
+  } else {
+    cardItem.appendChild(newBody);
+  }
+}
+
+export default async function decorate(block) {
+  block.classList.add('cards-testimonial', 'testimonial-card');
+
+  const cardsContainer = document.createElement('div');
+  cardsContainer.classList.add('grid-cards');
+  const rows = [...block.children];
+
+  rows.forEach((row) => {
+    const cardItem = document.createElement('div');
+    cardItem.classList.add('cards-card');
+    moveInstrumentation(row, cardItem);
+    while (row.firstElementChild) cardItem.append(row.firstElementChild);
+    const divsToRemove = [];
+    [...cardItem.children].forEach((div) => {
+      if (div.children.length === 1 && div.querySelector('picture')) {
+        div.className = 'cards-card-image';
+      } else if (div.children.length > 0 || div.textContent.trim().length > 0) {
+        div.className = 'cards-card-body';
+      } else {
+        divsToRemove.push(div);
+      }
+    });
+    divsToRemove.forEach((div) => div.remove());
+    cardsContainer.append(cardItem);
+  });
+
+  cardsContainer.querySelectorAll('picture > img').forEach((img) => {
+    const optimizedPic = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
+    const optimizedImg = optimizedPic.querySelector('img');
+    moveInstrumentation(img, optimizedImg);
+    const width = img.getAttribute('width');
+    const height = img.getAttribute('height');
+    if (width && height) {
+      optimizedImg.setAttribute('width', width);
+      optimizedImg.setAttribute('height', height);
+    } else if (img.closest('.swiper-slide')) {
+      optimizedImg.setAttribute('width', '232');
+      optimizedImg.setAttribute('height', '358');
+    }
+    img.closest('picture').replaceWith(optimizedPic);
+  });
+
+  block.replaceChildren(cardsContainer);
+  extractBlockProperties(block, cardsContainer);
+
+  const section = block.closest('.section');
+  const blockContent = block.closest('.block-content');
+  [blockContent, section].filter(Boolean).forEach((el) => {
+    const { dataset } = el;
+    if (block.dataset.swipable === undefined && dataset.swipable !== undefined) {
+      block.dataset.swipable = dataset.swipable;
+    }
+    if (block.dataset.autoplayEnabled === undefined && dataset.autoplayEnabled !== undefined) {
+      block.dataset.autoplayEnabled = dataset.autoplayEnabled;
+    }
+    if (block.dataset.startingCard === undefined && dataset.startingCard !== undefined) {
+      block.dataset.startingCard = dataset.startingCard;
+    }
+  });
+
+  cardsContainer.querySelectorAll('.cards-card').forEach((cardItem) => normalizeTestimonialCard(cardItem));
+  block.append(cardsContainer);
+
+  const isSwipable = block.dataset.swipable === 'true';
+  const isAutoplayEnabled = block.dataset.autoplayEnabled === 'true';
+  const startingCard = parseInt(block.dataset.startingCard || '0', 10);
+
+  if (!isSwipable) {
+    window.requestAnimationFrame(() => {
+      block.querySelectorAll('img').forEach((img) => {
+        if (img.hasAttribute('width') && img.hasAttribute('height')) return;
+        const rect = img.getBoundingClientRect();
+        if (rect.width > 0 && rect.height > 0) {
+          img.setAttribute('width', Math.round(rect.width));
+          img.setAttribute('height', Math.round(rect.height));
+        }
+      });
+    });
+    injectSchema(generateTestimonialSchema(block));
+    return;
+  }
+
+  await loadCSS('/scripts/swiperjs/swiper-bundle.min.css');
+  await loadScript('/scripts/swiperjs/swiper-bundle.min.js');
+
+  const waitForSwiper = () => new Promise((resolve) => {
+    if (typeof Swiper !== 'undefined') {
+      resolve();
+    } else {
+      const checkInterval = setInterval(() => {
+        if (typeof Swiper !== 'undefined') {
+          clearInterval(checkInterval);
+          resolve();
+        }
+      }, 10);
+      setTimeout(() => {
+        clearInterval(checkInterval);
+        resolve();
+      }, 2000);
+    }
+  });
+  await waitForSwiper();
+
+  if (typeof Swiper === 'undefined') {
+    injectSchema(generateTestimonialSchema(block));
+    return;
+  }
+
+  block.classList.add('swiper');
+  cardsContainer.classList.add('swiper-wrapper');
+  cardsContainer.classList.remove('grid-cards');
+  cardsContainer.querySelectorAll('.cards-card').forEach((cardItem) => cardItem.classList.add('swiper-slide'));
+
+  const swiperPagination = document.createElement('div');
+  swiperPagination.className = 'swiper-pagination';
+  block.appendChild(swiperPagination);
+
+  const slideCount = cardsContainer.querySelectorAll('.cards-card').length;
+  const isMobileView = window.innerWidth < 600;
+  const initialSlideIndex = isMobileView ? 0 : startingCard;
+  const isMayuraTemplate = document.body.classList.contains('mayura');
+
+  const swiperConfig = {
+    loop: false,
+    watchSlidesProgress: true,
+    watchSlidesVisibility: true,
+    slidesPerView: 1.3,
+    spaceBetween: 16,
+    centeredSlides: true,
+    initialSlide: initialSlideIndex,
+    pagination: {
+      el: '.swiper-pagination',
+      type: isMayuraTemplate ? 'progressbar' : 'bullets',
+      clickable: !isMayuraTemplate,
+      dynamicBullets: false,
+    },
+    breakpoints: {
+      600: { slidesPerView: 1.5, spaceBetween: 20, centeredSlides: true },
+      900: { slidesPerView: 3, spaceBetween: 36, centeredSlides: true },
+    },
+  };
+  if (isAutoplayEnabled) {
+    swiperConfig.autoplay = {
+      delay: 3000,
+      disableOnInteraction: false,
+      pauseOnMouseEnter: true,
+    };
+  }
+
+  // eslint-disable-next-line no-undef
+  const swiper = new Swiper(block, swiperConfig);
+  block.swiperInstance = swiper;
+
+  let updateScheduled = false;
+  const updateStarIcons = () => {
+    if (updateScheduled) return;
+    updateScheduled = true;
+    requestAnimationFrame(() => {
+      updateScheduled = false;
+      const slides = block.querySelectorAll('.swiper-slide');
+      const activeSlide = block.querySelector('.swiper-slide-active');
+      slides.forEach((slide) => {
+        const isActive = slide === activeSlide;
+        const iconSrc = isActive ? '/icons/star-yellow.svg' : '/icons/star-white.svg';
+        const iconName = isActive ? 'star-yellow' : 'star-white';
+        slide.querySelectorAll('[class*="icon-star"] img').forEach((img) => {
+          const currentSrc = img.getAttribute('src');
+          if (currentSrc && currentSrc.includes('star')) {
+            img.setAttribute('src', iconSrc);
+            img.setAttribute('data-icon-name', iconName);
+          }
+        });
+      });
+    });
+  };
+  updateStarIcons();
+  swiper.on('slideChange', updateStarIcons);
+  swiper.on('slideChangeTransitionEnd', updateStarIcons);
+
+  if (isMayuraTemplate) {
+    const paginationEl = block.querySelector('.swiper-pagination');
+    if (paginationEl) {
+      if (!window.swiperHandleDragState) {
+        window.swiperHandleDragState = {
+          isDragging: false,
+          activeSwiper: null,
+          activePagination: null,
+          activeSlideCount: 0,
+        };
+        document.addEventListener('mousemove', (e) => {
+          const state = window.swiperHandleDragState;
+          if (!state.isDragging || !state.activePagination) return;
+          const handle = state.activePagination.querySelector('.swiper-pagination-handle');
+          if (!handle) return;
+          const { clientX } = e;
+          const rect = state.activePagination.getBoundingClientRect();
+          const percentage = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+          handle.style.left = `${percentage * 100}%`;
+          state.activeSwiper.slideTo(Math.round(percentage * (state.activeSlideCount - 1)), 0);
+        });
+        document.addEventListener('touchmove', (e) => {
+          const state = window.swiperHandleDragState;
+          if (!state.isDragging || !state.activePagination) return;
+          const handle = state.activePagination.querySelector('.swiper-pagination-handle');
+          if (!handle) return;
+          const { clientX } = e.touches[0];
+          const rect = state.activePagination.getBoundingClientRect();
+          const percentage = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
+          handle.style.left = `${percentage * 100}%`;
+          state.activeSwiper.slideTo(Math.round(percentage * (state.activeSlideCount - 1)), 0);
+        }, { passive: true });
+        const handleGlobalDragEnd = () => {
+          const state = window.swiperHandleDragState;
+          if (!state.isDragging) return;
+          const handle = state.activePagination?.querySelector('.swiper-pagination-handle');
+          if (handle) {
+            handle.style.transition = 'left 0.3s ease';
+            handle.style.cursor = 'grab';
+          }
+          document.body.style.userSelect = '';
+          state.isDragging = false;
+          state.activeSwiper = null;
+          state.activePagination = null;
+          state.activeSlideCount = 0;
+        };
+        document.addEventListener('mouseup', handleGlobalDragEnd);
+        document.addEventListener('touchend', handleGlobalDragEnd);
+      }
+      const handleDragStart = (e) => {
+        const state = window.swiperHandleDragState;
+        state.isDragging = true;
+        state.activeSwiper = swiper;
+        state.activePagination = paginationEl;
+        state.activeSlideCount = slideCount;
+        const handle = e.currentTarget;
+        handle.style.transition = 'none';
+        handle.style.cursor = 'grabbing';
+        document.body.style.userSelect = 'none';
+        e.preventDefault();
+      };
+      const createHandle = () => {
+        const handle = document.createElement('div');
+        handle.className = 'swiper-pagination-handle';
+        handle.innerHTML = '<img src="/icons/scrollbar-handle.svg" alt="" width="28" height="8">';
+        handle.addEventListener('mousedown', handleDragStart);
+        handle.addEventListener('touchstart', handleDragStart, { passive: false });
+        return handle;
+      };
+      paginationEl.appendChild(createHandle());
+      const updateHandlePosition = () => {
+        let handle = paginationEl.querySelector('.swiper-pagination-handle');
+        if (!handle) {
+          handle = createHandle();
+          paginationEl.appendChild(handle);
+        }
+        const { progress } = swiper;
+        handle.style.left = `${Math.max(0, Math.min(1, progress)) * 100}%`;
+      };
+      updateHandlePosition();
+      swiper.on('progress', updateHandlePosition);
+      swiper.on('slideChange', updateHandlePosition);
+      swiper.on('resize', updateHandlePosition);
+      swiper.on('breakpoint', updateHandlePosition);
+      paginationEl.style.cursor = 'pointer';
+      paginationEl.addEventListener('click', (e) => {
+        if (e.target.closest('.swiper-pagination-handle')) return;
+        const rect = paginationEl.getBoundingClientRect();
+        const targetSlide = Math.round(((e.clientX - rect.left) / rect.width) * (slideCount - 1));
+        swiper.slideTo(targetSlide);
+      });
+    }
+  }
+
+  injectSchema(generateTestimonialSchema(block));
+}

--- a/blocks/cards-testimonial/cards-testimonial.js
+++ b/blocks/cards-testimonial/cards-testimonial.js
@@ -562,10 +562,8 @@ export default async function decorate(block) {
   swiperPagination.className = 'swiper-pagination';
   block.appendChild(swiperPagination);
 
-  const slideCount = cardsContainer.querySelectorAll('.cards-card').length;
   const isMobileView = window.innerWidth < 600;
   const initialSlideIndex = isMobileView ? 0 : startingCard;
-  const isMayuraTemplate = document.body.classList.contains('mayura');
 
   const swiperConfig = {
     loop: false,
@@ -577,8 +575,8 @@ export default async function decorate(block) {
     initialSlide: initialSlideIndex,
     pagination: {
       el: '.swiper-pagination',
-      type: isMayuraTemplate ? 'progressbar' : 'bullets',
-      clickable: !isMayuraTemplate,
+      type: 'bullets',
+      clickable: true,
       dynamicBullets: false,
     },
     breakpoints: {
@@ -623,100 +621,6 @@ export default async function decorate(block) {
   updateStarIcons();
   swiper.on('slideChange', updateStarIcons);
   swiper.on('slideChangeTransitionEnd', updateStarIcons);
-
-  if (isMayuraTemplate) {
-    const paginationEl = block.querySelector('.swiper-pagination');
-    if (paginationEl) {
-      if (!window.swiperHandleDragState) {
-        window.swiperHandleDragState = {
-          isDragging: false,
-          activeSwiper: null,
-          activePagination: null,
-          activeSlideCount: 0,
-        };
-        document.addEventListener('mousemove', (e) => {
-          const state = window.swiperHandleDragState;
-          if (!state.isDragging || !state.activePagination) return;
-          const handle = state.activePagination.querySelector('.swiper-pagination-handle');
-          if (!handle) return;
-          const { clientX } = e;
-          const rect = state.activePagination.getBoundingClientRect();
-          const percentage = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
-          handle.style.left = `${percentage * 100}%`;
-          state.activeSwiper.slideTo(Math.round(percentage * (state.activeSlideCount - 1)), 0);
-        });
-        document.addEventListener('touchmove', (e) => {
-          const state = window.swiperHandleDragState;
-          if (!state.isDragging || !state.activePagination) return;
-          const handle = state.activePagination.querySelector('.swiper-pagination-handle');
-          if (!handle) return;
-          const { clientX } = e.touches[0];
-          const rect = state.activePagination.getBoundingClientRect();
-          const percentage = Math.max(0, Math.min(1, (clientX - rect.left) / rect.width));
-          handle.style.left = `${percentage * 100}%`;
-          state.activeSwiper.slideTo(Math.round(percentage * (state.activeSlideCount - 1)), 0);
-        }, { passive: true });
-        const handleGlobalDragEnd = () => {
-          const state = window.swiperHandleDragState;
-          if (!state.isDragging) return;
-          const handle = state.activePagination?.querySelector('.swiper-pagination-handle');
-          if (handle) {
-            handle.style.transition = 'left 0.3s ease';
-            handle.style.cursor = 'grab';
-          }
-          document.body.style.userSelect = '';
-          state.isDragging = false;
-          state.activeSwiper = null;
-          state.activePagination = null;
-          state.activeSlideCount = 0;
-        };
-        document.addEventListener('mouseup', handleGlobalDragEnd);
-        document.addEventListener('touchend', handleGlobalDragEnd);
-      }
-      const handleDragStart = (e) => {
-        const state = window.swiperHandleDragState;
-        state.isDragging = true;
-        state.activeSwiper = swiper;
-        state.activePagination = paginationEl;
-        state.activeSlideCount = slideCount;
-        const handle = e.currentTarget;
-        handle.style.transition = 'none';
-        handle.style.cursor = 'grabbing';
-        document.body.style.userSelect = 'none';
-        e.preventDefault();
-      };
-      const createHandle = () => {
-        const handle = document.createElement('div');
-        handle.className = 'swiper-pagination-handle';
-        handle.innerHTML = '<img src="/icons/scrollbar-handle.svg" alt="" width="28" height="8">';
-        handle.addEventListener('mousedown', handleDragStart);
-        handle.addEventListener('touchstart', handleDragStart, { passive: false });
-        return handle;
-      };
-      paginationEl.appendChild(createHandle());
-      const updateHandlePosition = () => {
-        let handle = paginationEl.querySelector('.swiper-pagination-handle');
-        if (!handle) {
-          handle = createHandle();
-          paginationEl.appendChild(handle);
-        }
-        const { progress } = swiper;
-        handle.style.left = `${Math.max(0, Math.min(1, progress)) * 100}%`;
-      };
-      updateHandlePosition();
-      swiper.on('progress', updateHandlePosition);
-      swiper.on('slideChange', updateHandlePosition);
-      swiper.on('resize', updateHandlePosition);
-      swiper.on('breakpoint', updateHandlePosition);
-      paginationEl.style.cursor = 'pointer';
-      paginationEl.addEventListener('click', (e) => {
-        if (e.target.closest('.swiper-pagination-handle')) return;
-        const rect = paginationEl.getBoundingClientRect();
-        const targetSlide = Math.round(((e.clientX - rect.left) / rect.width) * (slideCount - 1));
-        swiper.slideTo(targetSlide);
-      });
-    }
-  }
 
   injectSchema(generateTestimonialSchema(block));
 }


### PR DESCRIPTION
Break out of testimonial cards into their own block. The look and feel should be the same, but the authoring experience has been modified per the issue.  I have left the old block authored and the old code alone for comparison and validation. 

Fix #133 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://133-testimonialEnhancement--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- Library Before: https://main--idfc--aemsites.aem.page/tools/sidekick/library.html?plugin=blocks&path=/library/cards-testimonial&index=0
-Library After: https://133-testimonialenhancement--idfc--aemsites.aem.page/tools/sidekick/library.html?plugin=blocks&path=/library/cards-testimonial&index=0 

Desktop (Old above, New below):
<img width="1238" height="1316" alt="image" src="https://github.com/user-attachments/assets/c5884058-d8a7-4145-a011-897d2017d7d6" />

Mobile (Old above, New below):
<img width="510" height="1203" alt="image" src="https://github.com/user-attachments/assets/f3e133e8-681b-4a83-a186-421383f9f2b4" />
