### PR TITLE
Refactor table block to use section background handling code

### DIFF
--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -9,6 +9,7 @@ import {
   handleBackgroundImages,
   handleBackground,
   normalizeBackgroundColor,
+  getColorScheme,
 } from '../../scripts/scripts.js';
 
 /**
@@ -207,6 +208,14 @@ export default async function decorate(block) {
 
     if (imageAlt) imageWrapper.dataset.imageAlt = imageAlt;
     block.append(imageWrapper);
+
+    // setColorScheme(imageWrapper) only applies to imageWrapper's direct children (the picture).
+    // The table is a sibling, not a child, so apply scheme to block and table so content gets it.
+    const scheme = getColorScheme(imageWrapper);
+    if (scheme) {
+      block.classList.add(scheme);
+      table.classList.add(scheme);
+    }
   }
 
   if (thead) table.append(thead);

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -8,6 +8,7 @@ import {
   moveInstrumentation,
   handleBackgroundImages,
   handleBackground,
+  normalizeBackgroundColor,
 } from '../../scripts/scripts.js';
 
 /**
@@ -20,19 +21,6 @@ function extractImageUrl(element) {
   if (element.tagName === 'IMG') return element.src;
   if (element.tagName === 'PICTURE') return element.querySelector('img')?.src || null;
   return null;
-}
-
-/**
- * Normalizes color for shared handleBackground (Table: backgroundColor; Section: backgroundcolor).
- * Ensures bare hex (e.g. "fff") gets "#" prefix so CSS is valid.
- * @param {string} color - Raw color from table metadata
- * @returns {string} - Color string suitable for handleBackground
- */
-function normalizeBackgroundColor(color) {
-  if (!color || typeof color !== 'string') return color;
-  const trimmed = color.trim();
-  if (trimmed.match(/^[0-9a-fA-F]{3,6}$/)) return `#${trimmed}`;
-  return trimmed;
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -427,14 +427,18 @@ async function loadTemplate(doc, templateName) {
 /** SECTIONS */
 
 /**
- * Converts a CSS color value to RGB values
- * @param {string} color - CSS color value (hex, rgb, rgba, hsl, hsla, or named color)
- * @returns {Object|null} Object with r, g, b values (0-255) or null if invalid
+ * Converts the computed background color of an element to RGB values.
+ * Used for section or table background containers to drive light-scheme/dark-scheme.
+ * @param {Element} element - Section or table bg wrapper (.section, .table-background-image)
+ * @returns {Object|null} Object with r, g, b values (0-255) or null if invalid/unavailable
  */
-function parseColor(section) {
-  if (!section) return null; // for now, only using on sections
+function parseColor(element) {
+  // Only run for section or table background wrapper; ignore other element types for now.
+  const isSection = element?.classList?.contains('section');
+  const isTableBg = element?.classList?.contains('table-background-image');
+  if (!isSection && !isTableBg) return null;
 
-  const computedBg = getComputedStyle(section).background;
+  const computedBg = getComputedStyle(element).background;
   const rgbMatch = computedBg.match(/rgb\((\d+),\s*(\d+),\s*(\d+)\)/);
   if (!rgbMatch) return null;
   return {
@@ -460,28 +464,43 @@ function getRelativeLuminance({ r, g, b }) {
 }
 
 /**
- * The color scheme detection uses the WCAG relative luminance formula to determine if a bg color
- * is light or dark, ensuring accessible and appropriate styling for content within the section.
- * Determines if a CSS color value is light or dark
- * @param {string} color - CSS color value
- * @param {number} threshold - Luminance threshold (default: 0.5)
- * @returns {boolean} true if light, false if dark, null if invalid color
+ * Uses WCAG relative luminance on the element's computed background to determine light or dark
+ * scheme for accessible styling. Works for section or table background containers.
+ * @param {Element} element - Section or table background wrapper with a set background
+ * @returns {string|null} 'light-scheme' | 'dark-scheme' or null if color cannot be determined
  */
-export function getColorScheme(section) {
-  const rgb = parseColor(section);
+export function getColorScheme(element) {
+  const rgb = parseColor(element);
   if (!rgb) return null;
 
   return getRelativeLuminance(rgb) > 0.5 ? 'light-scheme' : 'dark-scheme';
 }
 
-export function setColorScheme(section) {
-  const scheme = getColorScheme(section);
+/**
+ * Applies light-scheme or dark-scheme to direct children based on element's background luminance.
+ * Use with section or table background wrapper (e.g. .section, .table-background-image).
+ * @param {Element} element - Section or table background wrapper
+ */
+export function setColorScheme(element) {
+  const scheme = getColorScheme(element);
   if (!scheme) return;
-  section.querySelectorAll(':scope > *').forEach((el) => {
-    // Reset any pre-made color schemes
+  element.querySelectorAll(':scope > *').forEach((el) => {
     el.classList.remove('light-scheme', 'dark-scheme');
     el.classList.add(scheme);
   });
+}
+
+/**
+ * Normalizes a background color string for use with handleBackground (e.g. Table backgroundColor,
+ * Section backgroundcolor). Ensures bare hex (e.g. "fff") gets "#" prefix so CSS is valid.
+ * @param {string} color - Raw color from block/section metadata
+ * @returns {string} - Color string suitable for handleBackground
+ */
+export function normalizeBackgroundColor(color) {
+  if (!color || typeof color !== 'string') return color;
+  const trimmed = color.trim();
+  if (trimmed.match(/^[0-9a-fA-F]{3,6}$/)) return `#${trimmed}`;
+  return trimmed;
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -518,7 +518,7 @@ function extractImageUrl(content) {
  * @param {string|null} mobileUrl the mobile background image URL (optional)
  * @param {Element} section the section element to add the background to
  */
-function handleBackgroundImages(desktopUrl, mobileUrl, section) {
+export function handleBackgroundImages(desktopUrl, mobileUrl, section) {
   if (!desktopUrl) return;
 
   const newPic = document.createElement('picture');
@@ -555,7 +555,7 @@ function handleBackgroundImages(desktopUrl, mobileUrl, section) {
   section.prepend(newPic);
 }
 
-function handleBackground(background, section) {
+export function handleBackground(background, section) {
   const color = background.text;
   // instead of typing "var(--color-name)" authors can use "color-token-name"
   if (color) {


### PR DESCRIPTION
Normalized background color handling and improve image management. 
Added normalizeBackgroundColor function and updated handleBackground and handleBackgroundImages usage for better consistency.

Fix #373 

# Table vs Section background — shared logic

Table block now uses the same `handleBackground` and `handleBackgroundImages` from `scripts.js` as Section. Letter-case and JSON field names differ between the two; both are normalized before calling the shared functions.

---

## 1. JSON / schema field names (letter-case)

| Purpose | Section (metadata keys) | Table (block schema) |
|---------|-------------------------|----------------------|
| Background color | `backgroundcolor` | `backgroundColor` |
| Desktop image | `sectionBackgroundImage` | `image` |
| Mobile image | `sectionBackgroundImageMobile` | `imageMobile` |

---

## 2. How Table maps into the shared functions

- **Color:** Table reads `backgroundColor` from the block, normalizes bare hex (e.g. `fff` → `#fff`), then calls `handleBackground({ text: normalizedColor }, imageWrapper)` — same as Section's `handleBackground(metadata.backgroundcolor, section)`.
- **Images:** Table passes desktop/mobile URLs (from `image` / `imageMobile`) to `handleBackgroundImages(desktopUrl, mobileUrl, imageWrapper)`. If only mobile is set, Table passes `desktopUrl = mobileImageUrl` so the function still receives a desktop URL.

---

## 3. DOM after update (Section vs Table)

Both Section and Table now produce the same background structure when images are used:

**Section (e.g. .section)**

```html
<div class="section has-bg-images">
  <picture class="bg-images">
    <!-- source: mobile, tablet, desktop -->
    <img class="section-img" ...>
  </picture>
  <!-- ... block content ... -->
</div>
```

**Table (e.g. .table-background-image)**

```html
<div class="table-background-image has-bg-images">
  <picture class="bg-images">
    <!-- source: same breakpoints as Section -->
    <img class="section-img" ...>
  </picture>
</div>
<table>...</table>
```

---

## 4. Differences summary

| Aspect | Before (Table only) | After (shared with Section) |
|--------|---------------------|-----------------------------|
| **Color** | Custom hex/gradient logic, no `color-token` or `setColorScheme` | `handleBackground`: color-token support, `setColorScheme`, same as Section |
| **Images** | `createResponsivePicture` in table.js (different breakpoints) | `handleBackgroundImages`: same `createSource` + MEDIA_QUERIES as Section |
| **Classes on wrapper** | `.table-background-image` only | `.table-background-image` + `.has-bg-images`; inner `.bg-images`, `.section-img` |

---

*Reference only. Run the site and use a Table block with background color and/or images to verify (e.g. [library/table](https://main--idfc--aemsites.aem.page/library/table)).*


Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/table
- After: https://373-tablestyles--idfc--aemsites.aem.page/library/table
