### PR TITLE
Tabs: put back standalone tabs block logic

### DIFF
--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -53,28 +53,34 @@
   display: none;
 }
 
+.tabs.blue-white-text .tabs-tab,
 .tabs-container.blue-white-text .tabs-tab {
   background: var(--gradient-silver);
 }
 
+.tabs-container.silver-blue-text .tabs-tab,
 .tabs-container.silver-blue-text .tabs-tab {
   background: rgb(255 255 255 / 70%);
 }
 
+.tabs.silver-blue-text .tabs-list .tabs-tab p
 .tabs-container.silver-blue-text .tabs-list .tabs-tab p {
   color: #08133C;
 }
 
+.tabs.blue-white-text .tabs-tab[aria-selected='true'],
 .tabs-container.blue-white-text .tabs-tab[aria-selected='true'] {
   background: var(--gradient-blue);
   color: var(--color-white);
 }
 
+.tabs.silver-blue-text .tabs-list,
 .tabs-container.silver-blue-text .tabs-list {
   padding: 0;
   margin-bottom: 0;
 }
 
+.tabs.silver-blue-text .tabs-tab[aria-selected='true'],
 .tabs-container.silver-blue-text .tabs-tab[aria-selected='true'] {
   background: linear-gradient(138deg, #999 -15.44%, #EFEFEF 0.15%, #CACACA 18.04%, #EFEFEF 37.09%, #CACACA 58.44%, #999 76.91%, #EFEFEF 87.3%);
   color: #08133C;
@@ -85,8 +91,8 @@
 
   .tabs-list, .section-title {
     max-width: var(--grid-container-width);
+    width: fit-content;
     margin: 0 auto;
-    justify-content: center;
   }
 
   .tabs.vertical .tabs-list {

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -101,7 +101,7 @@ export default async function decorate(block) {
       tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
       tabpanel.setAttribute('role', 'tabpanel');
 
-      moveInstrumentation(tab.parentElement, tabpanel.lastElementChild);
+   //   moveInstrumentation(tab.parentElement, tabpanel.lastElementChild);
       const button = createTabButton(
         block,
         tabpanel,
@@ -112,7 +112,7 @@ export default async function decorate(block) {
       );
       tablist.append(button);
       tab.remove();
-      moveInstrumentation(button.querySelector('p'), null);
+  //    moveInstrumentation(button.querySelector('p'), null);
     });
 
     block.prepend(tablist);

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -112,7 +112,7 @@ export default async function decorate(block) {
       );
       tablist.append(button);
       tab.remove();
-  //    moveInstrumentation(button.querySelector('p'), null);
+      moveInstrumentation(button.querySelector('p'), null);
     });
 
     block.prepend(tablist);

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -63,6 +63,7 @@ export default async function decorate(block) {
       tabpanel.setAttribute('aria-hidden', !!i);
       tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
       tabpanel.setAttribute('role', 'tabpanel');
+      moveInstrumentation(tab.parentElement, tabpanel.lastElementChild);
 
       const tabTextWrapper = document.createElement('div');
       if (tabName) {
@@ -101,7 +102,6 @@ export default async function decorate(block) {
       tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
       tabpanel.setAttribute('role', 'tabpanel');
 
-   //   moveInstrumentation(tab.parentElement, tabpanel.lastElementChild);
       const button = createTabButton(
         block,
         tabpanel,

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -102,9 +102,6 @@ export default async function decorate(block) {
       tabpanel.setAttribute('role', 'tabpanel');
 
       moveInstrumentation(tab.parentElement, tabpanel.lastElementChild);
-      // Remove the label cell so the tab panel only shows content, not the tab text
-      tab.remove();
-
       const button = createTabButton(
         block,
         tabpanel,
@@ -114,6 +111,8 @@ export default async function decorate(block) {
         `tab-${id}`,
       );
       tablist.append(button);
+      tab.remove();
+      moveInstrumentation(button.querySelector('p'), null);
     });
 
     block.prepend(tablist);

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -1,23 +1,12 @@
 // eslint-disable-next-line import/no-unresolved
 import { toClassName } from '../../scripts/aem.js';
-import { getBlockId } from '../../scripts/scripts.js';
+import { getBlockId, moveInstrumentation } from '../../scripts/scripts.js';
 
-function fetchTabName(tab) {
-  const tabTextWrapper = document.createElement('div');
-  const tabName = tab.getAttribute('data-tabname');
-  if (tabName) {
-    const tabText = document.createElement('p');
-    tabText.textContent = tabName;
-    tabTextWrapper.append(tabText);
-  }
-  return tabTextWrapper;
-}
-
-function createTabButton(block, tab, tabpanel, tablist, index) {
+function createTabButton(block, tabpanel, tablist, index, buttonContent, buttonId) {
   const button = document.createElement('button');
   button.className = 'tabs-tab';
-  button.id = `${block.id}_tab_${index}`;
-  button.innerHTML = fetchTabName(tab).innerHTML;
+  button.id = buttonId;
+  button.innerHTML = buttonContent;
   button.setAttribute('aria-controls', tabpanel.id);
   button.setAttribute('aria-selected', !index);
   button.setAttribute('role', 'tab');
@@ -38,16 +27,18 @@ function createTabButton(block, tab, tabpanel, tablist, index) {
 export default async function decorate(block) {
   block.id = getBlockId('tabs');
 
-  // build tablist
+  // Check if this is a multisection tabs block (items have data-multisection)
+  const isMultiSection = [...block.children].some((child) => child.hasAttribute('data-multisection'));
+
   const tablist = document.createElement('div');
   tablist.className = 'tabs-list';
   tablist.setAttribute('role', 'tablist');
 
-  // decorate tabs and tabpanels
-  const tabs = [...block.children];
-  const sectionTitles = [];
-  if (tabs.length > 0) {
-    // Collect all .tab-section-title elements from all tabs
+  if (isMultiSection) {
+    // MultiSection mode: block children are tab items with data-tabname and content
+    const tabs = [...block.children];
+    const sectionTitles = [];
+
     tabs.forEach((tab) => {
       const titles = tab.querySelectorAll('.tab-section-title');
       titles.forEach((title) => {
@@ -57,7 +48,6 @@ export default async function decorate(block) {
       });
     });
 
-    // add tab style (horizontal or vertical)
     const headers = tabs[0];
     const tabStyle = headers.getAttribute('data-category');
     if (tabStyle) {
@@ -65,8 +55,8 @@ export default async function decorate(block) {
     }
 
     tabs.forEach((tab, i) => {
-      const id = toClassName(tab.getAttribute('data-tabname'));
-      // decorate tabpanel
+      const tabName = tab.getAttribute('data-tabname') || '';
+      const id = toClassName(tabName);
       const tabpanel = block.children[i];
       tabpanel.classList.add('tabs-panel');
       tabpanel.id = `${block.id}_tabPane_${i}`;
@@ -74,15 +64,58 @@ export default async function decorate(block) {
       tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
       tabpanel.setAttribute('role', 'tabpanel');
 
-      // build tab button
-      const button = createTabButton(block, tab, tabpanel, tablist, i);
+      const tabTextWrapper = document.createElement('div');
+      if (tabName) {
+        const tabText = document.createElement('p');
+        tabText.textContent = tabName;
+        tabTextWrapper.append(tabText);
+      }
+      const button = createTabButton(
+        block,
+        tabpanel,
+        tablist,
+        i,
+        tabTextWrapper.innerHTML,
+        `${block.id}_tab_${i}`,
+      );
       tablist.append(button);
     });
+
+    block.prepend(tablist);
+    sectionTitles.forEach((sectionTitle) => {
+      sectionTitle.remove();
+      tablist.insertAdjacentElement('afterend', sectionTitle);
+    });
+  } else {
+    // Standalone mode: row-based structure (each row = tab label cell + content cell)
+    const tabs = [...block.children].map((child) => child.firstElementChild);
+    if (tabs.length === 0) return;
+
+    tabs.forEach((tab, i) => {
+      const id = toClassName(tab.textContent);
+      const buttonContent = tab.innerHTML;
+      const tabpanel = block.children[i];
+      tabpanel.className = 'tabs-panel';
+      tabpanel.id = `${block.id}_tabPane_${i}`;
+      tabpanel.setAttribute('aria-hidden', !!i);
+      tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
+      tabpanel.setAttribute('role', 'tabpanel');
+
+      moveInstrumentation(tab.parentElement, tabpanel.lastElementChild);
+      // Remove the label cell so the tab panel only shows content, not the tab text
+      tab.remove();
+
+      const button = createTabButton(
+        block,
+        tabpanel,
+        tablist,
+        i,
+        buttonContent,
+        `tab-${id}`,
+      );
+      tablist.append(button);
+    });
+
+    block.prepend(tablist);
   }
-  block.prepend(tablist);
-  // Prepend all sectionTitles after tablist so they appear first
-  // Reverse order to maintain original DOM order when prepending
-  sectionTitles.reverse().forEach((sectionTitle) => {
-    block.prepend(sectionTitle);
-  });
 }


### PR DESCRIPTION
Re-allowing a standalone tabs block instead of replacing 100% with a multi-section.
This is part 1 of the multi-section refactor (to be done next via https://github.com/aemsites/idfc/issues/593 )

Fix #594 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://593-multisections--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

Before:
<img width="1260" height="438" alt="image" src="https://github.com/user-attachments/assets/c480a9cd-b112-4355-b5b6-be8eb6b35f4f" />

After:
<img width="1107" height="422" alt="image" src="https://github.com/user-attachments/assets/8bff97e3-14ca-4e03-881d-a4ef06f00512" />


