### PR TITLE
UE only: new section related UE json

### DIFF
--- a/blocks/section-title/_section-title.json
+++ b/blocks/section-title/_section-title.json
@@ -119,10 +119,6 @@
             {
               "name": "Right",
               "value": "right"
-            },
-            {
-              "name": "Tab section: above tabs",
-              "value": "tab-section-title"
             }
           ]
         }

--- a/component-definition.json
+++ b/component-definition.json
@@ -87,7 +87,6 @@
                   "name": "Multi Section",
                   "model": "multi-section",
                   "filter": "multi-section",
-                  "multisection": "group1",
                   "tabname": "Item 1"
                 }
               }

--- a/component-models.json
+++ b/component-models.json
@@ -311,7 +311,7 @@
         "component": "text",
         "name": "multisection",
         "label": "Section group identifier - give all sections the same value to group them in one section",
-        "value": "group1",
+        "value": "",
         "condition": {
           "==": [
             {
@@ -361,22 +361,82 @@
         ]
       },
       {
+        "component": "select",
+        "name": "spacing",
+        "label": "Spacing top and bottom of section",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Default",
+            "value": ""
+          },
+          {
+            "name": "XXL",
+            "value": "size-xxl"
+          },
+          {
+            "name": "XL",
+            "value": "size-xl"
+          },
+          {
+            "name": "L",
+            "value": "size-l"
+          },
+          {
+            "name": "M",
+            "value": "size-m"
+          },
+          {
+            "name": "S",
+            "value": "size-s"
+          },
+          {
+            "name": "XS",
+            "value": "size-xs"
+          }
+        ]
+      },
+      {
         "component": "text",
         "name": "grid",
-        "label": "Grid (# of columns, 2-6)",
+        "label": "Grid layout(# of columns, 2-6)",
         "valueType": "string"
       },
       {
-        "component": "text",
+        "component": "select",
         "name": "gap",
-        "label": "Gap between blocks (xs, s, m, l, xl, xxl)",
-        "valueType": "string"
-      },
-      {
-        "component": "text",
-        "name": "spacing",
-        "label": "Spacing top and bottom of section (xs, s, m, l, xl, xxl)",
-        "valueType": "string"
+        "label": "(grid layout) gap between blocks",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Default",
+            "value": ""
+          },
+          {
+            "name": "XXL",
+            "value": "size-xxl"
+          },
+          {
+            "name": "XL",
+            "value": "size-xl"
+          },
+          {
+            "name": "L",
+            "value": "size-l"
+          },
+          {
+            "name": "M",
+            "value": "size-m"
+          },
+          {
+            "name": "S",
+            "value": "size-s"
+          },
+          {
+            "name": "XS",
+            "value": "size-xs"
+          }
+        ]
       },
       {
         "component": "text",
@@ -605,7 +665,7 @@
         "component": "text",
         "name": "multisection",
         "label": "Section group identifier - give all sections the same value to group them in one section",
-        "value": "group1"
+        "value": ""
       },
       {
         "component": "text",
@@ -659,10 +719,82 @@
         ]
       },
       {
-        "component": "text",
+        "component": "select",
         "name": "spacing",
-        "label": "Spacing top and bottom of section (xs, s, m, l, xl, xxl)",
+        "label": "Spacing top and bottom of section",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Default",
+            "value": ""
+          },
+          {
+            "name": "XXL",
+            "value": "size-xxl"
+          },
+          {
+            "name": "XL",
+            "value": "size-xl"
+          },
+          {
+            "name": "L",
+            "value": "size-l"
+          },
+          {
+            "name": "M",
+            "value": "size-m"
+          },
+          {
+            "name": "S",
+            "value": "size-s"
+          },
+          {
+            "name": "XS",
+            "value": "size-xs"
+          }
+        ]
+      },
+      {
+        "component": "text",
+        "name": "grid",
+        "label": "Grid layout(# of columns, 2-6)",
         "valueType": "string"
+      },
+      {
+        "component": "select",
+        "name": "gap",
+        "label": "(grid layout) gap between blocks",
+        "valueType": "string",
+        "options": [
+          {
+            "name": "Default",
+            "value": ""
+          },
+          {
+            "name": "XXL",
+            "value": "size-xxl"
+          },
+          {
+            "name": "XL",
+            "value": "size-xl"
+          },
+          {
+            "name": "L",
+            "value": "size-l"
+          },
+          {
+            "name": "M",
+            "value": "size-m"
+          },
+          {
+            "name": "S",
+            "value": "size-s"
+          },
+          {
+            "name": "XS",
+            "value": "size-xs"
+          }
+        ]
       },
       {
         "component": "text",

--- a/component-models.json
+++ b/component-models.json
@@ -299,58 +299,7 @@
         "component": "text",
         "name": "id",
         "label": "ID",
-        "description": "Adds an ID value to the section"
-      },
-      {
-        "component": "boolean",
-        "name": "is-multisection",
-        "label": "This is a multi-section configuration section",
-        "value": false
-      },
-      {
-        "component": "text",
-        "name": "multisection",
-        "label": "Section group identifier - give all sections the same value to group them in one section",
-        "value": "",
-        "condition": {
-          "==": [
-            {
-              "var": "is-multisection"
-            },
-            true
-          ]
-        }
-      },
-      {
-        "component": "select",
-        "name": "category",
-        "label": "Grouped section type",
-        "condition": {
-          "==": [
-            {
-              "var": "is-multisection"
-            },
-            true
-          ]
-        },
-        "options": [
-          {
-            "name": "Tabs horizontal",
-            "value": "tabs-horizontal"
-          },
-          {
-            "name": "Tabs vertical",
-            "value": "tabs-vertical"
-          },
-          {
-            "name": "Accordion",
-            "value": "accordion"
-          },
-          {
-            "name": "none",
-            "value": ""
-          }
-        ]
+        "description": "Adds an HTML ID value to the section"
       },
       {
         "component": "multiselect",
@@ -424,6 +373,57 @@
           {
             "name": "XS",
             "value": "size-xs"
+          }
+        ]
+      },
+      {
+        "component": "boolean",
+        "name": "is-multisection",
+        "label": "This is a multi-section configuration section",
+        "value": false
+      },
+      {
+        "component": "text",
+        "name": "multisection",
+        "label": "Section group identifier - give all sections the same value to group them in one section",
+        "value": "",
+        "condition": {
+          "==": [
+            {
+              "var": "is-multisection"
+            },
+            true
+          ]
+        }
+      },
+      {
+        "component": "select",
+        "name": "category",
+        "label": "Grouped section type",
+        "condition": {
+          "==": [
+            {
+              "var": "is-multisection"
+            },
+            true
+          ]
+        },
+        "options": [
+          {
+            "name": "Tabs horizontal",
+            "value": "tabs-horizontal"
+          },
+          {
+            "name": "Tabs vertical",
+            "value": "tabs-vertical"
+          },
+          {
+            "name": "Accordion",
+            "value": "accordion"
+          },
+          {
+            "name": "none",
+            "value": ""
           }
         ]
       },
@@ -727,6 +727,12 @@
         "label": "Tab/Accordion heading label"
       },
       {
+        "component": "text",
+        "name": "id",
+        "label": "ID",
+        "description": "Adds an HTML ID value to the section"
+      },
+      {
         "component": "multiselect",
         "name": "style",
         "label": "Style",
@@ -837,12 +843,6 @@
                 "value": "size-xs"
               }
             ]
-          },
-          {
-            "component": "text",
-            "name": "id",
-            "label": "ID",
-            "description": "Adds an ID value to the section"
           },
           {
             "component": "select",

--- a/component-models.json
+++ b/component-models.json
@@ -397,53 +397,76 @@
         ]
       },
       {
-        "component": "text",
-        "name": "grid",
-        "label": "Grid layout(# of columns, 2-6)",
-        "valueType": "string"
-      },
-      {
-        "component": "select",
-        "name": "gap",
-        "label": "(grid layout) gap between blocks",
+        "component": "container",
+        "label": "Optional layout properties",
+        "name": "container",
         "valueType": "string",
-        "options": [
+        "collapsible": true,
+        "fields": [
           {
-            "name": "Default",
-            "value": ""
+            "component": "text",
+            "name": "grid",
+            "label": "Grid layout (enter # of columns, 2-6)",
+            "valueType": "string"
           },
           {
-            "name": "XXL",
-            "value": "size-xxl"
+            "component": "select",
+            "name": "gap",
+            "label": "(grid layout) gap between blocks",
+            "valueType": "string",
+            "options": [
+              {
+                "name": "Default",
+                "value": ""
+              },
+              {
+                "name": "XXL",
+                "value": "size-xxl"
+              },
+              {
+                "name": "XL",
+                "value": "size-xl"
+              },
+              {
+                "name": "L",
+                "value": "size-l"
+              },
+              {
+                "name": "M",
+                "value": "size-m"
+              },
+              {
+                "name": "S",
+                "value": "size-s"
+              },
+              {
+                "name": "XS",
+                "value": "size-xs"
+              }
+            ]
           },
           {
-            "name": "XL",
-            "value": "size-xl"
-          },
-          {
-            "name": "L",
-            "value": "size-l"
-          },
-          {
-            "name": "M",
-            "value": "size-m"
-          },
-          {
-            "name": "S",
-            "value": "size-s"
-          },
-          {
-            "name": "XS",
-            "value": "size-xs"
+            "component": "select",
+            "name": "containerwidth",
+            "label": "Inner div width",
+            "valueType": "string",
+            "description": "unrelated to grid layout",
+            "options": [
+              {
+                "name": "33%",
+                "value": "2"
+              },
+              {
+                "name": "66%",
+                "value": "4"
+              },
+              {
+                "name": "100%",
+                "value": "6"
+              }
+            ]
           }
         ]
-      },
-      {
-        "component": "text",
-        "name": "containerwidth",
-        "label": "Inner container width(2, 4, 6)",
-        "valueType": "string",
-        "description": "container = width of .section > div"
       },
       {
         "component": "container",
@@ -755,52 +778,82 @@
         ]
       },
       {
-        "component": "text",
-        "name": "grid",
-        "label": "Grid layout(# of columns, 2-6)",
-        "valueType": "string"
-      },
-      {
-        "component": "select",
-        "name": "gap",
-        "label": "(grid layout) gap between blocks",
+        "component": "container",
+        "label": "Optional layout properties",
+        "name": "container",
         "valueType": "string",
-        "options": [
+        "collapsible": true,
+        "fields": [
           {
-            "name": "Default",
-            "value": ""
+            "component": "text",
+            "name": "grid",
+            "label": "Grid layout (enter # of columns, 2-6)",
+            "valueType": "string"
           },
           {
-            "name": "XXL",
-            "value": "size-xxl"
+            "component": "select",
+            "name": "gap",
+            "label": "(grid layout) gap between blocks",
+            "valueType": "string",
+            "options": [
+              {
+                "name": "Default",
+                "value": ""
+              },
+              {
+                "name": "XXL",
+                "value": "size-xxl"
+              },
+              {
+                "name": "XL",
+                "value": "size-xl"
+              },
+              {
+                "name": "L",
+                "value": "size-l"
+              },
+              {
+                "name": "M",
+                "value": "size-m"
+              },
+              {
+                "name": "S",
+                "value": "size-s"
+              },
+              {
+                "name": "XS",
+                "value": "size-xs"
+              }
+            ]
           },
           {
-            "name": "XL",
-            "value": "size-xl"
+            "component": "text",
+            "name": "id",
+            "label": "ID",
+            "description": "Adds an ID value to the section"
           },
           {
-            "name": "L",
-            "value": "size-l"
-          },
-          {
-            "name": "M",
-            "value": "size-m"
-          },
-          {
-            "name": "S",
-            "value": "size-s"
-          },
-          {
-            "name": "XS",
-            "value": "size-xs"
+            "component": "select",
+            "name": "containerwidth",
+            "label": "Inner div width",
+            "valueType": "string",
+            "description": "unrelated to grid layout",
+            "options": [
+              {
+                "name": "33%",
+                "value": "2"
+              },
+              {
+                "name": "66%",
+                "value": "4"
+              },
+              {
+                "name": "100%",
+                "value": "6"
+              }
+            ]
           }
         ]
-      },
-      {
-        "component": "text",
-        "name": "id",
-        "label": "ID",
-        "description": "Adds an ID value to the section"
       },
       {
         "component": "container",

--- a/component-models.json
+++ b/component-models.json
@@ -302,6 +302,26 @@
         "description": "Adds an ID value to the section"
       },
       {
+        "component": "boolean",
+        "name": "is-multisection",
+        "label": "This is a multi-section configuration section",
+        "value": false
+      },
+      {
+        "component": "text",
+        "name": "multisection",
+        "label": "Section group identifier - give all sections the same value to group them in one section",
+        "value": "group1",
+        "condition": {
+          "==": [
+            {
+              "var": "is-multisection"
+            },
+            true
+          ]
+        }
+      },
+      {
         "component": "multiselect",
         "name": "style",
         "label": "Style",
@@ -327,12 +347,16 @@
             "value": "hide-desktop"
           },
           {
-            "name": "UPI steps red background",
-            "value": "upi-steps-red-bg"
-          },
-          {
             "name": "Entrance Animation",
             "value": "entrance-animation"
+          },
+          {
+            "name": "(Tabs) Blue with White Text",
+            "value": "blue-white-text"
+          },
+          {
+            "name": "(Tabs) Silver with Blue Text",
+            "value": "silver-blue-text"
           }
         ]
       },
@@ -631,18 +655,6 @@
           {
             "name": "Hide in desktop",
             "value": "hide-desktop"
-          },
-          {
-            "name": "Entrance Animation",
-            "value": "entrance-animation"
-          },
-          {
-            "name": "(Tabs) Blue with White Text",
-            "value": "blue-white-text"
-          },
-          {
-            "name": "(Tabs) Silver with Blue Text",
-            "value": "silver-blue-text"
           }
         ]
       },
@@ -1967,10 +1979,6 @@
           {
             "name": "Right",
             "value": "right"
-          },
-          {
-            "name": "Tab section: above tabs",
-            "value": "tab-section-title"
           }
         ]
       }

--- a/component-models.json
+++ b/component-models.json
@@ -430,7 +430,7 @@
       {
         "component": "container",
         "label": "Optional layout properties",
-        "name": "container",
+        "name": "layout-container",
         "valueType": "string",
         "collapsible": true,
         "fields": [
@@ -792,7 +792,7 @@
       {
         "component": "container",
         "label": "Optional layout properties",
-        "name": "container",
+        "name": "layout-container",
         "valueType": "string",
         "collapsible": true,
         "fields": [

--- a/component-models.json
+++ b/component-models.json
@@ -322,6 +322,37 @@
         }
       },
       {
+        "component": "select",
+        "name": "category",
+        "label": "Grouped section type",
+        "condition": {
+          "==": [
+            {
+              "var": "is-multisection"
+            },
+            true
+          ]
+        },
+        "options": [
+          {
+            "name": "Tabs horizontal",
+            "value": "tabs-horizontal"
+          },
+          {
+            "name": "Tabs vertical",
+            "value": "tabs-vertical"
+          },
+          {
+            "name": "Accordion",
+            "value": "accordion"
+          },
+          {
+            "name": "none",
+            "value": ""
+          }
+        ]
+      },
+      {
         "component": "multiselect",
         "name": "style",
         "label": "Style",
@@ -694,25 +725,6 @@
         "component": "text",
         "name": "tabname",
         "label": "Tab/Accordion heading label"
-      },
-      {
-        "component": "select",
-        "name": "category",
-        "label": "Grouped section type",
-        "options": [
-          {
-            "name": "Tabs horizontal (default)",
-            "value": "horizontal"
-          },
-          {
-            "name": "Tabs vertical",
-            "value": "vertical"
-          },
-          {
-            "name": "Accordion",
-            "value": "accordion"
-          }
-        ]
       },
       {
         "component": "multiselect",

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -81,7 +81,7 @@
           {
             "component": "container",
             "label": "Optional layout properties",
-            "name": "container",
+            "name": "layout-container",
             "valueType": "string",
             "collapsible": true,
             "fields": [

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -98,9 +98,16 @@
             ]
           },
           {
+            "component": "container",
+            "label": "Optional layout properties",
+            "name": "container",
+            "valueType": "string",
+            "collapsible": true,
+            "fields": [
+          {
             "component": "text",
             "name": "grid",
-            "label": "Grid layout(# of columns, 2-6)",
+            "label": "Grid layout (enter # of columns, 2-6)",
             "valueType": "string"
           },
           {
@@ -119,6 +126,29 @@
             "name": "id",
             "label": "ID",
             "description": "Adds an ID value to the section"
+          },
+          {
+            "component": "select",
+            "name": "containerwidth",
+            "label": "Inner div width",
+            "valueType": "string",
+            "description": "unrelated to grid layout",
+            "options": [
+              {
+                "name": "33%",
+                "value": "2"
+              },
+              {
+                "name": "66%",
+                "value": "4"
+              },
+              {
+                "name": "100%",
+                "value": "6"
+              }
+            ]
+          }
+          ]
           },
           {
             "component": "container",

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -33,7 +33,7 @@
             "component": "text",
             "name": "multisection",
             "label": "Section group identifier - give all sections the same value to group them in one section",
-            "value": "group1"
+            "value": ""
           },
           {
             "component": "text",
@@ -87,10 +87,32 @@
             ]
           },
           {
-            "component": "text",
+            "component": "select",
             "name": "spacing",
-            "label": "Spacing top and bottom of section (xs, s, m, l, xl, xxl)",
+            "label": "Spacing top and bottom of section",
+            "valueType": "string",
+            "options": [
+              {
+                "...": "./partials/_sizes.json#/options"
+              }
+            ]
+          },
+          {
+            "component": "text",
+            "name": "grid",
+            "label": "Grid layout(# of columns, 2-6)",
             "valueType": "string"
+          },
+          {
+            "component": "select",
+            "name": "gap",
+            "label": "(grid layout) gap between blocks",
+            "valueType": "string",
+            "options": [
+              {
+                "...": "./partials/_sizes.json#/options"
+              }
+            ]
           },
           {
             "component": "text",

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -11,7 +11,6 @@
                 "name": "Multi Section",
                 "model": "multi-section",
                 "filter": "multi-section",
-                "multisection": "group1",
                 "tabname": "Item 1"
               }
             }

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -40,6 +40,12 @@
             "label": "Tab/Accordion heading label"
           },
           {
+            "component": "text",
+            "name": "id",
+            "label": "ID",
+            "description": "Adds an HTML ID value to the section"
+          },
+          {
             "component": "multiselect",
             "name": "style",
             "label": "Style",
@@ -100,12 +106,6 @@
                 "...": "./partials/_sizes.json#/options"
               }
             ]
-          },
-          {
-            "component": "text",
-            "name": "id",
-            "label": "ID",
-            "description": "Adds an ID value to the section"
           },
           {
             "component": "select",

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -41,25 +41,6 @@
             "label": "Tab/Accordion heading label"
           },
           {
-            "component": "select",
-            "name": "category",
-            "label": "Grouped section type",
-            "options": [
-                {
-                    "name": "Tabs horizontal (default)",
-                    "value": "horizontal"
-                },
-                {
-                    "name": "Tabs vertical",
-                    "value": "vertical"
-                },
-                {
-                    "name": "Accordion",
-                    "value": "accordion"
-                }
-            ]
-          },
-          {
             "component": "multiselect",
             "name": "style",
             "label": "Style",

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -83,18 +83,6 @@
               {
                 "name": "Hide in desktop",
                 "value": "hide-desktop"
-              },
-              {
-                "name": "Entrance Animation",
-                "value": "entrance-animation"
-              },
-              {
-                "name": "(Tabs) Blue with White Text",
-                "value": "blue-white-text"
-              },
-              {
-                "name": "(Tabs) Silver with Blue Text",
-                "value": "silver-blue-text"
               }
             ]
           },

--- a/models/_section.json
+++ b/models/_section.json
@@ -29,7 +29,28 @@
           "component": "text",
           "name": "id",
           "label": "ID",
-          "description": "Adds an ID value to the section"
+          "description": "Adds an HTML ID value to the section"
+        },
+        {
+          "component": "multiselect",
+          "name": "style",
+          "label": "Style",
+          "options": [
+            {
+              "...": "./partials/_section-style.json#/options"
+            }
+          ]
+        },
+        {
+          "component": "select",
+          "name": "spacing",
+          "label": "Spacing top and bottom of section",
+          "valueType": "string",
+          "options": [
+            {
+              "...": "./partials/_sizes.json#/options"
+            }
+          ]
         },
         {
           "component": "boolean",
@@ -69,27 +90,6 @@
               {
                 "name": "none",
                 "value": ""
-            }
-          ]
-        },
-        {
-          "component": "multiselect",
-          "name": "style",
-          "label": "Style",
-          "options": [
-            {
-              "...": "./partials/_section-style.json#/options"
-            }
-          ]
-        },
-        {
-          "component": "select",
-          "name": "spacing",
-          "label": "Spacing top and bottom of section",
-          "valueType": "string",
-          "options": [
-            {
-              "...": "./partials/_sizes.json#/options"
             }
           ]
         },

--- a/models/_section.json
+++ b/models/_section.json
@@ -96,7 +96,7 @@
         {
           "component": "container",
           "label": "Optional layout properties",
-          "name": "container",
+          "name": "layout-container",
           "valueType": "string",
           "collapsible": true,
           "fields": [

--- a/models/_section.json
+++ b/models/_section.json
@@ -68,9 +68,16 @@
           ]
         },
         {
+          "component": "container",
+          "label": "Optional layout properties",
+          "name": "container",
+          "valueType": "string",
+          "collapsible": true,
+          "fields": [
+        {
           "component": "text",
           "name": "grid",
-          "label": "Grid layout(# of columns, 2-6)",
+          "label": "Grid layout (enter # of columns, 2-6)",
           "valueType": "string"
         },
         {
@@ -85,11 +92,27 @@
           ]
         },
         {
-          "component": "text",
+          "component": "select",
           "name": "containerwidth",
-          "label": "Inner container width(2, 4, 6)",
+          "label": "Inner div width",
           "valueType": "string",
-          "description": "container = width of .section > div"
+          "description": "unrelated to grid layout",
+          "options": [
+            {
+              "name": "33%",
+              "value": "2"
+            },
+            {
+              "name": "66%",
+              "value": "4"
+            },
+            {
+              "name": "100%",
+              "value": "6"
+            }
+          ]
+        }
+        ]
         },
         {
           "component": "container",

--- a/models/_section.json
+++ b/models/_section.json
@@ -47,6 +47,32 @@
           }
         },
         {
+          "component": "select",
+          "name": "category",
+          "label": "Grouped section type",
+          "condition": {
+            "==": [{ "var": "is-multisection" }, true]
+          },
+          "options": [
+              {
+                  "name": "Tabs horizontal",
+                  "value": "tabs-horizontal"
+              },
+              {
+                  "name": "Tabs vertical",
+                  "value": "tabs-vertical"
+              },
+              {
+                  "name": "Accordion",
+                  "value": "accordion"
+              },
+              {
+                "name": "none",
+                "value": ""
+            }
+          ]
+        },
+        {
           "component": "multiselect",
           "name": "style",
           "label": "Style",

--- a/models/_section.json
+++ b/models/_section.json
@@ -41,7 +41,7 @@
           "component": "text",
           "name": "multisection",
           "label": "Section group identifier - give all sections the same value to group them in one section",
-          "value": "group1",
+          "value": "",
           "condition": {
             "==": [{ "var": "is-multisection" }, true]
           }
@@ -57,22 +57,32 @@
           ]
         },
         {
+          "component": "select",
+          "name": "spacing",
+          "label": "Spacing top and bottom of section",
+          "valueType": "string",
+          "options": [
+            {
+              "...": "./partials/_sizes.json#/options"
+            }
+          ]
+        },
+        {
           "component": "text",
           "name": "grid",
-          "label": "Grid (# of columns, 2-6)",
+          "label": "Grid layout(# of columns, 2-6)",
           "valueType": "string"
         },
         {
-          "component": "text",
+          "component": "select",
           "name": "gap",
-          "label": "Gap between blocks (xs, s, m, l, xl, xxl)",
-          "valueType": "string"
-        },
-        {
-          "component": "text",
-          "name": "spacing",
-          "label": "Spacing top and bottom of section (xs, s, m, l, xl, xxl)",
-          "valueType": "string"
+          "label": "(grid layout) gap between blocks",
+          "valueType": "string",
+          "options": [
+            {
+              "...": "./partials/_sizes.json#/options"
+            }
+          ]
         },
         {
           "component": "text",

--- a/models/_section.json
+++ b/models/_section.json
@@ -32,6 +32,21 @@
           "description": "Adds an ID value to the section"
         },
         {
+          "component": "boolean",
+          "name": "is-multisection",
+          "label": "This is a multi-section configuration section",
+          "value": false
+        },
+        {
+          "component": "text",
+          "name": "multisection",
+          "label": "Section group identifier - give all sections the same value to group them in one section",
+          "value": "group1",
+          "condition": {
+            "==": [{ "var": "is-multisection" }, true]
+          }
+        },
+        {
           "component": "multiselect",
           "name": "style",
           "label": "Style",

--- a/models/partials/_section-style.json
+++ b/models/partials/_section-style.json
@@ -21,12 +21,16 @@
           "value": "hide-desktop"
         },
         {
-          "name": "UPI steps red background",
-          "value": "upi-steps-red-bg"
-        },
-        {
           "name": "Entrance Animation",
           "value": "entrance-animation"
+        },
+        {
+          "name": "(Tabs) Blue with White Text",
+          "value": "blue-white-text"
+        },
+        {
+          "name": "(Tabs) Silver with Blue Text",
+          "value": "silver-blue-text"
         }
       ]
 }

--- a/models/partials/_sizes.json
+++ b/models/partials/_sizes.json
@@ -1,0 +1,32 @@
+{
+    "options": [
+        {
+          "name": "Default",
+          "value": ""
+        },
+        {
+          "name": "XXL",
+          "value": "size-xxl"
+        },
+        {
+          "name": "XL",
+          "value": "size-xl"
+        },
+        {
+          "name": "L",
+          "value": "size-l"
+        },
+        {
+          "name": "M",
+          "value": "size-m"
+        },
+        {
+          "name": "S",
+          "value": "size-s"
+        },
+        {
+          "name": "XS",
+          "value": "size-xs"
+        }
+      ]
+}


### PR DESCRIPTION
UE only changes to start refactor of multisectins.

In the section:
Moved some things around, added a couple of new things for the multi-section work coming soon,  created selects for the grid layout related options, etc but all the fields will work as expected.
<img width="485" height="977" alt="image" src="https://github.com/user-attachments/assets/8e380c68-16dc-4d2c-b6d3-f0ae7e6f473c" />


Fix #596 
Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/tab-section
- After: https://593-multisections--idfc--aemsites.aem.page/library/tab-section
