### PR TITLE
refactored to show modal on exit intent instead of timer.

### DIFF
--- a/blocks/hero-heritage-cc/hero-heritage-cc.js
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.js
@@ -71,16 +71,27 @@ export default function decorate(block) {
   const mainElement = document.querySelector('main');
   const hasAueResource = mainElement?.hasAttribute('data-aue-resource');
 
-  // Handle "The Concept" link (#the-concept-hotspot) - collapse hero height 100% -> 19%
+  // Helper: collapse hero and show first hotspot block (when "The Concept" is clicked)
+  function showConceptHotspotBlock() {
+    const hero = document.querySelector('.hero-heritage-cc');
+    if (hero) hero.classList.toggle('hero-heritage-cc-collapsed');
+    const firstBlock = document.getElementById('the-concept-hotspot')
+      || document.querySelector('.hotspot-container .hotspot');
+    if (firstBlock?.classList.contains('hotspot')) {
+      firstBlock.style.display = '';
+    }
+  }
+
+  // Handle "The Concept" link (hash anchor): collapse hero, show first hotspot block
   if (!document.body.dataset.heroConceptLinkListener) {
     document.body.dataset.heroConceptLinkListener = 'true';
     document.addEventListener('click', (e) => {
-      const link = e.target.closest('a[href="#the-concept-hotspot"]');
+      const link = e.target.closest('a[href*="the-concept-hotspot"]');
       if (!link) return;
-      const hero = document.querySelector('.hero-heritage-cc');
-      if (hero) {
-        hero.classList.toggle('hero-heritage-cc-collapsed');
-      }
+      const isHashLink = link.hash === '#the-concept-hotspot'
+        || link.getAttribute('href')?.includes('the-concept-hotspot');
+      if (!isHashLink) return;
+      showConceptHotspotBlock();
     });
   }
 
@@ -445,6 +456,9 @@ export default function decorate(block) {
 
       e.preventDefault();
       e.stopPropagation();
+
+      // Collapse hero and show first hotspot block (hidden initially to prevent CLS)
+      showConceptHotspotBlock();
 
       // If concept is already loaded, just show it
       if (conceptContainer) {

--- a/blocks/hero-heritage-cc/hero-heritage-cc.js
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.js
@@ -78,7 +78,7 @@ export default function decorate(block) {
     const firstBlock = document.getElementById('the-concept-hotspot')
       || document.querySelector('.hotspot-container .hotspot');
     if (firstBlock?.classList.contains('hotspot')) {
-      firstBlock.style.display = '';
+      firstBlock.style.display = 'block';
     }
   }
 

--- a/blocks/hotspot/hotspot.js
+++ b/blocks/hotspot/hotspot.js
@@ -837,9 +837,10 @@ export default function decorate(block) {
     }
   }
 
-  // Hide non-first blocks in this section (only show the first hotspot block initially)
+  // Hide all blocks initially (including first) to prevent CLS
+  // First block is shown only when user clicks "The Concept" button (see hero-heritage-cc)
+  block.style.display = 'none';
   if (blockId !== sectionData.firstBlockId) {
-    block.style.display = 'none';
     block.setAttribute('aria-hidden', 'true');
   }
 

--- a/blocks/hotspot/hotspot.js
+++ b/blocks/hotspot/hotspot.js
@@ -831,9 +831,13 @@ export default function decorate(block) {
   const blockHeight = block.offsetHeight;
   if (blockHeight > sectionData.maxHeight) {
     sectionData.maxHeight = blockHeight;
-    // Update section min-height to accommodate the tallest block
     if (sectionWrapper) {
       sectionWrapper.style.minHeight = `${sectionData.maxHeight}px`;
+      // Reserve space on block-content too to prevent wrapper CLS
+      const blockContent = block.closest('.block-content');
+      if (blockContent) {
+        blockContent.style.minHeight = `${sectionData.maxHeight}px`;
+      }
     }
   }
 

--- a/component-models.json
+++ b/component-models.json
@@ -126,14 +126,22 @@
         "component": "text",
         "name": "modal-timer",
         "valueType": "string",
-        "label": "Modal Timer (ms)"
+        "label": "Modal Timer (ms)",
+        "description": "Deprecated. Use exit intent modal with modal-content."
       },
       {
         "component": "aem-content",
         "name": "modal-content",
         "label": "Modal Content",
-        "description": "Load this modal content after the modal timer duration",
+        "description": "Load this modal when exit intent is detected (mouse leaves top, back button, etc.)",
         "valueType": "string"
+      },
+      {
+        "component": "text",
+        "name": "modal-idle-time",
+        "valueType": "string",
+        "label": "Modal Idle Time (ms)",
+        "description": "Idle-after-scroll delay in ms. Default: 5000"
       },
       {
         "component": "tab",

--- a/component-models.json
+++ b/component-models.json
@@ -127,7 +127,7 @@
         "name": "modal-timer",
         "valueType": "string",
         "label": "Modal Timer (ms)",
-        "description": "Deprecated. Use exit intent modal with modal-content."
+        "description": "Idle-after-scroll delay in ms. Default: 5000"
       },
       {
         "component": "aem-content",
@@ -135,13 +135,6 @@
         "label": "Modal Content",
         "description": "Load this modal when exit intent is detected (mouse leaves top, back button, etc.)",
         "valueType": "string"
-      },
-      {
-        "component": "text",
-        "name": "modal-idle-time",
-        "valueType": "string",
-        "label": "Modal Idle Time (ms)",
-        "description": "Idle-after-scroll delay in ms. Default: 5000"
       },
       {
         "component": "tab",

--- a/models/_page.json
+++ b/models/_page.json
@@ -128,7 +128,7 @@
           "name": "modal-timer",
           "valueType": "string",
           "label": "Modal Timer (ms)",
-          "description": "Deprecated. Use exit intent modal with modal-content."
+          "description": "Idle-after-scroll delay in ms. Default: 5000"
         },
         {
           "component": "aem-content",
@@ -136,13 +136,6 @@
           "label": "Modal Content",
           "description": "Load this modal when exit intent is detected (mouse leaves top, back button, etc.)",
           "valueType": "string"
-        },
-        {
-          "component": "text",
-          "name": "modal-idle-time",
-          "valueType": "string",
-          "label": "Modal Idle Time (ms)",
-          "description": "Idle-after-scroll delay in ms. Default: 5000"
         },
         {
           "component": "tab",

--- a/models/_page.json
+++ b/models/_page.json
@@ -127,14 +127,22 @@
           "component": "text",
           "name": "modal-timer",
           "valueType": "string",
-          "label": "Modal Timer (ms)"
+          "label": "Modal Timer (ms)",
+          "description": "Deprecated. Use exit intent modal with modal-content."
         },
         {
           "component": "aem-content",
           "name": "modal-content",
           "label": "Modal Content",
-          "description": "Load this modal content after the modal timer duration",
+          "description": "Load this modal when exit intent is detected (mouse leaves top, back button, etc.)",
           "valueType": "string"
+        },
+        {
+          "component": "text",
+          "name": "modal-idle-time",
+          "valueType": "string",
+          "label": "Modal Idle Time (ms)",
+          "description": "Idle-after-scroll delay in ms. Default: 5000"
         },
         {
           "component": "tab",

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -1545,7 +1545,7 @@ async function loadBreadcrumbs(main) {
 /**
  * Exit intent whole page popup (modal)
  * Loads a modal based on page metadata when exit intent conditions are met.
- * Reads 'modal-content' (path) and optionally 'modal-idle-time' (ms for idle-after-scroll).
+ * Reads 'modal-content' (path) and optionally 'modal-timer' (ms for idle-after-scroll).
  *
  * Triggers (show popup immediately when any is detected):
  * - Mouse leaves top of page (cursor goes above viewport, clientY < 10)
@@ -1556,7 +1556,7 @@ async function loadBreadcrumbs(main) {
  * - Tab focus (user returns to tab via visibilitychange)
  *
  * Delayed trigger:
- * - Idle after scroll: user stops scrolling for modal-idle-time ms (default 5000)
+ * - Idle after scroll: user stops scrolling for modal-timer ms (default 5000)
  */
 function loadExitIntentModal() {
   // Suppress exit intent modals in Universal Editor to avoid disrupting content editing
@@ -1569,7 +1569,7 @@ function loadExitIntentModal() {
     return;
   }
 
-  const idleTimeMs = parseInt(getMetadata('modal-idle-time'), 10);
+  const idleTimeMs = parseInt(getMetadata('modal-timer'), 10);
   const idleAfterScrollMs = (Number.isNaN(idleTimeMs) || idleTimeMs < 0) ? 5000 : idleTimeMs;
 
   let showPopup = true;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -238,6 +238,11 @@ main > h1:first-of-type {
   display: none;
 }
 
+/* Prevent CLS: hide hotspot block from first paint when in hero+hotspot section */
+.block-content:has(.hero-heritage-cc):has(.hotspot) .hotspot {
+  display: none;
+}
+
 main>div {
   margin: 40px 16px;
 }


### PR DESCRIPTION
I currently left in the deprecated json parts, since i'm not sure that if i remove them would imply reauthoring. We can talk about this. 

Fix #562 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://562-exit-intent-popup--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
