### PR TITLE
Refactor header height management for app banner visibility

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -944,10 +944,15 @@ async function loadEager(doc) {
 
   const getAppBanner = sessionStorage.getItem('getAppBanner');
   const header = doc.querySelector('header');
-  // When app banner was closed previously, use nav-height only (avoids space on mobile)
-  if (getAppBanner && header && !MEDIA_QUERIES.desktop.matches) {
-    header.style.height = 'var(--nav-height)';
-    document.body.classList.add('app-banner-closed');
+  if (header && !MEDIA_QUERIES.desktop.matches) {
+    if (getAppBanner) {
+      // Banner was closed previously: use nav-height only (avoids gap on mobile)
+      header.style.height = 'var(--nav-height)';
+      document.body.classList.add('app-banner-closed');
+    } else {
+      // Reserve space for banner before it loads (minimizes CLS when banner injects in loadLazy)
+      document.body.classList.add('expect-app-banner');
+    }
   }
 
   const templateName = getMetadata('template');

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -944,9 +944,10 @@ async function loadEager(doc) {
 
   const getAppBanner = sessionStorage.getItem('getAppBanner');
   const header = doc.querySelector('header');
-  // we are starting out assuming the app banner is open
+  // When app banner was closed previously, use nav-height only (avoids space on mobile)
   if (getAppBanner && header && !MEDIA_QUERIES.desktop.matches) {
     header.style.height = 'var(--nav-height)';
+    document.body.classList.add('app-banner-closed');
   }
 
   const templateName = getMetadata('template');
@@ -1013,6 +1014,7 @@ function decorateGetAppBanner(container) {
     closeBtn.addEventListener('click', () => {
       getAppBanner.classList.add('d-none');
       sessionStorage.setItem('getAppBanner', 'true');
+      document.body.classList.add('app-banner-closed');
       // Reset height style on header when banner is closed
       const header = document.querySelector('header');
       if (header) {

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -159,9 +159,9 @@ header {
   background-color: var(--background-color); /* Header always white to prevent black flash on nav */
 }
 
-/* Mobile: only reserve banner space when the banner is actually in the header (avoids gap when banner not yet loaded or hidden) */
+/* Mobile: reserve space for app banner from first paint when we expect to show it (minimizes CLS when banner loads in loadLazy) */
 @media (width < 990px) {
-  header:has(#grnt-app-mob) {
+  body.expect-app-banner header {
     height: calc(var(--get-app-banner-height) + var(--nav-height));
   }
 }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -1285,7 +1285,7 @@ The height and width are set to 200 assuming the doodles won't be larger. */
 }
 
 @media (width >= 990px) {
-    /* Desktop: no app banner, so header is nav-height only. Prevents awkward space on pages without category nav. */
+    /* Desktop: no app banner, so header is nav-height only. Prevents space on pages without category nav. */
     header {
       height: var(--nav-height);
     }

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -155,8 +155,20 @@ body.appear {
 }
 
 header {
-  height: calc(var(--get-app-banner-height) + var(--nav-height));
+  height: var(--nav-height);
   background-color: var(--background-color); /* Header always white to prevent black flash on nav */
+}
+
+/* Mobile: only reserve banner space when the banner is actually in the header (avoids gap when banner not yet loaded or hidden) */
+@media (width < 990px) {
+  header:has(#grnt-app-mob) {
+    height: calc(var(--get-app-banner-height) + var(--nav-height));
+  }
+}
+
+/* When user has closed the app banner, use nav-height only (class set in loadEager or when they click close) */
+body.app-banner-closed header {
+  height: var(--nav-height);
 }
 
 header .header,
@@ -1273,13 +1285,17 @@ The height and width are set to 200 assuming the doodles won't be larger. */
 }
 
 @media (width >= 990px) {
+    /* Desktop: no app banner, so header is nav-height only. Prevents awkward space on pages without category nav. */
+    header {
+      height: var(--nav-height);
+    }
     /* Reserve space for category-nav BEFORE it loads to prevent CLS.
      The has-category-nav class is added by scripts.js based on page metadata.
      This runs BEFORE body.appear, ensuring correct header height from the start. */
-     body.has-category-nav header,
-     header:has(.category-nav-wrapper) {
-       height: calc(var(--category-nav-height) + var(--nav-height)); /* nav + category-nav = 80px + 64px = 144px */
-     }
+    body.has-category-nav header,
+    header:has(.category-nav-wrapper) {
+      height: calc(var(--category-nav-height) + var(--nav-height)); /* nav + category-nav = 80px + 64px = 144px */
+    }
   }
 
 @media (width >= 1200px) {


### PR DESCRIPTION
Updated header height logic to conditionally adjust based on app banner state. When the app banner is closed, the header now uses only the nav-height to prevent spacing on mobile. Added corresponding CSS rules to ensure proper layout across different screen sizes.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #592 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/cards-testimonial
- After: https://592-remove-space-for-category--idfc--aemsites.aem.page/library/cards-testimonial
