### PR TITLE
Rename 'doodle' references to 'decoration' in JSON, JavaScript, and CSS

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -599,24 +599,24 @@
           {
             "component": "reference",
             "valueType": "string",
-            "name": "doodle-image-top",
-            "label": "Background accessory image - top",
+            "name": "decoration-image-top",
+            "label": "Background decoration image - top",
             "description": "Displayed at top left of the section",
             "multi": false
           },
           {
             "component": "reference",
             "valueType": "string",
-            "name": "doodle-image-bottom",
-            "label": "Background accessory image - bottom",
+            "name": "decoration-image-bottom",
+            "label": "Background decoration image - bottom",
             "description": "Displayed at bottom right of the section",
             "multi": false
           },
           {
             "component": "boolean",
             "valueType": "boolean",
-            "name": "doodle-reverse",
-            "label": "Reverse background accessory images",
+            "name": "decoration-reverse",
+            "label": "Reverse background decoration images",
             "description": "Display at top right and bottom left of the section"
           }
         ]

--- a/models/_section.json
+++ b/models/_section.json
@@ -214,24 +214,24 @@
         {
           "component": "reference",
           "valueType": "string",
-          "name": "doodle-image-top",
-          "label": "Background accessory image - top",
+          "name": "decoration-image-top",
+          "label": "Background decoration image - top",
           "description": "Displayed at top left of the section",
           "multi": false
         },
         {
           "component": "reference",
           "valueType": "string",
-          "name": "doodle-image-bottom",
-          "label": "Background accessory image - bottom",
+          "name": "decoration-image-bottom",
+          "label": "Background decoration image - bottom",
           "description": "Displayed at bottom right of the section",
           "multi": false
         },
         {
           "component": "boolean",
           "valueType": "boolean",
-          "name": "doodle-reverse",
-          "label": "Reverse background accessory images",
+          "name": "decoration-reverse",
+          "label": "Reverse background decoration images",
           "description": "Display at top right and bottom left of the section"
         }
           ]

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -687,7 +687,7 @@ export function handleSectionMetadata(el) {
   }
 
   // Define which keys are handled specially for section or block-content
-  const specialKeys = ['style', 'grid', 'gap', 'spacing', 'container', 'height', 'heightmobile', 'sectionbackgroundimage', 'sectionbackgroundimagemobile', 'backgroundcolor', 'background-block', 'background-block-image', 'background-block-image-mobile', 'object-fit-block', 'object-position-block', 'doodle-image-top', 'doodle-image-bottom', 'doodle-reverse'];
+  const specialKeys = ['style', 'grid', 'gap', 'spacing', 'container', 'height', 'heightmobile', 'sectionbackgroundimage', 'sectionbackgroundimagemobile', 'backgroundcolor', 'background-block', 'background-block-image', 'background-block-image-mobile', 'object-fit-block', 'object-position-block', 'decoration-image-top', 'decoration-image-bottom', 'decoration-reverse'];
 
   // Keys that should preserve original case (not lowercased)
   const preserveCaseKeys = ['tabname', 'multisection'];
@@ -720,28 +720,28 @@ export function handleSectionMetadata(el) {
     handleBackgroundImages(desktopBgImg, mobileBgImg, section);
   }
 
-  // Handle doodle images (background accessory images for ::before and ::after)
-  const doodleImageTop = metadata['doodle-image-top']?.content
-    ? extractImageUrl(metadata['doodle-image-top'].content)
+  // Handle decoration images (background accessory images for ::before and ::after) - previously 'doodles'
+  const decorationImageTop = (metadata['decoration-image-top'] ?? metadata['doodle-image-top'])?.content
+    ? extractImageUrl((metadata['decoration-image-top'] ?? metadata['doodle-image-top']).content)
     : null;
-  const doodleImageBottom = metadata['doodle-image-bottom']?.content
-    ? extractImageUrl(metadata['doodle-image-bottom'].content)
+  const decorationImageBottom = (metadata['decoration-image-bottom'] ?? metadata['doodle-image-bottom'])?.content
+    ? extractImageUrl((metadata['decoration-image-bottom'] ?? metadata['doodle-image-bottom']).content)
     : null;
-  const doodleReverse = metadata['doodle-reverse']?.text === 'true';
+  const decorationReverse = (metadata['decoration-reverse'] ?? metadata['doodle-reverse'])?.text === 'true';
 
-  if (doodleImageTop || doodleImageBottom) {
-    // Set CSS custom properties for the doodle images
+  if (decorationImageTop || decorationImageBottom) {
+    // Set CSS custom properties for the decoration images (previously 'doodles')
     // If reversed, swap top and bottom
-    if (doodleReverse) {
-      if (doodleImageBottom) section.style.setProperty('--doodle-before-image', `url(${doodleImageBottom})`);
-      if (doodleImageTop) section.style.setProperty('--doodle-after-image', `url(${doodleImageTop})`);
+    if (decorationReverse) {
+      if (decorationImageBottom) section.style.setProperty('--decoration-before-image', `url(${decorationImageBottom})`);
+      if (decorationImageTop) section.style.setProperty('--decoration-after-image', `url(${decorationImageTop})`);
     } else {
-      if (doodleImageTop) section.style.setProperty('--doodle-before-image', `url(${doodleImageTop})`);
-      if (doodleImageBottom) section.style.setProperty('--doodle-after-image', `url(${doodleImageBottom})`);
+      if (decorationImageTop) section.style.setProperty('--decoration-before-image', `url(${decorationImageTop})`);
+      if (decorationImageBottom) section.style.setProperty('--decoration-after-image', `url(${decorationImageBottom})`);
     }
-    // Add a class to indicate doodle images are present
-    section.classList.add('has-doodles');
-    if (doodleReverse) section.classList.add('doodles-reversed');
+    // Add a class to indicate decoration images are present (previously 'doodles')
+    section.classList.add('has-decorations');
+    if (decorationReverse) section.classList.add('decorations-reversed');
   }
 
   // Handle BLOCK-CONTENT specific properties

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -720,7 +720,7 @@ export function handleSectionMetadata(el) {
     handleBackgroundImages(desktopBgImg, mobileBgImg, section);
   }
 
-  // Handle decoration images (background accessory images for ::before and ::after) - previously 'doodles'
+  // Handle decoration images (background accessory images (aka doodles) for ::before and ::after)
   const decorationImageTop = (metadata['decoration-image-top'] ?? metadata['doodle-image-top'])?.content
     ? extractImageUrl((metadata['decoration-image-top'] ?? metadata['doodle-image-top']).content)
     : null;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -992,22 +992,22 @@ body.is-framework-page .section.category-nav-section {
   transform: translateY(0);
 }
 
-/* Base styles for sections with doodles */
-.section.has-doodles {
+/* Base styles for sections with decorations (previously 'doodles') */
+.section.has-decorations {
   position: relative;
-  overflow: hidden; /* Optional: prevents doodles from overflowing */
+  overflow: hidden; /* Optional: prevents decorations from overflowing (previously 'doodles') */
 }
 
-/* Top doodle image (top-left by default)
-The height and width are set to 200 assuming the doodles won't be larger. */
-.section.has-doodles::before {
+/* Top decoration image (top-left by default) - previously 'doodles'
+The height and width are set to 200 assuming the decorations won't be larger. */
+.section.has-decorations::before {
   content: '';
   position: absolute;
   top: -50px;
   left: 0;
   width: 200px;
   height: 200px;
-  background-image: var(--doodle-before-image);
+  background-image: var(--decoration-before-image);
   background-size: contain;
   background-repeat: no-repeat;
   background-position: top left;
@@ -1015,15 +1015,15 @@ The height and width are set to 200 assuming the doodles won't be larger. */
   pointer-events: none;
 }
 
-/* Bottom doodle image (bottom-right by default) */
-.section.has-doodles::after {
+/* Bottom decoration image (bottom-right by default) - previously 'doodles' */
+.section.has-decorations::after {
   content: '';
   position: absolute;
   bottom: -80px;
   right: 0;
   width: 200px;
   height: 200px;
-  background-image: var(--doodle-after-image);
+  background-image: var(--decoration-after-image);
   background-size: contain;
   background-repeat: no-repeat;
   background-position: bottom right;
@@ -1031,14 +1031,14 @@ The height and width are set to 200 assuming the doodles won't be larger. */
   pointer-events: none;
 }
 
-/* Reversed positioning (top-right and bottom-left) */
-.section.has-doodles.doodles-reversed::before {
+/* Reversed positioning (top-right and bottom-left) - previously 'doodles' */
+.section.has-decorations.decorations-reversed::before {
   left: auto;
   right: 0;
   background-position: top right;
 }
 
-.section.has-doodles.doodles-reversed::after {
+.section.has-decorations.decorations-reversed::after {
   right: auto;
   left: 0;
   background-position: bottom left;


### PR DESCRIPTION
Also updated handling logic and styles for background decoration images in sections. This is in use on the Mayura page in the Reward Points section. There should be no visual change at all with this update. 

<img width="976" height="938" alt="image" src="https://github.com/user-attachments/assets/ee425cc1-8152-4489-bef1-88350336bfc8" />

Fix #590 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://590-doodles--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
