### PR TITLE
Testimonial Cards styling updates after semantic fixes

### DIFF
--- a/blocks/cards-testimonial/cards-testimonial.css
+++ b/blocks/cards-testimonial/cards-testimonial.css
@@ -1,7 +1,7 @@
 /* stylelint-disable no-descending-specificity */
 
 /* =================================================================
-   TESTIMONIAL CARDS - aligned with old .cards.testimonial-card DOM
+   TESTIMONIAL CARDS
    ================================================================= */
 
 .cards-testimonial > .grid-cards {
@@ -19,7 +19,6 @@
   margin: 0;
 }
 
-/* Grid mode (no Swiper): same card look and dimensions as old testimonial cards */
 .cards-testimonial .grid-cards > .cards-card {
   max-width: 326px;
   background-color: var(--color-gray-300);
@@ -50,39 +49,33 @@
   border-radius: 6px;
 }
 
-/* Grid mode: card body text and icons (match Swiper slide styling) */
-.cards-testimonial .grid-cards .cards-card-body .testimonial-person-name,
-.cards-testimonial .grid-cards .cards-card-body .testimonial-date,
-.cards-testimonial .grid-cards .cards-card-body .testimonial-product-name,
-.cards-testimonial .grid-cards .cards-card-body h5,
-.cards-testimonial .grid-cards .cards-card-body h6,
-.cards-testimonial .grid-cards .cards-card-body p {
+.cards-testimonial .cards-card-body .testimonial-person-name,
+.cards-testimonial .cards-card-body .testimonial-date,
+.cards-testimonial .cards-card-body .testimonial-product-name,
+.cards-testimonial .cards-card-body p {
   color: var(--color-white);
 }
 
-.cards-testimonial .grid-cards .cards-card-body .testimonial-person-name,
-.cards-testimonial .grid-cards .cards-card-body h5 {
+.cards-testimonial .cards-card-body .testimonial-person-name {
   font-size: var(--body-font-size-l);
   font-weight: 500;
   margin: 36px 0 11px;
 }
 
-.cards-testimonial .grid-cards .cards-card-body .testimonial-person-name + p,
-.cards-testimonial .grid-cards .cards-card-body h5 + p {
+.cards-testimonial .cards-card-body .testimonial-person-name + p {
   font-size: var(--body-font-size-s);
   margin: 0 0 var(--spacing-xxs);
 }
 
-.cards-testimonial .grid-cards .cards-card-body .testimonial-product-name,
-.cards-testimonial .grid-cards .cards-card-body .testimonial-product-name u,
-.cards-testimonial .grid-cards .cards-card-body p u {
+.cards-testimonial .cards-card-body .testimonial-product-name,
+.cards-testimonial .cards-card-body .testimonial-product-name u,
+.cards-testimonial .cards-card-body p u {
   font-size: var(--body-font-size-s);
   text-decoration: none;
   font-weight: 700;
 }
 
-/* Review text only; exclude person name, product, date */
-.cards-testimonial .grid-cards .cards-card-body p:not(
+.cards-testimonial .cards-card-body p:not(
   .testimonial-person-name,
   .testimonial-product-name,
   .testimonial-date,
@@ -96,50 +89,40 @@
   margin: 0;
 }
 
-/* Person name: match old cards testimonial h5 (cards.css:1667) */
-.cards-testimonial .grid-cards .cards-card-body .testimonial-person-name {
-  font-size: var(--body-font-size-l);
-  font-weight: 500;
-  margin: 36px 0 11px;
-}
-
-.cards-testimonial .grid-cards .cards-card-body p:has(.icon-inverted-commas) {
+.cards-testimonial .cards-card-body p:has(.icon-inverted-commas) {
   margin: 0 0 16px;
   line-height: 0;
 }
 
-.cards-testimonial .grid-cards .icon-inverted-commas img {
+.cards-testimonial .cards-card-body .icon-inverted-commas img {
   width: 20px;
   height: 16.75px;
 }
 
-.cards-testimonial .grid-cards .cards-card-body p:has(.icon-star) {
+.cards-testimonial .cards-card-body p:has(.icon-star) {
   display: flex;
   margin: 0 0 var(--spacing-xs);
 }
 
-.cards-testimonial .grid-cards .icon-star,
-.cards-testimonial .grid-cards .icon-star-white,
-.cards-testimonial .grid-cards .icon-star-yellow {
+.cards-testimonial .cards-card-body .icon-star,
+.cards-testimonial .cards-card-body .icon-star-white,
+.cards-testimonial .cards-card-body .icon-star-yellow {
   display: inline-block;
   width: auto;
   height: 12px;
   padding-right: 4px;
 }
 
-.cards-testimonial .grid-cards .cards-card-body .testimonial-date,
-.cards-testimonial .grid-cards .cards-card-body h6 {
+.cards-testimonial .cards-card-body .testimonial-date {
   font-size: var(--body-font-size-xs);
   line-height: 1.5;
   text-align: left;
 }
 
-.cards-testimonial .grid-cards .cards-card-body p:has(.icon-star) .icon-star:last-child,
-.cards-testimonial .grid-cards .cards-card-body h6:has(.icon-star) .icon-star:last-child {
+.cards-testimonial .cards-card-body p:has(.icon-star) .icon-star:last-child {
   padding-right: 16px;
 }
 
-/* Section: black background, white centered title (like old .cards-container) */
 .section:has(.cards-testimonial),
 .section:has(.testimonial-cards),
 .section.cards-testimonial-container {
@@ -148,7 +131,6 @@
   padding: 40px 0;
 }
 
-/* Center section content: use same container width as rest of site (main>.section>div) so section isn’t smaller and cards keep 326px. */
 .section:has(.cards-testimonial) .block-content.cards-testimonial-wrapper,
 .section:has(.testimonial-cards) .block-content.cards-testimonial-wrapper,
 .section.cards-testimonial-container .block-content.cards-testimonial-wrapper {
@@ -167,10 +149,6 @@
   text-align: center;
 }
 
-/* =================================================================
-   SWIPER - TESTIMONIAL
-   ================================================================= */
-
 .cards-testimonial.swiper {
   width: 100%;
   height: auto;
@@ -180,7 +158,6 @@
   overflow: hidden;
 }
 
-/* Match old .cards.testimonial-card.swiper: 1050px at 900px (same as .cards.swiper in cards.css) */
 @media (width >= 900px) {
   .cards-testimonial.swiper {
     max-width: 1050px;
@@ -193,7 +170,6 @@
   }
 }
 
-/* Match old .cards.testimonial-card.swiper wrapper/slide styling */
 .cards-testimonial.swiper .swiper-wrapper {
   display: flex;
   flex-wrap: nowrap;
@@ -205,7 +181,6 @@
   cursor: grab;
 }
 
-/* Match old cards testimonial slide (no max-width on mobile; 326px only at 900px+) */
 .cards-testimonial.swiper .swiper-slide {
   flex: 0 0 auto;
   height: auto;
@@ -268,95 +243,6 @@
 
 .cards-testimonial.swiper .swiper-slide-active .cards-card-body {
   z-index: 10;
-}
-
-/* Testimonial card text */
-.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-person-name,
-.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-date,
-.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-product-name,
-.cards-testimonial.swiper .swiper-slide .cards-card-body h5,
-.cards-testimonial.swiper .swiper-slide .cards-card-body h6,
-.cards-testimonial.swiper .swiper-slide .cards-card-body p {
-  color: var(--color-white);
-}
-
-.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-person-name,
-.cards-testimonial.swiper .swiper-slide .cards-card-body h5 {
-  font-size: var(--body-font-size-l);
-  font-weight: 500;
-  margin: 36px 0 11px;
-}
-
-.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-person-name + p,
-.cards-testimonial.swiper .swiper-slide .cards-card-body h5 + p {
-  font-size: var(--body-font-size-s);
-  margin: 0 0 var(--spacing-xxs);
-}
-
-.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-product-name,
-.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-product-name u,
-.cards-testimonial.swiper .swiper-slide .cards-card-body p u {
-  font-size: var(--body-font-size-s);
-  text-decoration: none;
-  font-weight: 700;
-}
-
-/* Review text paragraph only (exclude person name, product, date so their margins apply) */
-.cards-testimonial.swiper .swiper-slide .cards-card-body p:not(
-  .testimonial-person-name,
-  .testimonial-product-name,
-  .testimonial-date,
-  :has(.icon-inverted-commas),
-  :has(.icon-star),
-  :has(u)
-) {
-  font-size: var(--body-font-size-m);
-  font-weight: 600;
-  line-height: normal;
-  margin: 0;
-}
-
-/* Person name: match old cards testimonial h5 (cards.css:1667) */
-.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-person-name {
-  font-size: var(--body-font-size-l);
-  font-weight: 500;
-  margin: 36px 0 11px;
-}
-
-.cards-testimonial.swiper .swiper-slide .cards-card-body p:has(.icon-inverted-commas) {
-  margin: 0 0 16px;
-  line-height: 0;
-}
-
-.cards-testimonial.swiper .swiper-slide .icon-inverted-commas img {
-  width: 20px;
-  height: 16.75px;
-}
-
-.cards-testimonial.swiper .swiper-slide .cards-card-body p:has(.icon-star) {
-  display: flex;
-  margin: 0 0 var(--spacing-xs);
-}
-
-.cards-testimonial.swiper .swiper-slide .icon-star,
-.cards-testimonial.swiper .swiper-slide .icon-star-white,
-.cards-testimonial.swiper .swiper-slide .icon-star-yellow {
-  display: inline-block;
-  width: auto;
-  height: 12px;
-  padding-right: 4px;
-}
-
-.cards-testimonial.swiper .swiper-slide .cards-card-body .testimonial-date,
-.cards-testimonial.swiper .swiper-slide .cards-card-body h6 {
-  font-size: var(--body-font-size-xs);
-  line-height: 1.5;
-  text-align: left;
-}
-
-.cards-testimonial.swiper .swiper-slide .cards-card-body p:has(.icon-star) .icon-star:last-child,
-.cards-testimonial.swiper .swiper-slide h6:has(.icon-star) .icon-star:last-child {
-  padding-right: 16px;
 }
 
 .cards-testimonial.swiper .swiper-slide .cards-card-body:empty {


### PR DESCRIPTION
Styling clean up after the semantic DOM reconstruction. 
I updated the review date property to be a date-time component and restricted the input to date only. This is a clearer authoring experience, however the full ISO date and time string is still found in the markdown and the JCR. Cursor suggests this is how AEM handles datetime types. 

Fix #606 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://606-testimonialUE--idfc--aemsites.aem.page/credit-card/rupay-credit-card


Main after UE changes, before styling updates:
<img width="931" height="586" alt="image" src="https://github.com/user-attachments/assets/80fe32a4-37bb-4746-8677-cbf4e8ed0750" />

Branch after UE changes and styling updates:
<img width="757" height="677" alt="image" src="https://github.com/user-attachments/assets/bf5931bd-d20b-4a39-aa14-a34fbaf9b2da" />

Updated markdown:
<img width="735" height="952" alt="image" src="https://github.com/user-attachments/assets/d130bb44-3a8f-4343-ba0b-cb3c6736aef7" />
