### PR TITLE
Add new section configurations and background properties to component…

### DIFF
--- a/component-models.json
+++ b/component-models.json
@@ -711,6 +711,11 @@
     "id": "multi-section",
     "fields": [
       {
+        "component": "tab",
+        "label": "Section Configs",
+        "name": "tab1"
+      },
+      {
         "component": "text",
         "name": "name",
         "label": "Section Name",
@@ -869,103 +874,99 @@
         ]
       },
       {
-        "component": "container",
-        "label": "Optional outer background properties",
-        "name": "container",
+        "component": "tab",
+        "label": "Background Properties",
+        "name": "tab2"
+      },
+      {
+        "component": "text",
+        "name": "backgroundColor",
+        "label": "Background Color/gradient",
+        "value": "",
         "valueType": "string",
-        "collapsible": true,
-        "fields": [
+        "description": "Use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) or CSS color values (e.g. var(--gradient-silver)"
+      },
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "sectionBackgroundImage",
+        "label": "Background Image",
+        "description": "Background image of the section, displayed on top of the background color if specified",
+        "multi": false
+      },
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "sectionBackgroundImageMobile",
+        "label": "Background Image Mobile",
+        "description": "Background image for mobile",
+        "multi": false
+      },
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "object-fit",
+        "label": "Background Fit",
+        "value": "cover",
+        "options": [
           {
-            "component": "text",
-            "name": "backgroundColor",
-            "label": "Background Color/gradient",
-            "value": "",
-            "valueType": "string",
-            "description": "Use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) or CSS color values (e.g. var(--gradient-silver)"
+            "name": "cover",
+            "value": "cover"
           },
           {
-            "component": "reference",
-            "valueType": "string",
-            "name": "sectionBackgroundImage",
-            "label": "Background Image",
-            "description": "Background image of the section, displayed on top of the background color if specified",
-            "multi": false
+            "name": "contain",
+            "value": "contain"
           },
           {
-            "component": "reference",
-            "valueType": "string",
-            "name": "sectionBackgroundImageMobile",
-            "label": "Background Image Mobile",
-            "description": "Background image for mobile",
-            "multi": false
-          },
-          {
-            "component": "select",
-            "valueType": "string",
-            "name": "object-fit",
-            "label": "Background Fit",
-            "value": "cover",
-            "options": [
-              {
-                "name": "cover",
-                "value": "cover"
-              },
-              {
-                "name": "contain",
-                "value": "contain"
-              },
-              {
-                "name": "none",
-                "value": "none"
-              }
-            ]
-          },
-          {
-            "component": "select",
-            "valueType": "string",
-            "name": "object-position",
-            "label": "Background Image Position",
-            "value": "center",
-            "options": [
-              {
-                "name": "center",
-                "value": "center"
-              },
-              {
-                "name": "top left",
-                "value": "top left"
-              },
-              {
-                "name": "top right",
-                "value": "top right"
-              },
-              {
-                "name": "bottom left",
-                "value": "bottom left"
-              },
-              {
-                "name": "bottom right",
-                "value": "bottom right"
-              }
-            ]
-          },
-          {
-            "component": "text",
-            "name": "height",
-            "label": "Desktop Height",
-            "value": "",
-            "valueType": "string",
-            "description": "optional minimum height when in desktop, e.g. 400px"
-          },
-          {
-            "component": "text",
-            "name": "heightmobile",
-            "label": "Mobile Height",
-            "value": "",
-            "valueType": "string",
-            "description": "optional minimum height when in mobile, e.g. 400px"
+            "name": "none",
+            "value": "none"
           }
         ]
+      },
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "object-position",
+        "label": "Background Image Position",
+        "value": "center",
+        "options": [
+          {
+            "name": "center",
+            "value": "center"
+          },
+          {
+            "name": "top left",
+            "value": "top left"
+          },
+          {
+            "name": "top right",
+            "value": "top right"
+          },
+          {
+            "name": "bottom left",
+            "value": "bottom left"
+          },
+          {
+            "name": "bottom right",
+            "value": "bottom right"
+          }
+        ]
+      },
+      {
+        "component": "text",
+        "name": "height",
+        "label": "Desktop Height",
+        "value": "",
+        "valueType": "string",
+        "description": "optional minimum height when in desktop, e.g. 400px"
+      },
+      {
+        "component": "text",
+        "name": "heightmobile",
+        "label": "Mobile Height",
+        "value": "",
+        "valueType": "string",
+        "description": "optional minimum height when in mobile, e.g. 400px"
       }
     ]
   },

--- a/component-models.json
+++ b/component-models.json
@@ -290,6 +290,11 @@
     "id": "section",
     "fields": [
       {
+        "component": "tab",
+        "label": "Section Configs",
+        "name": "section-configs"
+      },
+      {
         "component": "text",
         "name": "name",
         "label": "Section Name",
@@ -500,126 +505,122 @@
         ]
       },
       {
-        "component": "container",
-        "label": "Optional outer background properties",
-        "name": "container",
+        "component": "tab",
+        "label": "Background Properties",
+        "name": "background-properties"
+      },
+      {
+        "component": "text",
+        "name": "backgroundColor",
+        "label": "Background Color/gradient",
+        "value": "",
         "valueType": "string",
-        "collapsible": true,
-        "fields": [
+        "description": "Use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) or CSS color values (e.g. var(--gradient-silver)"
+      },
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "sectionBackgroundImage",
+        "label": "Background Image",
+        "description": "Background image of the section, displayed on top of the background color if specified",
+        "multi": false
+      },
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "sectionBackgroundImageMobile",
+        "label": "Background Image Mobile",
+        "description": "Background image for mobile",
+        "multi": false
+      },
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "object-fit",
+        "label": "Background Fit",
+        "value": "cover",
+        "options": [
           {
-            "component": "text",
-            "name": "backgroundColor",
-            "label": "Background Color/gradient",
-            "value": "",
-            "valueType": "string",
-            "description": "Use hex (e.g. #000000), RGB (e.g. rgb(0, 0, 0)) or CSS color values (e.g. var(--gradient-silver)"
+            "name": "cover",
+            "value": "cover"
           },
           {
-            "component": "reference",
-            "valueType": "string",
-            "name": "sectionBackgroundImage",
-            "label": "Background Image",
-            "description": "Background image of the section, displayed on top of the background color if specified",
-            "multi": false
+            "name": "contain",
+            "value": "contain"
           },
           {
-            "component": "reference",
-            "valueType": "string",
-            "name": "sectionBackgroundImageMobile",
-            "label": "Background Image Mobile",
-            "description": "Background image for mobile",
-            "multi": false
-          },
-          {
-            "component": "select",
-            "valueType": "string",
-            "name": "object-fit",
-            "label": "Background Fit",
-            "value": "cover",
-            "options": [
-              {
-                "name": "cover",
-                "value": "cover"
-              },
-              {
-                "name": "contain",
-                "value": "contain"
-              },
-              {
-                "name": "none",
-                "value": "none"
-              }
-            ]
-          },
-          {
-            "component": "select",
-            "valueType": "string",
-            "name": "object-position",
-            "label": "Background Image Position",
-            "value": "center",
-            "options": [
-              {
-                "name": "center",
-                "value": "center"
-              },
-              {
-                "name": "top left",
-                "value": "top left"
-              },
-              {
-                "name": "top right",
-                "value": "top right"
-              },
-              {
-                "name": "bottom left",
-                "value": "bottom left"
-              },
-              {
-                "name": "bottom right",
-                "value": "bottom right"
-              }
-            ]
-          },
-          {
-            "component": "text",
-            "name": "height",
-            "label": "Desktop Height",
-            "value": "",
-            "valueType": "string",
-            "description": "optional minimum height when in desktop, e.g. 400px"
-          },
-          {
-            "component": "text",
-            "name": "heightmobile",
-            "label": "Mobile Height",
-            "value": "",
-            "valueType": "string",
-            "description": "optional minimum height when in mobile, e.g. 400px"
-          },
-          {
-            "component": "reference",
-            "valueType": "string",
-            "name": "doodle-image-top",
-            "label": "Background accessory image - top",
-            "description": "Displayed at top left of the section",
-            "multi": false
-          },
-          {
-            "component": "reference",
-            "valueType": "string",
-            "name": "doodle-image-bottom",
-            "label": "Background accessory image - bottom",
-            "description": "Displayed at bottom right of the section",
-            "multi": false
-          },
-          {
-            "component": "boolean",
-            "valueType": "boolean",
-            "name": "doodle-reverse",
-            "label": "Reverse background accessory images",
-            "description": "Display at top right and bottom left of the section"
+            "name": "none",
+            "value": "none"
           }
         ]
+      },
+      {
+        "component": "select",
+        "valueType": "string",
+        "name": "object-position",
+        "label": "Background Image Position",
+        "value": "center",
+        "options": [
+          {
+            "name": "center",
+            "value": "center"
+          },
+          {
+            "name": "top left",
+            "value": "top left"
+          },
+          {
+            "name": "top right",
+            "value": "top right"
+          },
+          {
+            "name": "bottom left",
+            "value": "bottom left"
+          },
+          {
+            "name": "bottom right",
+            "value": "bottom right"
+          }
+        ]
+      },
+      {
+        "component": "text",
+        "name": "height",
+        "label": "Desktop Height",
+        "value": "",
+        "valueType": "string",
+        "description": "optional minimum height when in desktop, e.g. 400px"
+      },
+      {
+        "component": "text",
+        "name": "heightmobile",
+        "label": "Mobile Height",
+        "value": "",
+        "valueType": "string",
+        "description": "optional minimum height when in mobile, e.g. 400px"
+      },
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "doodle-image-top",
+        "label": "Background accessory image - top",
+        "description": "Displayed at top left of the section",
+        "multi": false
+      },
+      {
+        "component": "reference",
+        "valueType": "string",
+        "name": "doodle-image-bottom",
+        "label": "Background accessory image - bottom",
+        "description": "Displayed at bottom right of the section",
+        "multi": false
+      },
+      {
+        "component": "boolean",
+        "valueType": "boolean",
+        "name": "doodle-reverse",
+        "label": "Reverse background accessory images",
+        "description": "Display at top right and bottom left of the section"
       },
       {
         "component": "container",

--- a/component-models.json
+++ b/component-models.json
@@ -802,11 +802,6 @@
         ]
       },
       {
-        "component": "tab",
-        "label": "Background Properties",
-        "name": "tab2"
-      },
-      {
         "component": "container",
         "label": "Optional layout properties",
         "name": "layout-container",
@@ -877,6 +872,11 @@
             ]
           }
         ]
+      },
+      {
+        "component": "tab",
+        "label": "Background Properties",
+        "name": "tab2"
       },
       {
         "component": "text",

--- a/component-models.json
+++ b/component-models.json
@@ -802,6 +802,11 @@
         ]
       },
       {
+        "component": "tab",
+        "label": "Background Properties",
+        "name": "tab2"
+      },
+      {
         "component": "container",
         "label": "Optional layout properties",
         "name": "layout-container",
@@ -872,11 +877,6 @@
             ]
           }
         ]
-      },
-      {
-        "component": "tab",
-        "label": "Background Properties",
-        "name": "tab2"
       },
       {
         "component": "text",

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -89,11 +89,6 @@
             ]
           },
           {
-            "component": "tab",
-            "label": "Background Properties",
-            "name": "tab2"
-          },
-          {
             "component": "container",
             "label": "Optional layout properties",
             "name": "layout-container",
@@ -139,6 +134,11 @@
             ]
           }
           ]
+          },
+          {
+            "component": "tab",
+            "label": "Background Properties",
+            "name": "tab2"
           },
           {
             "component": "text",

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -23,6 +23,11 @@
         "id": "multi-section",
         "fields": [
             {
+                "component": "tab",
+                "label": "Section Configs",
+                "name": "tab1"
+            },
+            {
                 "component": "text",
                 "name": "name",
                 "label": "Section Name",
@@ -131,12 +136,10 @@
           ]
           },
           {
-            "component": "container",
-            "label": "Optional outer background properties",
-            "name": "container",
-            "valueType": "string",
-            "collapsible": true,
-            "fields": [
+            "component": "tab",
+            "label": "Background Properties",
+            "name": "tab2"
+          },
           {
             "component": "text",
             "name": "backgroundColor",
@@ -200,8 +203,6 @@
             "value": "",
             "valueType": "string",
             "description": "optional minimum height when in mobile, e.g. 400px"
-          }
-            ]
           }
         ]
       }

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -89,6 +89,11 @@
             ]
           },
           {
+            "component": "tab",
+            "label": "Background Properties",
+            "name": "tab2"
+          },
+          {
             "component": "container",
             "label": "Optional layout properties",
             "name": "layout-container",
@@ -134,11 +139,6 @@
             ]
           }
           ]
-          },
-          {
-            "component": "tab",
-            "label": "Background Properties",
-            "name": "tab2"
           },
           {
             "component": "text",

--- a/models/_section.json
+++ b/models/_section.json
@@ -20,6 +20,11 @@
       "id": "section",
       "fields": [
         {
+          "component": "tab",
+          "label": "Section Configs",
+          "name": "section-configs"
+        },
+        {
           "component": "text",
           "name": "name",
           "label": "Section Name",
@@ -37,7 +42,36 @@
           "label": "Style",
           "options": [
             {
-              "...": "./partials/_section-style.json#/options"
+              "name": "Center",
+              "value": "center"
+            },
+            {
+              "name": "Light scheme",
+              "value": "light-scheme"
+            },
+            {
+              "name": "Dark scheme",
+              "value": "dark-scheme"
+            },
+            {
+              "name": "Hide in mobile",
+              "value": "hide-mobile"
+            },
+            {
+              "name": "Hide in desktop",
+              "value": "hide-desktop"
+            },
+            {
+              "name": "Entrance Animation",
+              "value": "entrance-animation"
+            },
+            {
+              "name": "(Tabs) Blue with White Text",
+              "value": "blue-white-text"
+            },
+            {
+              "name": "(Tabs) Silver with Blue Text",
+              "value": "silver-blue-text"
             }
           ]
         },
@@ -48,7 +82,32 @@
           "valueType": "string",
           "options": [
             {
-              "...": "./partials/_sizes.json#/options"
+              "name": "Default",
+              "value": ""
+            },
+            {
+              "name": "XXL",
+              "value": "size-xxl"
+            },
+            {
+              "name": "XL",
+              "value": "size-xl"
+            },
+            {
+              "name": "L",
+              "value": "size-l"
+            },
+            {
+              "name": "M",
+              "value": "size-m"
+            },
+            {
+              "name": "S",
+              "value": "size-s"
+            },
+            {
+              "name": "XS",
+              "value": "size-xs"
             }
           ]
         },
@@ -64,7 +123,12 @@
           "label": "Section group identifier - give all sections the same value to group them in one section",
           "value": "",
           "condition": {
-            "==": [{ "var": "is-multisection" }, true]
+            "==": [
+              {
+                "var": "is-multisection"
+              },
+              true
+            ]
           }
         },
         {
@@ -72,24 +136,29 @@
           "name": "category",
           "label": "Grouped section type",
           "condition": {
-            "==": [{ "var": "is-multisection" }, true]
+            "==": [
+              {
+                "var": "is-multisection"
+              },
+              true
+            ]
           },
           "options": [
-              {
-                  "name": "Tabs horizontal",
-                  "value": "tabs-horizontal"
-              },
-              {
-                  "name": "Tabs vertical",
-                  "value": "tabs-vertical"
-              },
-              {
-                  "name": "Accordion",
-                  "value": "accordion"
-              },
-              {
-                "name": "none",
-                "value": ""
+            {
+              "name": "Tabs horizontal",
+              "value": "tabs-horizontal"
+            },
+            {
+              "name": "Tabs vertical",
+              "value": "tabs-vertical"
+            },
+            {
+              "name": "Accordion",
+              "value": "accordion"
+            },
+            {
+              "name": "none",
+              "value": ""
             }
           ]
         },
@@ -100,53 +169,76 @@
           "valueType": "string",
           "collapsible": true,
           "fields": [
-        {
-          "component": "text",
-          "name": "grid",
-          "label": "Grid layout (enter # of columns, 2-6)",
-          "valueType": "string"
-        },
-        {
-          "component": "select",
-          "name": "gap",
-          "label": "(grid layout) gap between blocks",
-          "valueType": "string",
-          "options": [
             {
-              "...": "./partials/_sizes.json#/options"
+              "component": "text",
+              "name": "grid",
+              "label": "Grid layout (enter # of columns, 2-6)",
+              "valueType": "string"
+            },
+            {
+              "component": "select",
+              "name": "gap",
+              "label": "(grid layout) gap between blocks",
+              "valueType": "string",
+              "options": [
+                {
+                  "name": "Default",
+                  "value": ""
+                },
+                {
+                  "name": "XXL",
+                  "value": "size-xxl"
+                },
+                {
+                  "name": "XL",
+                  "value": "size-xl"
+                },
+                {
+                  "name": "L",
+                  "value": "size-l"
+                },
+                {
+                  "name": "M",
+                  "value": "size-m"
+                },
+                {
+                  "name": "S",
+                  "value": "size-s"
+                },
+                {
+                  "name": "XS",
+                  "value": "size-xs"
+                }
+              ]
+            },
+            {
+              "component": "select",
+              "name": "containerwidth",
+              "label": "Inner div width",
+              "valueType": "string",
+              "description": "unrelated to grid layout",
+              "options": [
+                {
+                  "name": "33%",
+                  "value": "2"
+                },
+                {
+                  "name": "66%",
+                  "value": "4"
+                },
+                {
+                  "name": "100%",
+                  "value": "6"
+                }
+              ]
             }
           ]
         },
         {
-          "component": "select",
-          "name": "containerwidth",
-          "label": "Inner div width",
-          "valueType": "string",
-          "description": "unrelated to grid layout",
-          "options": [
-            {
-              "name": "33%",
-              "value": "2"
-            },
-            {
-              "name": "66%",
-              "value": "4"
-            },
-            {
-              "name": "100%",
-              "value": "6"
-            }
-          ]
-        }
-        ]
+          "component": "tab",
+          "label": "Background Properties",
+          "name": "background-properties"
         },
-        {
-          "component": "container",
-          "label": "Optional outer background properties",
-          "name": "container",
-          "valueType": "string",
-          "collapsible": true,
-          "fields": [
         {
           "component": "text",
           "name": "backgroundColor",
@@ -179,7 +271,16 @@
           "value": "cover",
           "options": [
             {
-              "...": "./partials/_bg-fit.json#/options"
+              "name": "cover",
+              "value": "cover"
+            },
+            {
+              "name": "contain",
+              "value": "contain"
+            },
+            {
+              "name": "none",
+              "value": "none"
             }
           ]
         },
@@ -191,7 +292,24 @@
           "value": "center",
           "options": [
             {
-              "...": "./partials/_bg-position.json#/options"
+              "name": "center",
+              "value": "center"
+            },
+            {
+              "name": "top left",
+              "value": "top left"
+            },
+            {
+              "name": "top right",
+              "value": "top right"
+            },
+            {
+              "name": "bottom left",
+              "value": "bottom left"
+            },
+            {
+              "name": "bottom right",
+              "value": "bottom right"
             }
           ]
         },
@@ -233,8 +351,6 @@
           "name": "doodle-reverse",
           "label": "Reverse background accessory images",
           "description": "Display at top right and bottom left of the section"
-        }
-          ]
         },
         {
           "component": "container",
@@ -275,7 +391,16 @@
               "value": "cover",
               "options": [
                 {
-                  "...": "./partials/_bg-fit.json#/options"
+                  "name": "cover",
+                  "value": "cover"
+                },
+                {
+                  "name": "contain",
+                  "value": "contain"
+                },
+                {
+                  "name": "none",
+                  "value": "none"
                 }
               ]
             },
@@ -287,7 +412,24 @@
               "value": "center",
               "options": [
                 {
-                  "...": "./partials/_bg-position.json#/options"
+                  "name": "center",
+                  "value": "center"
+                },
+                {
+                  "name": "top left",
+                  "value": "top left"
+                },
+                {
+                  "name": "top right",
+                  "value": "top right"
+                },
+                {
+                  "name": "bottom left",
+                  "value": "bottom left"
+                },
+                {
+                  "name": "bottom right",
+                  "value": "bottom right"
                 }
               ]
             }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2992,10 +2992,11 @@
       }
     },
     "node_modules/lodash": {
-      "version": "4.17.21",
-      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-      "dev": true
+      "version": "4.17.23",
+      "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.23.tgz",
+      "integrity": "sha512-LgVTMpQtIopCi79SJeDiP0TfWi5CNEc/L/aRdTh3yIvmZXTnheWpKjSZhnvMl8iXbC1tFg9gdHHDMLoV7CnG+w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/lodash.merge": {
       "version": "4.6.2",


### PR DESCRIPTION
… models

- Introduced a new tab for "Section Configs" in the component models.
- Refactored background properties to include separate fields for desktop and mobile height, background images, and object-fit options.
- Enhanced the structure for better organization and clarity in the JSON configuration.

Please always provide the [GitHub issue(s)](../issues) your PR is for, as well as test URLs where your change can be observed (before and after):

Fix #609 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://609-background-tab--idfc--aemsites.aem.page/

This will need to be tested in the UE by selecting any section within a page to see. Here is a link as an example of how to look:

https://experience.adobe.com/#/@sitesinternal/aem/editor/canvas/author-idfc-stage-65.adobecqms.net/content/idfc-edge/credit-card/rupay-credit-card.html?ref=609-background-tab

<img width="2876" height="1278" alt="image" src="https://github.com/user-attachments/assets/89baaa70-f325-41fd-aee8-6c8897e6a3ae" />

