### PR TITLE
First UE update for tabs-UPI

### DIFF
--- a/blocks/tabs-upi-link/_tabs-upi-link.json
+++ b/blocks/tabs-upi-link/_tabs-upi-link.json
@@ -39,11 +39,10 @@
         "id": "tabs-upi-link",
         "fields": [
           {
-            "component": "reference",
+            "component": "text",
             "valueType": "string",
-            "name": "image",
-            "label": "Image",
-            "multi": false
+            "name": "classes",
+            "label": "Style"
           },
           {
             "component": "richtext",
@@ -53,27 +52,21 @@
             "valueType": "string"
           },
           {
-            "component": "text",
+            "component": "reference",
             "valueType": "string",
-            "name": "classes",
-            "label": "Style"
+            "name": "phone_image",
+            "label": "Image",
+            "multi": false
           },
           {
             "component": "reference",
             "valueType": "string",
-            "name": "phone-video",
+            "name": "phone_video",
             "label": "Phone Video",
             "multi": false,
             "filter": {
               "mimeTypes": ["video/mp4"]
             }
-          },
-          {
-            "component": "richtext",
-            "name": "temp-video-url",
-            "value": "",
-            "label": "Temporary External Phone Video URL",
-            "valueType": "string"
           }
         ]
       },

--- a/component-models.json
+++ b/component-models.json
@@ -2406,11 +2406,10 @@
     "id": "tabs-upi-link",
     "fields": [
       {
-        "component": "reference",
+        "component": "text",
         "valueType": "string",
-        "name": "image",
-        "label": "Image",
-        "multi": false
+        "name": "classes",
+        "label": "Style"
       },
       {
         "component": "richtext",
@@ -2420,15 +2419,16 @@
         "valueType": "string"
       },
       {
-        "component": "text",
+        "component": "reference",
         "valueType": "string",
-        "name": "classes",
-        "label": "Style"
+        "name": "phone_image",
+        "label": "Image",
+        "multi": false
       },
       {
         "component": "reference",
         "valueType": "string",
-        "name": "phone-video",
+        "name": "phone_video",
         "label": "Phone Video",
         "multi": false,
         "filter": {
@@ -2436,13 +2436,6 @@
             "video/mp4"
           ]
         }
-      },
-      {
-        "component": "richtext",
-        "name": "temp-video-url",
-        "value": "",
-        "label": "Temporary External Phone Video URL",
-        "valueType": "string"
       }
     ]
   },


### PR DESCRIPTION
UE updates for the linting and MP4 adjusting of the tabs-UPI block. The lint error is gone after this update, but styling and some re-authoring still need to be done. 

The JSON changes look messier than they are due to me moving around items to make more visual sense with the new groupings.

Fix #624 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://624-tabUPI-lintCleanup--idfc--aemsites.aem.page/credit-card/rupay-credit-card
