### PR TITLE
refactor of multi sections

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -868,7 +868,7 @@
 .cards.experience-life > .grid-cards > .cards-card,
 .cards.experience-life > .swiper-wrapper > .cards-card,
 .cards.experience-life .benefit-cards {
-  padding-top: 140px;
+  padding-top: 160px;
 }
 
 /* Experience Life - Gray/silver gradient with image as background */
@@ -910,7 +910,7 @@
   border: 1px solid rgba(255 255 255 / 60%);
   border-radius: 4px;
   color: #2E3E79;
-  font-size: var(--body-font-size-xxs);
+  font-size: var(--body-font-size-xxs) !important;
   font-weight: 700;
   line-height: 1.2;
   margin: 0;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -1007,7 +1007,6 @@
   color: var(--color-white);
   font-size: var(--heading-font-size-xs);
   font-weight: 700;
-  line-height: 1.3;
   margin: 0 0 var(--spacing-xs);
   background: var(--gradient-silver);
   background-clip: text;
@@ -1018,7 +1017,6 @@
 .cards.reward-points .benefit-cards .cards-card-body p {
   color: rgba(255 255 255 / 80%);
   font-size: var(--body-font-size-s);
-  line-height: 1.5;
   margin: 0 0 var(--spacing-xxs);
 }
 
@@ -1237,7 +1235,6 @@
 
   .cards .benefit-cards .cards-card-body p {
     font-size: var(--body-font-size-s);
-    line-height: 24px;
   }
 
   /* Important Documents Cards - Tablet View (600px+) */
@@ -1933,10 +1930,6 @@
 
   .cards.key-benefits .benefit-cards .cards-card-body {
     padding: 0 28px 28px;
-  }
-  
-  .cards.reward-points .benefit-cards .cards-card-body p {
-    font-size: var(--body-font-size-m);
   }
 
   .cards.key-benefits .benefit-cards .cards-card-body p:has(.icon-arrow-right-white) {

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -90,7 +90,7 @@
 .section.multi.tabs-container .tabs-list {
     max-width: var(--grid-container-width);
     width: fit-content;
-    margin: 0 auto;
+    margin: 0 auto var(--spacing-s) auto;
 }
 
 .section[data-category="tabs-vertical"].multi.tabs-container .tabs-list {

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -87,20 +87,17 @@
 }
 
 /* new tab-section styles */
-.section.tabs-container div.tabs-wrapper {
-
-  .tabs-list, .section-title {
+.section.multi.tabs-container .tabs-list {
     max-width: var(--grid-container-width);
     width: fit-content;
     margin: 0 auto;
-  }
+}
 
-  .tabs.vertical .tabs-list {
+.section[data-category="tabs-vertical"].multi.tabs-container .tabs-list {
     display: flex;
     flex-direction: column;
     width: 100%;
   }
-}
 
 @media (width >= 900px) {
   .tabs .tabs-list .tabs-tab {
@@ -125,18 +122,7 @@
   }
 
   /* new tab-section styles */
-.section.tabs-container div.tabs-wrapper {
-
-  .tabs.vertical {
-    display: flex;
-    flex-direction: row;
-    flex-wrap: wrap;
-    align-items: flex-start;
-    gap: var(--spacing-s);
-
-    > div {
-      flex: 0 0 100%;
-    }
+.section.multi.tabs-container {
 
     .tabs-list {
       flex: 0 0 150px;
@@ -145,6 +131,13 @@
     .tabs-panel {
       flex: 1 1 calc(100% - 200px);
     }
-  }
+}
+
+.section[data-category="tabs-vertical"].multi.tabs-container .tabs {
+  display: flex;
+  flex-direction: row;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  gap: var(--spacing-s);
 }
 }

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -63,7 +63,6 @@ export default async function decorate(block) {
       tabpanel.setAttribute('aria-hidden', !!i);
       tabpanel.setAttribute('aria-labelledby', `tab-${id}`);
       tabpanel.setAttribute('role', 'tabpanel');
-      moveInstrumentation(tab.parentElement, tabpanel.lastElementChild);
 
       const tabTextWrapper = document.createElement('div');
       if (tabName) {

--- a/component-models.json
+++ b/component-models.json
@@ -760,42 +760,6 @@
         ]
       },
       {
-        "component": "select",
-        "name": "spacing",
-        "label": "Spacing top and bottom of section",
-        "valueType": "string",
-        "options": [
-          {
-            "name": "Default",
-            "value": ""
-          },
-          {
-            "name": "XXL",
-            "value": "xxl"
-          },
-          {
-            "name": "XL",
-            "value": "xl"
-          },
-          {
-            "name": "L",
-            "value": "l"
-          },
-          {
-            "name": "M",
-            "value": "m"
-          },
-          {
-            "name": "S",
-            "value": "s"
-          },
-          {
-            "name": "XS",
-            "value": "xs"
-          }
-        ]
-      },
-      {
         "component": "container",
         "label": "Optional layout properties",
         "name": "layout-container",

--- a/component-models.json
+++ b/component-models.json
@@ -352,27 +352,27 @@
           },
           {
             "name": "XXL",
-            "value": "size-xxl"
+            "value": "xxl"
           },
           {
             "name": "XL",
-            "value": "size-xl"
+            "value": "xl"
           },
           {
             "name": "L",
-            "value": "size-l"
+            "value": "l"
           },
           {
             "name": "M",
-            "value": "size-m"
+            "value": "m"
           },
           {
             "name": "S",
-            "value": "size-s"
+            "value": "s"
           },
           {
             "name": "XS",
-            "value": "size-xs"
+            "value": "xs"
           }
         ]
       },
@@ -452,27 +452,27 @@
               },
               {
                 "name": "XXL",
-                "value": "size-xxl"
+                "value": "xxl"
               },
               {
                 "name": "XL",
-                "value": "size-xl"
+                "value": "xl"
               },
               {
                 "name": "L",
-                "value": "size-l"
+                "value": "l"
               },
               {
                 "name": "M",
-                "value": "size-m"
+                "value": "m"
               },
               {
                 "name": "S",
-                "value": "size-s"
+                "value": "s"
               },
               {
                 "name": "XS",
-                "value": "size-xs"
+                "value": "xs"
               }
             ]
           },
@@ -771,27 +771,27 @@
           },
           {
             "name": "XXL",
-            "value": "size-xxl"
+            "value": "xxl"
           },
           {
             "name": "XL",
-            "value": "size-xl"
+            "value": "xl"
           },
           {
             "name": "L",
-            "value": "size-l"
+            "value": "l"
           },
           {
             "name": "M",
-            "value": "size-m"
+            "value": "m"
           },
           {
             "name": "S",
-            "value": "size-s"
+            "value": "s"
           },
           {
             "name": "XS",
-            "value": "size-xs"
+            "value": "xs"
           }
         ]
       },
@@ -820,27 +820,27 @@
               },
               {
                 "name": "XXL",
-                "value": "size-xxl"
+                "value": "xxl"
               },
               {
                 "name": "XL",
-                "value": "size-xl"
+                "value": "xl"
               },
               {
                 "name": "L",
-                "value": "size-l"
+                "value": "l"
               },
               {
                 "name": "M",
-                "value": "size-m"
+                "value": "m"
               },
               {
                 "name": "S",
-                "value": "size-s"
+                "value": "s"
               },
               {
                 "name": "XS",
-                "value": "size-xs"
+                "value": "xs"
               }
             ]
           },

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -73,17 +73,6 @@
             ]
           },
           {
-            "component": "select",
-            "name": "spacing",
-            "label": "Spacing top and bottom of section",
-            "valueType": "string",
-            "options": [
-              {
-                "...": "./partials/_sizes.json#/options"
-              }
-            ]
-          },
-          {
             "component": "container",
             "label": "Optional layout properties",
             "name": "layout-container",

--- a/models/partials/_sizes.json
+++ b/models/partials/_sizes.json
@@ -6,27 +6,27 @@
         },
         {
           "name": "XXL",
-          "value": "size-xxl"
+          "value": "xxl"
         },
         {
           "name": "XL",
-          "value": "size-xl"
+          "value": "xl"
         },
         {
           "name": "L",
-          "value": "size-l"
+          "value": "l"
         },
         {
           "name": "M",
-          "value": "size-m"
+          "value": "m"
         },
         {
           "name": "S",
-          "value": "size-s"
+          "value": "s"
         },
         {
           "name": "XS",
-          "value": "size-xs"
+          "value": "xs"
         }
       ]
 }

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -628,10 +628,12 @@ function decorateBlock(block) {
 
 /**
  * Decorates all blocks in a container element.
+ * Section elements (e.g. nested sections inside tabs/accordion) must not be
+ * treated as blocks; only actual content blocks are decorated.
  * @param {Element} main The container element
  */
 function decorateBlocks(main) {
-  main.querySelectorAll('div.section > div > div').forEach(decorateBlock);
+  main.querySelectorAll('div.section > div > div:not(.section)').forEach(decorateBlock);
 }
 
 /**

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -849,84 +849,83 @@ function initEntranceAnimationObserver(container) {
   sections.forEach((section) => observer.observe(section));
 }
 
-function groupItemsByMultisection(items) {
-  const grouped = {};
-  items.forEach((item) => {
-    const groupValue = item.getAttribute('data-multisection');
-    if (!grouped[groupValue]) {
-      grouped[groupValue] = [];
-    }
-    grouped[groupValue].push(item);
-  });
-  return grouped;
+/**
+ * Finds all elements in main with the same data-multisection as the container section,
+ * excluding the container itself. Items may be other sections or divs (tab/accordion panels).
+ */
+function getMultisectionItemsForSection(main, containerSection) {
+  const groupValue = containerSection.getAttribute('data-multisection');
+  if (!groupValue) return [];
+  const matches = main.querySelectorAll(`[data-multisection="${groupValue}"]`);
+  return [...matches].filter((el) => el !== containerSection);
 }
 
-function createSectionFromGroup(groupItems, blockClass, handlePicture = false) {
-  const firstItem = groupItems[0];
-  const section = document.createElement('div');
-  section.classList.add('section', 'multi');
-  section.id = firstItem.getAttribute('data-multisection');
-
-  // Copy all classes from the first item to the section
-  firstItem.classList.forEach((className) => {
-    section.classList.add(className);
-  });
-
-  // Copy inline styles from the first item to the section
-  const inlineStyles = firstItem.getAttribute('style');
-  if (inlineStyles) {
-    section.setAttribute('style', inlineStyles);
-    firstItem.removeAttribute('style');
+/**
+ * Ensures the section has a .block-content wrapper so blocks are discoverable.
+ * Creates one and prepends it to the section if missing.
+ * @param {Element} section The section element
+ * @returns {Element} The .block-content element (existing or newly created)
+ */
+function ensureBlockContent(section) {
+  let contentContainer = section.querySelector(':scope > .block-content');
+  if (!contentContainer) {
+    contentContainer = document.createElement('div');
+    contentContainer.className = 'block-content';
+    section.prepend(contentContainer);
+    if (section.blocks) section.blocks = [...section.querySelectorAll('.block-content > div[class]')];
   }
+  return contentContainer;
+}
 
-  // Handle picture.bg-images for tabs
+/**
+ * Builds the tabs/accordion block inside an existing section and moves the grouped items into it.
+ * Appends the block as a direct child of .block-content so it is discovered and decorated.
+ * Returns the created block element so the section's blocks list can be updated.
+ */
+function appendMultiSectionBlock(section, groupItems, blockClass, handlePicture = false) {
+  const firstItem = groupItems[0];
+
   if (handlePicture) {
     const firstChild = firstItem.firstElementChild;
-    if (firstChild && firstChild.tagName === 'PICTURE' && firstChild.classList.contains('bg-images')) {
+    if (firstChild?.tagName === 'PICTURE' && firstChild.classList.contains('bg-images')) {
       firstChild.remove();
       section.prepend(firstChild);
     }
   }
 
-  // Create wrapper and block structure
-  const wrapperDiv = document.createElement('div');
   const blockDiv = document.createElement('div');
   blockDiv.classList.add(blockClass);
   groupItems.forEach((item) => {
     blockDiv.append(item);
   });
-  wrapperDiv.append(blockDiv);
-  section.append(wrapperDiv);
 
-  return section;
+  const contentContainer = ensureBlockContent(section);
+  contentContainer.append(blockDiv);
+
+  if (section.blocks) {
+    section.blocks.push(blockDiv);
+  }
+  return blockDiv;
 }
 
 export function buildMultiSection(main) {
-  // Handle accordions
-  const accordionItems = main.querySelectorAll('div[data-category="accordion"]');
-  if (accordionItems.length > 0) {
-    const groupedAccordions = groupItemsByMultisection(accordionItems);
-    Object.values(groupedAccordions).forEach((groupItems) => {
-      const [firstItem] = groupItems;
-      const { parentElement: parent, nextSibling } = firstItem;
-      const accordionSection = createSectionFromGroup(groupItems, 'accordion', true);
-      // Insert section at the position where the first item was
-      parent.insertBefore(accordionSection, nextSibling);
-    });
-  }
+  const containerSections = main.querySelectorAll('.section[data-is-multisection="true"]');
 
-  // Handle tabs: items with data-multisection that are not accordions
-  const tabItems = main.querySelectorAll('div[data-multisection]:not([data-category="accordion"])');
-  if (tabItems.length > 0) {
-    const groupedTabs = groupItemsByMultisection(tabItems);
-    Object.values(groupedTabs).forEach((groupItems) => {
-      const [firstItem] = groupItems;
-      const { parentElement: parent, nextSibling } = firstItem;
-      const multisection = createSectionFromGroup(groupItems, 'tabs', true);
-      // Insert section at the position where the first item was
-      parent.insertBefore(multisection, nextSibling);
-    });
-  }
+  containerSections.forEach((section) => {
+    const items = getMultisectionItemsForSection(main, section);
+    if (items.length === 0) return;
+
+    // Block type comes from container section's "Grouped section type" (data-category)
+    const containerCategory = section.getAttribute('data-category') || '';
+    const blockClass = containerCategory === 'accordion'
+      ? 'accordion'
+      : 'tabs'; // tabs-horizontal, tabs-vertical, or any other value → tabs
+
+    section.classList.add('multi', `${blockClass}-container`);
+    appendMultiSectionBlock(section, items, blockClass, true);
+    // Decorate blocks inside nested sections so they get .block and are loaded by loadSection
+    decorateBlocks(section);
+  });
 }
 
 /**

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -639,12 +639,6 @@ main not:dialog.section.columns-container[data-section-status="loaded"] {
   overflow: visible;
 }
 
-/* 4. Sections with dark-scheme children should have dark backgrounds to prevent flash.
-      This catches cases where inline styles haven't applied yet. */
-main > .section:has(.dark-scheme) {
-  background-color: var(--color-black);
-}
-
 /* sections */
 main>.section {
   margin: 0;


### PR DESCRIPTION
The library page shows tabs horizontal, tabs vertical, and accordion multisection examples. We're only using the tabs-horizontal on the Mayura page though.

To do next: check that the multisections are being refreshed when authoring. I had intermittent times where I had to refresh after editing something, but it might be due to using ?ref.

Fix #608 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/multisection
- After: https://608-multisections--idfc--aemsites.aem.page/library/multisection

- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://608-multisections--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
<img width="1178" height="702" alt="image" src="https://github.com/user-attachments/assets/09ac24aa-bc08-4d98-8401-986b31ad59e1" />
