### PR TITLE
UPI Tabs Styling after lint refactor

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -675,8 +675,14 @@ export function handleSectionMetadata(el) {
   if (metadata.style?.text) handleStyle(metadata.style.text, section);
   if (metadata.backgroundcolor?.text) handleBackground(metadata.backgroundcolor, section);
   if (metadata.grid?.text) handleLayout(metadata.grid.text, section, 'grid');
-  if (metadata.gap?.text) handleLayout(metadata.gap.text, section, 'gap');
-  if (metadata.spacing?.text) handleLayout(metadata.spacing.text, section, 'spacing');
+  if (metadata.gap?.text) {
+    const gapText = metadata.gap.text.replace(/^size-/, '');
+    if (gapText) handleLayout(gapText, section, 'gap');
+  }
+  if (metadata.spacing?.text) {
+    const spacingText = metadata.spacing.text.replace(/^size-/, '');
+    if (spacingText) handleLayout(spacingText, section, 'spacing');
+  }
   if (metadata.containerwidth?.text) handleLayout(metadata.containerwidth.text, section, 'container');
 
   // Handle section height (desktop and mobile)


### PR DESCRIPTION
JS updates to properly style the Tabs UPI block after the UE linting refactor

Fix #624 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://624-tabUPI-lintCleanup--idfc--aemsites.aem.page/credit-card/rupay-credit-card

New block on Main branch:
<img width="1221" height="841" alt="image" src="https://github.com/user-attachments/assets/765927a2-3dad-415e-a404-05e09bae2d12" />

New block on tabUPI Branch:
<img width="1143" height="896" alt="image" src="https://github.com/user-attachments/assets/8771dfc4-f495-4934-a2b6-11176641385d" />
