### PR TITLE
Auto playback and loop video on UPI tabs

### DIFF
--- a/paths.json
+++ b/paths.json
@@ -15,6 +15,7 @@
   ],
   "includes": [
     "/content/idfc-edge/",
-    "/content/dam/idfc-edge/icons/"
+    "/content/dam/idfc-edge/icons/",
+    "/content/dam/idfc-edge/videos/"
   ]
 }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -675,8 +675,14 @@ export function handleSectionMetadata(el) {
   if (metadata.style?.text) handleStyle(metadata.style.text, section);
   if (metadata.backgroundcolor?.text) handleBackground(metadata.backgroundcolor, section);
   if (metadata.grid?.text) handleLayout(metadata.grid.text, section, 'grid');
-  if (metadata.gap?.text) handleLayout(metadata.gap.text, section, 'gap');
-  if (metadata.spacing?.text) handleLayout(metadata.spacing.text, section, 'spacing');
+  if (metadata.gap?.text) {
+    const gapText = metadata.gap.text.replace(/^size-/, '');
+    if (gapText) handleLayout(gapText, section, 'gap');
+  }
+  if (metadata.spacing?.text) {
+    const spacingText = metadata.spacing.text.replace(/^size-/, '');
+    if (spacingText) handleLayout(spacingText, section, 'spacing');
+  }
   if (metadata.containerwidth?.text) handleLayout(metadata.containerwidth.text, section, 'container');
 
   // Handle section height (desktop and mobile)


### PR DESCRIPTION
Make video from asset picker work on the page and loop playback.
This change is still in testing, but the video is not available on the page. Console errors report a 404 on the file. Fluffyjaws suggested the change to the paths.json to ensure the video was reachable by EDS. The JS changes are to remove the unnecessary video function that we removed with the UE updates. The scripts update was due to the size metadata not matching properly. 

Fix #626 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://626-tabsUPI-videoPicker--idfc--aemsites.aem.page/credit-card/rupay-credit-card
