### PR TITLE
UPI Video Picker Enhancement

### DIFF
--- a/blocks/tabs-upi-link/tabs-upi-link.js
+++ b/blocks/tabs-upi-link/tabs-upi-link.js
@@ -3,45 +3,65 @@ import { toClassName } from '../../scripts/aem.js';
 import { moveInstrumentation } from '../../scripts/scripts.js';
 
 /**
- * Creates a video element for the phone animation (loop, muted, autoplay).
- * Uses <source> + setAttribute for reliable playback across browsers.
- * @param {string} videoSrc - The video source URL
- * @returns {HTMLVideoElement} The video element
+ * Returns a fallback video URL for DAM paths. When the primary URL is /content/dam/...,
+ * EDS/preview often returns 404; the fallback points to the same filename under
+ * /blocks/tabs-upi-link/ so the repo file can be used.
+ * @param {string} primaryUrl - Absolute video URL (e.g. from AEM picker)
+ * @returns {string|null} Fallback URL or null if primary is not a DAM path
  */
-function createVideoElement(videoSrc) {
+function getBlockFallbackVideoUrl(primaryUrl) {
+  try {
+    const u = new URL(primaryUrl);
+    if (!u.pathname.includes('/content/dam/')) return null;
+    const filename = u.pathname.split('/').filter(Boolean).pop();
+    if (!filename?.toLowerCase().endsWith('.mp4')) return null;
+    return new URL(`/blocks/tabs-upi-link/${filename}`, u.origin).href;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Creates a looping, muted, autoplay video element for the phone animation.
+ * If fallbackUrl is provided and the initial source fails (e.g. 404), switches to fallback once.
+ * @param {string} videoSrc - Initial video URL
+ * @param {string|null} [fallbackUrl] - Optional URL to try if the initial source fails
+ * @returns {HTMLVideoElement}
+ */
+function createVideoElement(videoSrc, fallbackUrl = null) {
   const video = document.createElement('video');
   video.className = 'phone-animation-video';
   video.setAttribute('loop', '');
   video.setAttribute('muted', '');
   video.setAttribute('autoplay', '');
   video.setAttribute('playsinline', '');
-  video.setAttribute('webkit-playsinline', ''); // Older iOS
+  video.setAttribute('webkit-playsinline', '');
   video.setAttribute('preload', 'auto');
-  video.muted = true; // Required for autoplay policy
+  video.muted = true;
   const source = document.createElement('source');
   source.src = videoSrc;
   source.type = 'video/mp4';
   video.appendChild(source);
+
+  if (fallbackUrl) {
+    video.addEventListener('error', () => {
+      const srcEl = video.querySelector('source');
+      if (srcEl) {
+        srcEl.src = fallbackUrl;
+        video.load();
+        video.play().catch(() => {});
+      }
+    }, { once: true });
+  }
+
   return video;
 }
 
-/** Debug: set ?tabs-upi-video-debug=1 in URL to log video events to console */
-const VIDEO_DEBUG = typeof window !== 'undefined' && window.location?.search?.includes('tabs-upi-video-debug=1');
-
-function tryPlayVideo(video) {
-  video.play().catch((err) => {
-    if (VIDEO_DEBUG) {
-      // eslint-disable-next-line no-console
-      console.warn('[tabs-upi-link] video.play() failed:', err?.message || err);
-    }
-  });
-}
-
 /**
- * Extracts phone video URL from a block-level div (phone group: picture + video reference).
- * Removes the video link from DOM. Supports AEM picker (a[href]) and legacy HTTP URL in p.
- * Resolves relative paths (e.g. /content/dam/.../file.mp4) to a playable absolute URL.
- * @param {HTMLElement} phoneGroupDiv - Block child with picture and video link
+ * Gets the phone animation video URL from the phone group div (picture + .mp4 link).
+ * Removes the link from the DOM so it is not shown. Supports AEM picker links and
+ * legacy plain HTTP(S) URLs in a paragraph.
+ * @param {HTMLElement} phoneGroupDiv - Block child containing picture and an .mp4 link
  * @returns {string|null} Absolute video URL or null
  */
 function getPhoneVideoUrlFromPhoneGroup(phoneGroupDiv) {
@@ -77,18 +97,12 @@ function getPhoneVideoUrlFromPhoneGroup(phoneGroupDiv) {
 }
 
 export default async function decorate(block) {
-  // Check if tabs-list already exists - if so, script has already run successfully
-  if (block.querySelector('.tabs-list')) {
-    return; // Already processed, skip
-  }
+  if (block.querySelector('.tabs-list')) return;
 
-  // Get all children
   const children = [...block.children];
-
-  // Title: child with h2
   const titleDiv = children.find((child) => child.querySelector('h2'));
 
-  // Image: old model = child with only picture; new model = phone group (picture + video link)
+  // Image cell: either image-only (old) or phone group with picture + video link (new)
   const imageDiv = children.find((child) => {
     const hasPicture = child.querySelector('picture');
     const hasOtherContent = child.querySelector('h2, h3, p');
@@ -97,17 +111,13 @@ export default async function decorate(block) {
   const phoneGroupDiv = !imageDiv && titleDiv
     ? children.find((child) => child !== titleDiv && child.querySelector('picture') && child.querySelector('a[href*=".mp4"]'))
     : null;
-
-  // Single source for picture: prefer image-only cell (old), else phone group (new)
   const pictureSourceDiv = imageDiv || phoneGroupDiv;
 
-  // Extract video URL from phone group (new model) and remove the link from DOM
   if (phoneGroupDiv) {
     const videoUrl = getPhoneVideoUrlFromPhoneGroup(phoneGroupDiv);
     if (videoUrl) block.dataset.phoneVideoUrl = videoUrl;
   }
 
-  // Reset any partially processed panels (remove tabs-panel class and attributes)
   children.forEach((child) => {
     if (child.classList.contains('tabs-panel')) {
       child.classList.remove('tabs-panel');
@@ -118,36 +128,26 @@ export default async function decorate(block) {
     }
   });
 
-  // Tab panels: exclude title and picture source (image-only cell or phone group)
   const tabPanels = children.filter((child) => child !== titleDiv && child !== pictureSourceDiv);
-
-  // Build tablist
   const tablist = document.createElement('div');
   tablist.className = 'tabs-list';
   tablist.setAttribute('role', 'tablist');
-
-  // Store tab names for later use
   const tabNames = [];
-
-  // Process each tab panel
   const processableTabs = tabPanels.map((tabpanel) => ({ tabpanel }));
+
   processableTabs.forEach(({ tabpanel }, i) => {
-    // Find the tab name element - it's in the first child div's p element
     const firstChildDiv = tabpanel.querySelector(':scope > div:first-child');
-    if (!firstChildDiv) return; // Skip if no first child div
+    if (!firstChildDiv) return;
 
     const tabNameElement = firstChildDiv.querySelector('p');
-    if (!tabNameElement) return; // Skip if no tab name found
+    if (!tabNameElement) return;
 
     const tabName = tabNameElement.textContent.trim();
-    if (!tabName) return; // Skip if empty
+    if (!tabName) return;
 
-    // Store tab name (use "app" for first tab, actual name for others)
     tabNames.push(i === 0 ? 'the app' : tabName);
-
     const id = toClassName(tabName);
 
-    // Decorate tabpanel
     tabpanel.className = 'tabs-panel';
     tabpanel.id = `tabpanel-${id}`;
     tabpanel.setAttribute('aria-hidden', !!i);
@@ -158,9 +158,6 @@ export default async function decorate(block) {
     const button = document.createElement('button');
     button.className = 'tabs-tab';
     button.id = `tab-${id}`;
-
-    // Copy the tab name content (including icon) to button
-    // Wrap in p tag to match expected structure
     moveInstrumentation(tabNameElement.parentElement, tabpanel.lastElementChild);
     button.innerHTML = `<p>${tabNameElement.innerHTML}</p>`;
 
@@ -169,9 +166,7 @@ export default async function decorate(block) {
     button.setAttribute('role', 'tab');
     button.setAttribute('type', 'button');
     button.addEventListener('click', () => {
-      // Skip if already selected
       if (button.getAttribute('aria-selected') === 'true') return;
-
       block.querySelectorAll('[role=tabpanel]').forEach((panel) => {
         panel.setAttribute('aria-hidden', true);
       });
@@ -180,13 +175,8 @@ export default async function decorate(block) {
       });
       tabpanel.setAttribute('aria-hidden', false);
       button.setAttribute('aria-selected', true);
-
-      // Note: Video in phone frame stays visible for all tabs
-      // The phone animation is shared across all UPI app tabs
     });
     tablist.append(button);
-
-    // Remove the tab name div from the panel (it's now in the button)
     firstChildDiv.remove();
     const buttonP = button.querySelector('p');
     if (buttonP) {
@@ -194,142 +184,85 @@ export default async function decorate(block) {
     }
   });
 
-  // Create wrapper structure for tabs area (will contain image and tabs)
   const tabsWrapper = document.createElement('div');
   tabsWrapper.className = 'tabs-upi-link-content';
 
-  // Add image to wrapper (for desktop - outside tabs)
   if (pictureSourceDiv) {
     const imageWrapper = document.createElement('div');
     imageWrapper.className = 'tabs-upi-link-image';
-    // Clone the picture element (we'll use original for desktop, clones for mobile)
     const picture = pictureSourceDiv.querySelector('picture');
     if (picture) {
-      // Clone for desktop (outside tabs)
-      const desktopPicture = picture.cloneNode(true);
-      imageWrapper.appendChild(desktopPicture);
-
-      // Add video container for phone animation (desktop only)
+      imageWrapper.appendChild(picture.cloneNode(true));
       const videoContainer = document.createElement('div');
       videoContainer.className = 'phone-animation-video-container';
       imageWrapper.appendChild(videoContainer);
-
       tabsWrapper.appendChild(imageWrapper);
 
-      // Clone image into each tab panel for mobile (inside each tab)
       tabPanels.forEach((tabpanel) => {
         const mobileImageWrapper = document.createElement('div');
         mobileImageWrapper.className = 'tabs-upi-link-panel-image';
-        const mobilePicture = picture.cloneNode(true);
-        mobileImageWrapper.appendChild(mobilePicture);
-
-        // Add video container for mobile phone animation
+        mobileImageWrapper.appendChild(picture.cloneNode(true));
         const mobileVideoContainer = document.createElement('div');
         mobileVideoContainer.className = 'phone-animation-video-container mobile';
         mobileImageWrapper.appendChild(mobileVideoContainer);
 
-        // Extract button container if it exists
         const buttonContainer = tabpanel.querySelector('.button-container');
-        if (buttonContainer) {
-          buttonContainer.remove();
-        }
+        if (buttonContainer) buttonContainer.remove();
 
-        // Wrap all existing content (except the image we're adding) in a container
         const contentWrapper = document.createElement('div');
         contentWrapper.className = 'tabs-upi-link-panel-content';
         while (tabpanel.firstChild) {
           contentWrapper.appendChild(tabpanel.firstChild);
         }
-
-        // Create a wrapper for image and content (top section)
         const topSection = document.createElement('div');
         topSection.className = 'tabs-upi-link-panel-top';
         topSection.appendChild(mobileImageWrapper);
         topSection.appendChild(contentWrapper);
-
-        // Insert top section first, then button container at the bottom
         tabpanel.appendChild(topSection);
-        if (buttonContainer) {
-          tabpanel.appendChild(buttonContainer);
-        }
+        if (buttonContainer) tabpanel.appendChild(buttonContainer);
       });
     }
   }
 
-  // Create tabs container (will contain tabs-list and tabs-panels)
   const tabsContainer = document.createElement('div');
   tabsContainer.className = 'tabs-upi-link-tabs';
+  if (tablist.children.length > 0) tabsContainer.appendChild(tablist);
 
-  // Add tabs-list to tabs container
-  if (tablist.children.length > 0) {
-    tabsContainer.appendChild(tablist);
-  }
-
-  // Move all tab panels to tabs container and add QR code text
   let tabIndex = 0;
   tabPanels.forEach((tabpanel) => {
     tabsContainer.appendChild(tabpanel);
-
-    // Find the QR code picture in this tab panel
     const qrPicture = tabpanel.querySelector('.tabs-upi-link-panel-content picture');
     if (qrPicture && tabNames[tabIndex]) {
-      const tabName = tabNames[tabIndex];
-
-      // Create text element
       const qrText = document.createElement('p');
       qrText.className = 'tabs-upi-link-qr-text';
-      qrText.textContent = `Scan the QR code to open ${tabName}`;
-
-      // Wrap picture and text in a container
+      qrText.textContent = `Scan the QR code to open ${tabNames[tabIndex]}`;
       const qrWrapper = document.createElement('div');
       qrWrapper.className = 'tabs-upi-link-qr-wrapper';
       qrPicture.parentNode.insertBefore(qrWrapper, qrPicture);
       qrWrapper.appendChild(qrPicture);
       qrWrapper.appendChild(qrText);
     }
-
     tabIndex += 1;
   });
 
-  // Add tabs container to wrapper
   tabsWrapper.appendChild(tabsContainer);
-
-  // Clear block and rebuild structure: title -> wrapper (image + tabs)
   block.textContent = '';
 
-  // Add title at the top
   if (titleDiv) {
     const titleWrapper = document.createElement('div');
     titleWrapper.className = 'tabs-upi-link-title';
     titleWrapper.appendChild(titleDiv);
     block.appendChild(titleWrapper);
   }
-
-  // Add tabs wrapper (contains image + tabs)
   block.appendChild(tabsWrapper);
 
-  // Replace "Scan" with "Tap" in H3 elements for mobile/tablet view (< 900px)
   function updateScanToTap() {
     const isMobile = window.matchMedia('(max-width: 899px)').matches;
-    const h3Elements = block.querySelectorAll('.tabs-panel h3');
-
-    h3Elements.forEach((h3) => {
-      // Get the original text content (without any previous modifications)
-      let text = h3.textContent;
-
-      if (isMobile) {
-        // Replace "Scan" with "Tap"
-        text = text.replace(/Scan/g, 'Tap');
-        h3.textContent = text;
-      } else {
-        // Replace "Tap" back to "Scan"
-        text = text.replace(/Tap/g, 'Scan');
-        h3.textContent = text;
-      }
+    block.querySelectorAll('.tabs-panel h3').forEach((h3) => {
+      const text = h3.textContent;
+      h3.textContent = isMobile ? text.replace(/Scan/g, 'Tap') : text.replace(/Tap/g, 'Scan');
     });
   }
-
-  // Run on load and resize with debouncing
   updateScanToTap();
   let resizeTimeout;
   window.addEventListener('resize', () => {
@@ -337,33 +270,20 @@ export default async function decorate(block) {
     resizeTimeout = setTimeout(updateScanToTap, 150);
   });
 
-  // Initialize phone video in all containers (desktop and mobile)
   const videoPath = block.dataset.phoneVideoUrl;
   if (videoPath) {
-    if (VIDEO_DEBUG) {
-      // eslint-disable-next-line no-console
-      console.log('[tabs-upi-link] video URL:', videoPath);
+    const fallbackUrl = getBlockFallbackVideoUrl(videoPath);
+    // Use block fallback as initial source when primary is a DAM path (often 404 in EDS/preview)
+    let useFallbackFirst = false;
+    try {
+      useFallbackFirst = Boolean(fallbackUrl && new URL(videoPath).pathname.includes('/content/dam/'));
+    } catch {
+      // ignore
     }
-    const allVideoContainers = block.querySelectorAll('.phone-animation-video-container');
-    allVideoContainers.forEach((container) => {
-      const video = createVideoElement(videoPath);
-      container.appendChild(video);
-      tryPlayVideo(video);
-      // Retry play when enough data has loaded (autoplay can fail if called too early)
-      video.addEventListener('loadeddata', () => tryPlayVideo(video), { once: true });
-      video.addEventListener('canplay', () => tryPlayVideo(video), { once: true });
-      if (VIDEO_DEBUG) {
-        video.addEventListener('playing', () => {
-          // eslint-disable-next-line no-console
-          console.log('[tabs-upi-link] video playing');
-        });
-        video.addEventListener('error', () => {
-          const e = video.error;
-          const src = video.querySelector('source')?.src || video.src;
-          // eslint-disable-next-line no-console
-          console.warn('[tabs-upi-link] video error:', e?.message || e?.code, src);
-        });
-      }
+    const initialUrl = useFallbackFirst ? fallbackUrl : videoPath;
+    const errorFallbackUrl = useFallbackFirst ? null : fallbackUrl;
+    block.querySelectorAll('.phone-animation-video-container').forEach((container) => {
+      container.appendChild(createVideoElement(initialUrl, errorFallbackUrl));
     });
   }
 }


### PR DESCRIPTION
With the previous change (PR 634) we added a new path to the paths.json which allowed the video to be playable, but it is only working in the UE (this can be seen now without the below code). The code in this PR specifically cleans up some logic and allows for the use of the fallback , from the repo, video to be used on the rendered page. This is necessary due to a limitation of EDS to make MP4's available at the edge. 
Working with Fluffyjaws it seems this is known and the workarounds it was aware of did not work for this case (https://experienceleague.adobe.com/en/docs/experience-cloud-kcs/kbarticles/ka-27519#token_type=bearer&expires_in=28799997). 
This change makes the video work, but in a state that is not controlled by authors, as the video needs to be available in the code repo.  

Fix #626 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://626-tabsUPI-videoPicker--idfc--aemsites.aem.page/credit-card/rupay-credit-card
