### PR TITLE
Add Subtitle option to UE for Section-Title

### DIFF
--- a/blocks/section-title/_section-title.json
+++ b/blocks/section-title/_section-title.json
@@ -23,102 +23,97 @@
       "fields": [
         {
           "component": "text",
-          "name": "title",
-          "label": "Title",
+          "name": "title_text",
+          "label": "Title Text",
           "valueType": "string"
         },
         {
           "component": "select",
-          "name": "titleType",
+          "name": "title_type",
           "label": "Title Type",
           "value": "h2",
           "valueType": "string",
           "options": [
-            {
-              "name": "h1",
-              "value": "h1"
-            },
-            {
-              "name": "h2",
-              "value": "h2"
-            },
-            {
-              "name": "h3",
-              "value": "h3"
-            },
-            {
-              "name": "h4",
-              "value": "h4"
-            },
-            {
-              "name": "h5",
-              "value": "h5"
-            },
-            {
-              "name": "h6",
-              "value": "h6"
-            },
-            {
-              "name": "p",
-              "value": "p"
-            }
+            { "name": "h1", "value": "h1" },
+            { "name": "h2", "value": "h2" },
+            { "name": "h3", "value": "h3" },
+            { "name": "h4", "value": "h4" },
+            { "name": "h5", "value": "h5" },
+            { "name": "h6", "value": "h6" },
+            { "name": "p", "value": "p" }
           ]
         },
         {
           "component": "select",
-          "name": "textSize",
+          "name": "title_size",
           "label": "Text Size",
           "value": "",
           "valueType": "string",
           "options": [
-            {
-              "name": "Default (based on heading type)",
-              "value": ""
-            },
-            {
-              "name": "XXL",
-              "value": "size-xxl"
-            },
-            {
-              "name": "XL",
-              "value": "size-xl"
-            },
-            {
-              "name": "L",
-              "value": "size-l"
-            },
-            {
-              "name": "M",
-              "value": "size-m"
-            },
-            {
-              "name": "S",
-              "value": "size-s"
-            },
-            {
-              "name": "XS",
-              "value": "size-xs"
-            }
+            { "name": "Default (based on heading type)", "value": "" },
+            { "name": "XXL", "value": "size-xxl" },
+            { "name": "XL", "value": "size-xl" },
+            { "name": "L", "value": "size-l" },
+            { "name": "M", "value": "size-m" },
+            { "name": "S", "value": "size-s" },
+            { "name": "XS", "value": "size-xs" }
           ]
         },
         {
           "component": "multiselect",
           "name": "classes",
-          "label": "Alignment / location",
+          "label": "Text Alignment",
           "value": "",
           "valueType": "string",
           "options": [
+            { "name": "Default (Left)", "value": "left" },
+            { "name": "Center", "value": "center" },
+            { "name": "Right", "value": "right" }
+          ]
+        },
+        {
+          "component": "container",
+          "name": "optional-subtitle",
+          "label": "Optional Subtitle",
+          "collapsible": true,
+          "fields": [
             {
-              "name": "Default (Left)",
-              "value": "left"
+              "component": "text",
+              "name": "subtitle_text",
+              "label": "Subtitle Text",
+              "valueType": "string"
             },
             {
-              "name": "Center",
-              "value": "center"
+              "component": "select",
+              "name": "subtitle_type",
+              "label": "Subtitle Type",
+              "value": "p",
+              "valueType": "string",
+              "options": [
+                { "name": "h1", "value": "h1" },
+                { "name": "h2", "value": "h2" },
+                { "name": "h3", "value": "h3" },
+                { "name": "h4", "value": "h4" },
+                { "name": "h5", "value": "h5" },
+                { "name": "h6", "value": "h6" },
+                { "name": "p", "value": "p" }
+              ]
             },
             {
-              "name": "Right",
-              "value": "right"
+              "component": "select",
+              "name": "subtitle_size",
+              "label": "Subtitle Size",
+              "value": "",
+              "valueType": "string",
+              "options": [
+                { "name": "Default (based on type)", "value": "" },
+                { "name": "XXL", "value": "size-xxl" },
+                { "name": "XL", "value": "size-xl" },
+                { "name": "L", "value": "size-l" },
+                { "name": "M", "value": "size-m" },
+                { "name": "S", "value": "size-s" },
+                { "name": "XS", "value": "size-xs" }
+              ]
             }
           ]
         }

--- a/blocks/section-title/_section-title.json
+++ b/blocks/section-title/_section-title.json
@@ -23,7 +23,7 @@
       "fields": [
         {
           "component": "text",
-          "name": "title_text",
+          "name": "title",
           "label": "Title Text",
           "valueType": "string"
         },
@@ -79,7 +79,7 @@
           "fields": [
             {
               "component": "text",
-              "name": "subtitle_text",
+              "name": "subtitle",
               "label": "Subtitle Text",
               "valueType": "string"
             },

--- a/blocks/section-title/_section-title.json
+++ b/blocks/section-title/_section-title.json
@@ -29,7 +29,7 @@
         },
         {
           "component": "select",
-          "name": "title_type",
+          "name": "titleType",
           "label": "Title Type",
           "value": "h2",
           "valueType": "string",
@@ -56,7 +56,9 @@
             { "name": "L", "value": "size-l" },
             { "name": "M", "value": "size-m" },
             { "name": "S", "value": "size-s" },
-            { "name": "XS", "value": "size-xs" }
+            { "name": "XS", "value": "size-xs" },
+            { "name": "TEST", "value": "size-name" }
+
           ]
         },
         {
@@ -85,7 +87,7 @@
             },
             {
               "component": "select",
-              "name": "subtitle_type",
+              "name": "subtitleType",
               "label": "Subtitle Type",
               "value": "p",
               "valueType": "string",

--- a/blocks/section-title/_section-title.json
+++ b/blocks/section-title/_section-title.json
@@ -56,8 +56,7 @@
             { "name": "L", "value": "size-l" },
             { "name": "M", "value": "size-m" },
             { "name": "S", "value": "size-s" },
-            { "name": "XS", "value": "size-xs" },
-            { "name": "TEST", "value": "size-name" }
+            { "name": "XS", "value": "size-xs" }
 
           ]
         },

--- a/blocks/section-title/section-title.css
+++ b/blocks/section-title/section-title.css
@@ -6,64 +6,28 @@
   padding: 0;
 }
 
-/* Text size overrides using CSS custom properties from styles.css */
-.section-title.size-xxl h1,
-.section-title.size-xxl h2,
-.section-title.size-xxl h3,
-.section-title.size-xxl h4,
-.section-title.size-xxl h5,
-.section-title.size-xxl h6,
-.section-title.size-xxl p {
+/* Title and subtitle size: block modifier + .title / .subtitle, same pattern and variables */
+.section-title.size-xxl .title {
   font-size: var(--heading-font-size-xxl);
 }
 
-.section-title.size-xl h1,
-.section-title.size-xl h2,
-.section-title.size-xl h3,
-.section-title.size-xl h4,
-.section-title.size-xl h5,
-.section-title.size-xl h6,
-.section-title.size-xl p {
+.section-title.size-xl .title {
   font-size: var(--heading-font-size-xl);
 }
 
-.section-title.size-l h1,
-.section-title.size-l h2,
-.section-title.size-l h3,
-.section-title.size-l h4,
-.section-title.size-l h5,
-.section-title.size-l h6,
-.section-title.size-l p {
+.section-title.size-l .title {
   font-size: var(--heading-font-size-l);
 }
 
-.section-title.size-m h1,
-.section-title.size-m h2,
-.section-title.size-m h3,
-.section-title.size-m h4,
-.section-title.size-m h5,
-.section-title.size-m h6,
-.section-title.size-m p {
+.section-title.size-m .title {
   font-size: var(--heading-font-size-m);
 }
 
-.section-title.size-s h1,
-.section-title.size-s h2,
-.section-title.size-s h3,
-.section-title.size-s h4,
-.section-title.size-s h5,
-.section-title.size-s h6,
-.section-title.size-s p {
+.section-title.size-s .title {
   font-size: var(--heading-font-size-s);
 }
 
-.section-title.size-xs h1,
-.section-title.size-xs h2,
-.section-title.size-xs h3,
-.section-title.size-xs h4,
-.section-title.size-xs h5,
-.section-title.size-xs h6,
-.section-title.size-xs p {
+.section-title.size-xs .title {
   font-size: var(--heading-font-size-xs);
 }
 
@@ -71,10 +35,40 @@
 .section-title.center {
   text-align: center;
 }
+
 .section-title.right {
   text-align: right;
 }
 
 .section-title.left {
   text-align: left;
+}
+
+/* Subtitle (optional): same size-on-block pattern as title, reuses --heading-font-size-* */
+.section-title .subtitle {
+  margin: 0;
+}
+
+.section-title.subtitle-size-xxl .subtitle {
+  font-size: var(--heading-font-size-xxl);
+}
+
+.section-title.subtitle-size-xl .subtitle {
+  font-size: var(--heading-font-size-xl);
+}
+
+.section-title.subtitle-size-l .subtitle {
+  font-size: var(--heading-font-size-l);
+}
+
+.section-title.subtitle-size-m .subtitle {
+  font-size: var(--heading-font-size-m);
+}
+
+.section-title.subtitle-size-s .subtitle {
+  font-size: var(--heading-font-size-s);
+}
+
+.section-title.subtitle-size-xs .subtitle {
+  font-size: var(--heading-font-size-xs);
 }

--- a/blocks/section-title/section-title.js
+++ b/blocks/section-title/section-title.js
@@ -2,8 +2,8 @@
  * Section Title block: apply author-selected text size and alignment as block classes.
  * Title and subtitle share the same alignment (row3). Subtitle size uses block class
  * (subtitle-size-*) so CSS can reuse the same pattern as title (size on block).
- * EDS DOM order: row0=title, row1=title_type, row2=title_size, row3=classes;
- * optional subtitle: row4=subtitle, row5=subtitle_type, row6=subtitle_size.
+ * EDS DOM order: row0=title, row1=titleType, row2=title_size, row3=classes;
+ * optional subtitle: row4=subtitle, row5=subtitleType, row6=subtitle_size.
  */
 const SIZE_CLASSES = {
   xxl: 'size-xxl',

--- a/blocks/section-title/section-title.js
+++ b/blocks/section-title/section-title.js
@@ -1,6 +1,9 @@
 /**
- * Section Title block: apply author-selected text size and alignment as classes.
- * EDS DOM order: row0=title, row1=textSize, row2=alignment.
+ * Section Title block: apply author-selected text size and alignment as block classes.
+ * Title and subtitle share the same alignment (row3). Subtitle size uses block class
+ * (subtitle-size-*) so CSS can reuse the same pattern as title (size on block).
+ * EDS DOM order: row0=title_text, row1=title_type, row2=title_size, row3=classes;
+ * optional subtitle: row4=subtitle_text, row5=subtitle_type, row6=subtitle_size.
  */
 const SIZE_CLASSES = {
   xxl: 'size-xxl',
@@ -32,16 +35,44 @@ function cellText(row) {
   return (col.textContent || '').trim();
 }
 
-export default function decorate(block) {
+const SUBTITLE_TAG = /^h[1-6]|p$/i;
+
+function decorate(block) {
   const rows = block.querySelectorAll(':scope > div');
-  if (rows.length >= 2) {
-    const sizeClass = toSizeClass(cellText(rows[1]));
+  const titleSizeRowIndex = 2;
+  if (rows.length > titleSizeRowIndex) {
+    const sizeClass = toSizeClass(cellText(rows[titleSizeRowIndex]));
     if (sizeClass) block.classList.add(sizeClass);
   }
 
   const heading = block.querySelector('h1, h2, h3, h4, h5, h6, p');
   if (heading && block.children.length > 1) {
     block.innerHTML = '';
+    heading.classList.add('title');
     block.appendChild(heading);
+
+    const subtitleTextRowIndex = 4;
+    const subtitleTypeRowIndex = 5;
+    const subtitleSizeRowIndex = 6;
+    if (rows.length > subtitleTextRowIndex) {
+      const subtitleText = cellText(rows[subtitleTextRowIndex]);
+      if (subtitleText) {
+        let tagName = 'p';
+        if (rows.length > subtitleTypeRowIndex) {
+          const typeVal = cellText(rows[subtitleTypeRowIndex]);
+          if (typeVal && SUBTITLE_TAG.test(typeVal)) tagName = typeVal.toLowerCase();
+        }
+        const subtitle = document.createElement(tagName);
+        subtitle.className = 'subtitle';
+        if (rows.length > subtitleSizeRowIndex) {
+          const sizeClass = toSizeClass(cellText(rows[subtitleSizeRowIndex]));
+          if (sizeClass) block.classList.add(`subtitle-${sizeClass}`);
+        }
+        subtitle.textContent = subtitleText;
+        block.appendChild(subtitle);
+      }
+    }
   }
 }
+
+export default decorate;

--- a/blocks/section-title/section-title.js
+++ b/blocks/section-title/section-title.js
@@ -2,8 +2,8 @@
  * Section Title block: apply author-selected text size and alignment as block classes.
  * Title and subtitle share the same alignment (row3). Subtitle size uses block class
  * (subtitle-size-*) so CSS can reuse the same pattern as title (size on block).
- * EDS DOM order: row0=title_text, row1=title_type, row2=title_size, row3=classes;
- * optional subtitle: row4=subtitle_text, row5=subtitle_type, row6=subtitle_size.
+ * EDS DOM order: row0=title, row1=title_type, row2=title_size, row3=classes;
+ * optional subtitle: row4=subtitle, row5=subtitle_type, row6=subtitle_size.
  */
 const SIZE_CLASSES = {
   xxl: 'size-xxl',

--- a/component-definition.json
+++ b/component-definition.json
@@ -490,36 +490,6 @@
           }
         },
         {
-          "title": "Nav List",
-          "id": "nav-list",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/franklin/components/block/v1/block",
-                "template": {
-                  "name": "Nav List",
-                  "filter": "nav-list"
-                }
-              }
-            }
-          }
-        },
-        {
-          "title": "Nav Item",
-          "id": "nav-item",
-          "plugins": {
-            "xwalk": {
-              "page": {
-                "resourceType": "core/franklin/components/block/v1/block/item",
-                "template": {
-                  "name": "Nav Item",
-                  "model": "nav-item"
-                }
-              }
-            }
-          }
-        },
-        {
           "title": "Overview RTE",
           "id": "overview-rte",
           "plugins": {

--- a/component-filters.json
+++ b/component-filters.json
@@ -128,12 +128,6 @@
     "components": []
   },
   {
-    "id": "nav-list",
-    "components": [
-      "nav-item"
-    ]
-  },
-  {
     "id": "overview-rte",
     "components": [
       "overview-rte-item"

--- a/component-models.json
+++ b/component-models.json
@@ -2086,10 +2086,6 @@
           {
             "name": "XS",
             "value": "size-xs"
-          },
-          {
-            "name": "TEST",
-            "value": "size-name"
           }
         ]
       },

--- a/component-models.json
+++ b/component-models.json
@@ -2011,7 +2011,7 @@
     "fields": [
       {
         "component": "text",
-        "name": "title_text",
+        "name": "title",
         "label": "Title Text",
         "valueType": "string"
       },
@@ -2118,7 +2118,7 @@
         "fields": [
           {
             "component": "text",
-            "name": "subtitle_text",
+            "name": "subtitle",
             "label": "Subtitle Text",
             "valueType": "string"
           },

--- a/component-models.json
+++ b/component-models.json
@@ -358,27 +358,27 @@
           },
           {
             "name": "XXL",
-            "value": "xxl"
+            "value": "size-xxl"
           },
           {
             "name": "XL",
-            "value": "xl"
+            "value": "size-xl"
           },
           {
             "name": "L",
-            "value": "l"
+            "value": "size-l"
           },
           {
             "name": "M",
-            "value": "m"
+            "value": "size-m"
           },
           {
             "name": "S",
-            "value": "s"
+            "value": "size-s"
           },
           {
             "name": "XS",
-            "value": "xs"
+            "value": "size-xs"
           }
         ]
       },
@@ -458,27 +458,27 @@
               },
               {
                 "name": "XXL",
-                "value": "xxl"
+                "value": "size-xxl"
               },
               {
                 "name": "XL",
-                "value": "xl"
+                "value": "size-xl"
               },
               {
                 "name": "L",
-                "value": "l"
+                "value": "size-l"
               },
               {
                 "name": "M",
-                "value": "m"
+                "value": "size-m"
               },
               {
                 "name": "S",
-                "value": "s"
+                "value": "size-s"
               },
               {
                 "name": "XS",
-                "value": "xs"
+                "value": "size-xs"
               }
             ]
           },
@@ -603,24 +603,24 @@
       {
         "component": "reference",
         "valueType": "string",
-        "name": "doodle-image-top",
-        "label": "Background accessory image - top",
+        "name": "decoration-image-top",
+        "label": "Background decoration image - top",
         "description": "Displayed at top left of the section",
         "multi": false
       },
       {
         "component": "reference",
         "valueType": "string",
-        "name": "doodle-image-bottom",
-        "label": "Background accessory image - bottom",
+        "name": "decoration-image-bottom",
+        "label": "Background decoration image - bottom",
         "description": "Displayed at bottom right of the section",
         "multi": false
       },
       {
         "component": "boolean",
         "valueType": "boolean",
-        "name": "doodle-reverse",
-        "label": "Reverse background accessory images",
+        "name": "decoration-reverse",
+        "label": "Reverse background decoration images",
         "description": "Display at top right and bottom left of the section"
       },
       {
@@ -1977,40 +1977,6 @@
     ]
   },
   {
-    "id": "nav-item",
-    "fields": [
-      {
-        "component": "text",
-        "valueType": "string",
-        "name": "title",
-        "label": "Title",
-        "description": "Title of the navigation item."
-      },
-      {
-        "component": "text",
-        "valueType": "string",
-        "name": "link",
-        "label": "Link",
-        "description": "URL for the navigation item."
-      },
-      {
-        "component": "text",
-        "valueType": "string",
-        "name": "sub-title",
-        "label": "Sub Title",
-        "description": "Sub Title of the navigation item."
-      },
-      {
-        "component": "richtext",
-        "name": "description",
-        "value": "",
-        "label": "Description",
-        "valueType": "string",
-        "description": "Description or additional details for the navigation item."
-      }
-    ]
-  },
-  {
     "id": "overview-rte-item",
     "fields": []
   },
@@ -2045,13 +2011,13 @@
     "fields": [
       {
         "component": "text",
-        "name": "title",
-        "label": "Title",
+        "name": "title_text",
+        "label": "Title Text",
         "valueType": "string"
       },
       {
         "component": "select",
-        "name": "titleType",
+        "name": "title_type",
         "label": "Title Type",
         "value": "h2",
         "valueType": "string",
@@ -2088,7 +2054,7 @@
       },
       {
         "component": "select",
-        "name": "textSize",
+        "name": "title_size",
         "label": "Text Size",
         "value": "",
         "valueType": "string",
@@ -2126,7 +2092,7 @@
       {
         "component": "multiselect",
         "name": "classes",
-        "label": "Alignment / location",
+        "label": "Text Alignment",
         "value": "",
         "valueType": "string",
         "options": [
@@ -2141,6 +2107,94 @@
           {
             "name": "Right",
             "value": "right"
+          }
+        ]
+      },
+      {
+        "component": "container",
+        "name": "optional-subtitle",
+        "label": "Optional Subtitle",
+        "collapsible": true,
+        "fields": [
+          {
+            "component": "text",
+            "name": "subtitle_text",
+            "label": "Subtitle Text",
+            "valueType": "string"
+          },
+          {
+            "component": "select",
+            "name": "subtitle_type",
+            "label": "Subtitle Type",
+            "value": "p",
+            "valueType": "string",
+            "options": [
+              {
+                "name": "h1",
+                "value": "h1"
+              },
+              {
+                "name": "h2",
+                "value": "h2"
+              },
+              {
+                "name": "h3",
+                "value": "h3"
+              },
+              {
+                "name": "h4",
+                "value": "h4"
+              },
+              {
+                "name": "h5",
+                "value": "h5"
+              },
+              {
+                "name": "h6",
+                "value": "h6"
+              },
+              {
+                "name": "p",
+                "value": "p"
+              }
+            ]
+          },
+          {
+            "component": "select",
+            "name": "subtitle_size",
+            "label": "Subtitle Size",
+            "value": "",
+            "valueType": "string",
+            "options": [
+              {
+                "name": "Default (based on type)",
+                "value": ""
+              },
+              {
+                "name": "XXL",
+                "value": "size-xxl"
+              },
+              {
+                "name": "XL",
+                "value": "size-xl"
+              },
+              {
+                "name": "L",
+                "value": "size-l"
+              },
+              {
+                "name": "M",
+                "value": "size-m"
+              },
+              {
+                "name": "S",
+                "value": "size-s"
+              },
+              {
+                "name": "XS",
+                "value": "size-xs"
+              }
+            ]
           }
         ]
       }

--- a/component-models.json
+++ b/component-models.json
@@ -2017,7 +2017,7 @@
       },
       {
         "component": "select",
-        "name": "title_type",
+        "name": "titleType",
         "label": "Title Type",
         "value": "h2",
         "valueType": "string",
@@ -2086,6 +2086,10 @@
           {
             "name": "XS",
             "value": "size-xs"
+          },
+          {
+            "name": "TEST",
+            "value": "size-name"
           }
         ]
       },
@@ -2124,7 +2128,7 @@
           },
           {
             "component": "select",
-            "name": "subtitle_type",
+            "name": "subtitleType",
             "label": "Subtitle Type",
             "value": "p",
             "valueType": "string",


### PR DESCRIPTION
Initial UE updates for the sub-title of the section-title block. I also generated some updates to the styling to account for this update, but need the UE changes to be added to fully test and validate all styling works as expected. 

Fix #642 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/drafts/section-title
- After: https://642-sectionTitle-options--idfc--aemsites.aem.page/drafts/section-title
