### PR TITLE
imp docs, related seach, get in touch fixed

### DIFF
--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -25,10 +25,6 @@
   background-color: transparent;
 }
 
-.cards .cards-card-body {
-  margin: 16px 0;
-}
-
 .cards .cards-card-image {
   line-height: 0;
 }
@@ -66,7 +62,7 @@
 
 .cards .benefit-cards .cards-card-body {
   flex: 1;
-  margin-top: var(--spacing-xs);
+  margin: var(--spacing-xs) 0;
 }
 
 .cards .benefit-cards .cards-card-body h3 {
@@ -97,11 +93,6 @@
 .cards .card-clickable {
   cursor: pointer;
   transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
-
-.cards .card-clickable:hover {
-  transform: translateY(-5px);
-  box-shadow: 0 5px 15px 0 rgb(137 137 137 / 100%);
 }
 
 .cards .card-clickable:focus {
@@ -317,19 +308,11 @@
 }
 
 .cards.important-documents .important-documents-card-link {
-  display: flex;
-  flex-direction: column;
   align-items: center;
   width: 100%;
   height: 100%;
   text-decoration: none;
   color: inherit;
-  gap: 10px;
-  justify-content: flex-start;
-}
-
-.cards.important-documents .important-documents-card-link:hover {
-  text-decoration: none;
 }
 
 /* Important Documents Card Image */
@@ -349,18 +332,15 @@
 }
 
 /* Important Documents Card Body */
-.cards.important-documents .cards-card-body {
+.cards.important-documents .cards-card-body p,
+.cards.important-documents .cards-card-body h3 {
   width: 100%;
-  margin: 0;
   text-align: center;
   word-wrap: break-word;
   overflow-wrap: break-word;
 
   /* Base font styling for all text elements */
-  color: var(--color-black);
   font-size: var(--body-font-size-s);
-  font-weight: 600;
-  line-height: 1.4;
 }
 
 .cards.important-documents p {
@@ -384,20 +364,9 @@
   width: 100%;
 }
 
-.section:has(.cards.important-documents) .default-content-wrapper h3 {
-  color: var(--color-white);
-  font-size: var(--body-font-size-xl);
-  font-weight: 600;
-  text-align: center;
-  margin: 32px 0;
-  padding: 0 16px;
+.dark-scheme .cards .important-documents-card {
+  color: var(--text-color);
 }
-
-/* === RELATED SEARCH CARD VARIANT === 
-.section:has(.cards.related-search) {
-  padding: 40px 16px var(--spacing-xl);
-}
-  */
 
 .section:has(.cards.related-search) .default-content-wrapper h2 {
   color: #54565b;
@@ -437,11 +406,6 @@
   gap: 16px;
   position: relative;
   transition: box-shadow 0.2s ease, transform 0.2s ease;
-}
-
-.cards.related-search .benefit-cards:hover {
-  box-shadow: 0 4px 16px rgba(0 0 0 / 12%);
-  transform: translateY(-2px);
 }
 
 /* Related Search Card Image */
@@ -1841,7 +1805,6 @@
 
   .cards.important-documents .cards-card-body {
     flex: 1;
-    display: flex;
     align-items: center;
     justify-content: center;
   }
@@ -1945,7 +1908,6 @@
 
   .cards.experience-life .benefit-cards .cards-card-body {
     padding: 0 28px 28px;
-    margin-top: var(--spacing-xs);
   }
 
   .cards.experience-life .benefit-cards .cards-card-body h3 {

--- a/blocks/cards/cards.js
+++ b/blocks/cards/cards.js
@@ -155,10 +155,14 @@ function setupCardInteractivity(cardItem, shouldAddArrow = false, modalTheme = '
     });
 
     // Hide the original link text but keep it functional
-    const buttonContainer = cardLink.closest('.button-container');
-    if (buttonContainer) {
-      buttonContainer.classList.add('sr-only');
+    let buttonContainer = cardLink.closest('.button-container');
+    if (!buttonContainer) {
+      buttonContainer = document.createElement('div');
+      buttonContainer.className = 'button-container';
+      cardLink.parentNode.insertBefore(buttonContainer, cardLink);
+      buttonContainer.appendChild(cardLink);
     }
+    buttonContainer.classList.add('sr-only');
 
     // Add arrow icon for interactive cards (if enabled for this variant)
     if (shouldAddArrow) {
@@ -256,10 +260,14 @@ function setupCardInteractivity(cardItem, shouldAddArrow = false, modalTheme = '
     });
 
     // Hide the original link text but keep it functional
-    const buttonContainer = cardLink.closest('.button-container');
-    if (buttonContainer) {
-      buttonContainer.classList.add('sr-only');
+    let buttonContainer = cardLink.closest('.button-container');
+    if (!buttonContainer) {
+      buttonContainer = document.createElement('div');
+      buttonContainer.className = 'button-container';
+      cardLink.parentNode.insertBefore(buttonContainer, cardLink);
+      buttonContainer.appendChild(cardLink);
     }
+    buttonContainer.classList.add('sr-only');
 
     // Add arrow icon for interactive cards (if enabled for this variant)
     if (shouldAddArrow) {
@@ -639,45 +647,6 @@ export default async function decorate(block) {
   allCards.forEach((cardItem) => {
     if (isImportantDocuments) {
       cardItem.classList.add('important-documents-card');
-
-      // Make entire card clickable - wrap card content in link
-      const link = cardItem.querySelector('.cards-card-body a');
-      if (link && link.href) {
-        const linkUrl = link.href;
-        const linkTitle = link.getAttribute('title') || link.textContent.trim();
-        const imageDiv = cardItem.querySelector('.cards-card-image');
-        const bodyDiv = cardItem.querySelector('.cards-card-body');
-
-        // Create new link wrapper
-        const cardLink = document.createElement('a');
-        cardLink.href = linkUrl;
-        cardLink.title = linkTitle;
-        cardLink.className = 'important-documents-card-link';
-
-        // Move elements directly instead of cloning (performance optimization)
-        if (imageDiv) {
-          // Remove from parent and append to link
-          const imageDivClone = imageDiv.cloneNode(true);
-          cardLink.appendChild(imageDivClone);
-        }
-
-        // Move body content into link, but replace nested link with just text
-        if (bodyDiv) {
-          const bodyDivClone = bodyDiv.cloneNode(true);
-          const nestedLink = bodyDivClone.querySelector('a');
-          if (nestedLink) {
-            // Replace link with its text content (use textContent for better performance)
-            const strong = document.createElement('strong');
-            strong.textContent = nestedLink.textContent;
-            nestedLink.replaceWith(strong);
-          }
-          cardLink.appendChild(bodyDivClone);
-        }
-
-        // Clear and append link wrapper
-        cardItem.textContent = '';
-        cardItem.appendChild(cardLink);
-      }
     } else if (isBlogPosts) {
       cardItem.classList.add('blog-post-card');
     } else if (!isEarnRewards && !isJoiningPerks && !isAllAboutCard) {
@@ -689,8 +658,8 @@ export default async function decorate(block) {
     }
 
     // Setup interactivity for all card types (links, modals)
-    // Skip for blog-posts and important-documents - they use standard link behavior
-    if (!isBlogPosts && !isImportantDocuments) {
+    // Skip for blog-posts and important-documents - they use wrap-in-link behavior only
+    if (!isBlogPosts) {
       // Add arrow icons for key-benefits, experience-life, reward-points variants
       const shouldAddArrow = supportsSemanticElements;
       const modalTheme = block.dataset.modalTheme || '';


### PR DESCRIPTION
## On the main page content only (did not deal with the header nav dropdown cards)
After the refactor of the universal editor JSON, cards were broken.

- Standardized the Important Documents cards (now authored with H3 and can accept some paragraph text underneath if desired)
- fixed the link text that was showing on the Explore Other Cards, Imp. Docs, Related Card Search, and Get in Touch with Us. 

Fix #643 , #648 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://648-cardlinks--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://648-cardlinks--idfc--aemsites.aem.page/credit-card/rupay-credit-card

Before:
<img width="1272" height="999" alt="image" src="https://github.com/user-attachments/assets/1c4537a1-3346-4699-bac8-0842081d31b2" />


After:
<img width="1231" height="1005" alt="image" src="https://github.com/user-attachments/assets/7fc8ea6d-e4ca-49f5-af04-f2b94aec0fe7" />
