### PR TITLE
reverting JS to previously working version

### DIFF
--- a/blocks/section-title/section-title.js
+++ b/blocks/section-title/section-title.js
@@ -1,11 +1,11 @@
 /**
  * Section Title block: apply author-selected text size and alignment as block classes.
- * Primary: UE config (readBlockConfig) using JSON field names.
- * Fallback: EDS/DOM rows (row0=title, row1=titleType, row2=title_size, row3=classes,
- * row4=subtitle, row5=subtitleType, row6=subtitle_size) when config is empty.
+ * Title and subtitle share the same alignment (row3). Subtitle size uses block class
+ * (subtitle-size-*) so CSS can reuse the same pattern as title (size on block).
+ * EDS DOM row order follows _section-title.json model field order:
+ * row0=title, row1=titleType, row2=title_size, row3=classes;
+ * row4=subtitle, row5=subtitleType, row6=subtitle_size (optional-subtitle container).
  */
-import { readBlockConfig } from '../../scripts/aem.js';
-
 const SIZE_CLASSES = {
   xxl: 'size-xxl',
   xl: 'size-xl',
@@ -36,85 +36,44 @@ function cellText(row) {
   return (col.textContent || '').trim();
 }
 
-const HEADING_TAG = /^h[1-6]|p$/i;
+const SUBTITLE_TAG = /^h[1-6]|p$/i;
 
 function decorate(block) {
-  const config = readBlockConfig(block) || {};
   const rows = block.querySelectorAll(':scope > div');
-
-  let titleText = (config.title ?? '').trim();
-  if (!titleText && rows.length > 0) {
-    titleText = cellText(rows[0]);
+  const titleSizeRowIndex = 2;
+  if (rows.length > titleSizeRowIndex) {
+    const sizeClass = toSizeClass(cellText(rows[titleSizeRowIndex]));
+    if (sizeClass) block.classList.add(sizeClass);
   }
 
-  let rawTitleType = (config.titleType ?? '').trim();
-  if (!rawTitleType && rows.length > 1) {
-    rawTitleType = cellText(rows[1]);
-  }
-  const titleType = rawTitleType || 'h2';
-  const titleTag = HEADING_TAG.test(titleType) ? titleType.toLowerCase() : 'h2';
+  const heading = block.querySelector('h1, h2, h3, h4, h5, h6, p');
+  if (heading && block.children.length > 1) {
+    block.innerHTML = '';
+    heading.classList.add('title');
+    block.appendChild(heading);
 
-  let sizeVal = (config.title_size ?? '').trim();
-  if (!sizeVal && rows.length > 2) {
-    sizeVal = cellText(rows[2]);
-  }
-  const sizeClass = toSizeClass(sizeVal);
-  if (sizeClass) block.classList.add(sizeClass);
-
-  const alignmentVal = config.classes ?? '';
-  const validAlignment = ['left', 'center', 'right'];
-  if (alignmentVal) {
-    let classes = [];
-    if (typeof alignmentVal === 'string') {
-      classes = alignmentVal.split(',').map((c) => c.trim());
-    } else if (Array.isArray(alignmentVal)) {
-      classes = alignmentVal;
-    } else {
-      classes = [alignmentVal];
+    const subtitleTextRowIndex = 4;
+    const subtitleTypeRowIndex = 5;
+    const subtitleSizeRowIndex = 6;
+    if (rows.length > subtitleTextRowIndex) {
+      const subtitleText = cellText(rows[subtitleTextRowIndex]);
+      if (subtitleText) {
+        let tagName = 'p';
+        if (rows.length > subtitleTypeRowIndex) {
+          const typeVal = cellText(rows[subtitleTypeRowIndex]);
+          if (typeVal && SUBTITLE_TAG.test(typeVal)) tagName = typeVal.toLowerCase();
+        }
+        const subtitle = document.createElement(tagName);
+        subtitle.className = 'subtitle';
+        if (rows.length > subtitleSizeRowIndex) {
+          const sizeClass = toSizeClass(cellText(rows[subtitleSizeRowIndex]));
+          if (sizeClass) block.classList.add(`subtitle-${sizeClass}`);
+        }
+        subtitle.textContent = subtitleText;
+        block.appendChild(subtitle);
+      }
     }
-    classes.forEach((c) => {
-      if (c && validAlignment.includes(c)) block.classList.add(c);
-    });
   }
-
-  let heading = block.querySelector('h1, h2, h3, h4, h5, h6, p');
-  if (!heading && titleText) {
-    heading = document.createElement(titleTag);
-    heading.textContent = titleText;
-  }
-
-  if (!heading) return;
-
-  block.innerHTML = '';
-  heading.classList.add('title');
-  block.appendChild(heading);
-
-  let subtitleText = (config.subtitle ?? '').trim();
-  if (!subtitleText && rows.length > 4) {
-    subtitleText = cellText(rows[4]);
-  }
-
-  if (!subtitleText) return;
-
-  let rawSubType = (config.subtitleType ?? '').trim();
-  if (!rawSubType && rows.length > 5) {
-    rawSubType = cellText(rows[5]);
-  }
-  const subType = rawSubType || 'p';
-  const subTagName = HEADING_TAG.test(subType) ? subType.toLowerCase() : 'p';
-
-  const subtitle = document.createElement(subTagName);
-  subtitle.className = 'subtitle';
-  subtitle.textContent = subtitleText;
-
-  let subSizeVal = (config.subtitle_size ?? '').trim();
-  if (!subSizeVal && rows.length > 6) {
-    subSizeVal = cellText(rows[6]);
-  }
-  const subSizeClass = toSizeClass(subSizeVal);
-  if (subSizeClass) block.classList.add(`subtitle-${subSizeClass}`);
-
-  block.appendChild(subtitle);
 }
 
 export default decorate;


### PR DESCRIPTION
Reverting JS to previously working version. There is not much to test as the block is broken everywhere.

Fix #642 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/drafts/section-title
- After: https://642-sectionTitle-options--idfc--aemsites.aem.page/drafts/section-title
