### PR TITLE
Full revert to previous versions that worked

### DIFF
--- a/blocks/section-title/_section-title.json
+++ b/blocks/section-title/_section-title.json
@@ -44,7 +44,7 @@
         },
         {
           "component": "select",
-          "name": "title_size",
+          "name": "textSize",
           "label": "Text Size",
           "value": "",
           "valueType": "string",
@@ -56,13 +56,12 @@
             { "name": "M", "value": "size-m" },
             { "name": "S", "value": "size-s" },
             { "name": "XS", "value": "size-xs" }
-
           ]
         },
         {
-          "component": "multiselect",
+          "component": "select",
           "name": "classes",
-          "label": "Text Alignment",
+          "label": "Alignment",
           "value": "",
           "valueType": "string",
           "options": [

--- a/blocks/section-title/section-title.css
+++ b/blocks/section-title/section-title.css
@@ -6,28 +6,64 @@
   padding: 0;
 }
 
-/* Title and subtitle size: block modifier + .title / .subtitle, same pattern and variables */
-.section-title.size-xxl .title {
+/* Text size overrides using CSS custom properties from styles.css */
+.section-title.size-xxl h1,
+.section-title.size-xxl h2,
+.section-title.size-xxl h3,
+.section-title.size-xxl h4,
+.section-title.size-xxl h5,
+.section-title.size-xxl h6,
+.section-title.size-xxl p {
   font-size: var(--heading-font-size-xxl);
 }
 
-.section-title.size-xl .title {
+.section-title.size-xl h1,
+.section-title.size-xl h2,
+.section-title.size-xl h3,
+.section-title.size-xl h4,
+.section-title.size-xl h5,
+.section-title.size-xl h6,
+.section-title.size-xl p {
   font-size: var(--heading-font-size-xl);
 }
 
-.section-title.size-l .title {
+.section-title.size-l h1,
+.section-title.size-l h2,
+.section-title.size-l h3,
+.section-title.size-l h4,
+.section-title.size-l h5,
+.section-title.size-l h6,
+.section-title.size-l p {
   font-size: var(--heading-font-size-l);
 }
 
-.section-title.size-m .title {
+.section-title.size-m h1,
+.section-title.size-m h2,
+.section-title.size-m h3,
+.section-title.size-m h4,
+.section-title.size-m h5,
+.section-title.size-m h6,
+.section-title.size-m p {
   font-size: var(--heading-font-size-m);
 }
 
-.section-title.size-s .title {
+.section-title.size-s h1,
+.section-title.size-s h2,
+.section-title.size-s h3,
+.section-title.size-s h4,
+.section-title.size-s h5,
+.section-title.size-s h6,
+.section-title.size-s p {
   font-size: var(--heading-font-size-s);
 }
 
-.section-title.size-xs .title {
+.section-title.size-xs h1,
+.section-title.size-xs h2,
+.section-title.size-xs h3,
+.section-title.size-xs h4,
+.section-title.size-xs h5,
+.section-title.size-xs h6,
+.section-title.size-xs p {
   font-size: var(--heading-font-size-xs);
 }
 
@@ -42,33 +78,4 @@
 
 .section-title.left {
   text-align: left;
-}
-
-/* Subtitle (optional): same size-on-block pattern as title, reuses --heading-font-size-* */
-.section-title .subtitle {
-  margin: 0;
-}
-
-.section-title.subtitle-size-xxl .subtitle {
-  font-size: var(--heading-font-size-xxl);
-}
-
-.section-title.subtitle-size-xl .subtitle {
-  font-size: var(--heading-font-size-xl);
-}
-
-.section-title.subtitle-size-l .subtitle {
-  font-size: var(--heading-font-size-l);
-}
-
-.section-title.subtitle-size-m .subtitle {
-  font-size: var(--heading-font-size-m);
-}
-
-.section-title.subtitle-size-s .subtitle {
-  font-size: var(--heading-font-size-s);
-}
-
-.section-title.subtitle-size-xs .subtitle {
-  font-size: var(--heading-font-size-xs);
 }

--- a/blocks/section-title/section-title.js
+++ b/blocks/section-title/section-title.js
@@ -1,10 +1,6 @@
 /**
- * Section Title block: apply author-selected text size and alignment as block classes.
- * Title and subtitle share the same alignment (row3). Subtitle size uses block class
- * (subtitle-size-*) so CSS can reuse the same pattern as title (size on block).
- * EDS DOM row order follows _section-title.json model field order:
- * row0=title, row1=titleType, row2=title_size, row3=classes;
- * row4=subtitle, row5=subtitleType, row6=subtitle_size (optional-subtitle container).
+ * Section Title block: minimal decorate — add size/alignment classes and .title on heading.
+ * Does not clear or replace content; only decorates what’s already in the block.
  */
 const SIZE_CLASSES = {
   xxl: 'size-xxl',
@@ -36,44 +32,18 @@ function cellText(row) {
   return (col.textContent || '').trim();
 }
 
-const SUBTITLE_TAG = /^h[1-6]|p$/i;
-
-function decorate(block) {
+export default function decorate(block) {
   const rows = block.querySelectorAll(':scope > div');
-  const titleSizeRowIndex = 2;
-  if (rows.length > titleSizeRowIndex) {
-    const sizeClass = toSizeClass(cellText(rows[titleSizeRowIndex]));
+
+  if (rows.length > 2) {
+    const sizeClass = toSizeClass(cellText(rows[2]));
     if (sizeClass) block.classList.add(sizeClass);
+  }
+  if (rows.length > 3) {
+    const align = cellText(rows[3]).toLowerCase();
+    if (align === 'center' || align === 'right' || align === 'left') block.classList.add(align);
   }
 
   const heading = block.querySelector('h1, h2, h3, h4, h5, h6, p');
-  if (heading && block.children.length > 1) {
-    block.innerHTML = '';
-    heading.classList.add('title');
-    block.appendChild(heading);
-
-    const subtitleTextRowIndex = 4;
-    const subtitleTypeRowIndex = 5;
-    const subtitleSizeRowIndex = 6;
-    if (rows.length > subtitleTextRowIndex) {
-      const subtitleText = cellText(rows[subtitleTextRowIndex]);
-      if (subtitleText) {
-        let tagName = 'p';
-        if (rows.length > subtitleTypeRowIndex) {
-          const typeVal = cellText(rows[subtitleTypeRowIndex]);
-          if (typeVal && SUBTITLE_TAG.test(typeVal)) tagName = typeVal.toLowerCase();
-        }
-        const subtitle = document.createElement(tagName);
-        subtitle.className = 'subtitle';
-        if (rows.length > subtitleSizeRowIndex) {
-          const sizeClass = toSizeClass(cellText(rows[subtitleSizeRowIndex]));
-          if (sizeClass) block.classList.add(`subtitle-${sizeClass}`);
-        }
-        subtitle.textContent = subtitleText;
-        block.appendChild(subtitle);
-      }
-    }
-  }
+  if (heading) heading.classList.add('title');
 }
-
-export default decorate;

--- a/blocks/section-title/section-title.js
+++ b/blocks/section-title/section-title.js
@@ -1,6 +1,6 @@
 /**
- * Section Title block: minimal decorate — add size/alignment classes and .title on heading.
- * Does not clear or replace content; only decorates what’s already in the block.
+ * Section Title block: apply author-selected text size and alignment as classes.
+ * EDS DOM order: row0=title, row1=textSize, row2=alignment.
  */
 const SIZE_CLASSES = {
   xxl: 'size-xxl',
@@ -34,16 +34,14 @@ function cellText(row) {
 
 export default function decorate(block) {
   const rows = block.querySelectorAll(':scope > div');
-
-  if (rows.length > 2) {
-    const sizeClass = toSizeClass(cellText(rows[2]));
+  if (rows.length >= 2) {
+    const sizeClass = toSizeClass(cellText(rows[1]));
     if (sizeClass) block.classList.add(sizeClass);
-  }
-  if (rows.length > 3) {
-    const align = cellText(rows[3]).toLowerCase();
-    if (align === 'center' || align === 'right' || align === 'left') block.classList.add(align);
   }
 
   const heading = block.querySelector('h1, h2, h3, h4, h5, h6, p');
-  if (heading) heading.classList.add('title');
+  if (heading && block.children.length > 1) {
+    block.innerHTML = '';
+    block.appendChild(heading);
+  }
 }

--- a/component-models.json
+++ b/component-models.json
@@ -2058,7 +2058,7 @@
       },
       {
         "component": "select",
-        "name": "title_size",
+        "name": "textSize",
         "label": "Text Size",
         "value": "",
         "valueType": "string",
@@ -2094,9 +2094,9 @@
         ]
       },
       {
-        "component": "multiselect",
+        "component": "select",
         "name": "classes",
-        "label": "Text Alignment",
+        "label": "Alignment",
         "value": "",
         "valueType": "string",
         "options": [


### PR DESCRIPTION
Doing a full revert to commit 8f114cd to try and get this block working again. Then I will slowly and more carefully add in the subtitle options we are after. 

Fix #642 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/drafts/section-title
- After: https://642-sectionTitle-options--idfc--aemsites.aem.page/drafts/section-title
