### PR TITLE
UE allow cards-icon in sections

### DIFF
--- a/component-filters.json
+++ b/component-filters.json
@@ -35,7 +35,8 @@
       "overview",
       "section-title",
       "hotspot",
-      "cards-testimonial"
+      "cards-testimonial",
+      "cards-icon"
     ]
   },
   {
@@ -57,7 +58,8 @@
       "banner",
       "overview",
       "section-title",
-      "hotspot"
+      "hotspot",
+      "cards-icon"
     ]
   },
   {

--- a/models/_multi-section.json
+++ b/models/_multi-section.json
@@ -216,7 +216,8 @@
             "banner",
             "overview",
             "section-title",
-            "hotspot"
+            "hotspot",
+            "cards-icon"
         ]
       }
     ]

--- a/models/_section.json
+++ b/models/_section.json
@@ -468,7 +468,8 @@
         "overview",
         "section-title",
         "hotspot",
-        "cards-testimonial"
+        "cards-testimonial",
+        "cards-icon"
       ]
     }
   ]


### PR DESCRIPTION
I forgot to allow the new cards-icon under sections in the UE.

Fix #657 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://657-cardsicon--idfc--aemsites.aem.page/
