### PR TITLE
UE rename of card item

### DIFF
--- a/blocks/cards-icon/_cards-icon.json
+++ b/blocks/cards-icon/_cards-icon.json
@@ -1,14 +1,14 @@
 {
   "definitions": [
     {
-      "title": "Cards Icon",
+      "title": "Cards with Icon",
       "id": "cards-icon",
       "plugins": {
         "xwalk": {
           "page": {
             "resourceType": "core/franklin/components/block/v1/block",
             "template": {
-              "name": "Cards Icon",
+              "name": "Cards with Icon",
               "model": "cards-icon",
               "filter": "cards-icon"
             }
@@ -18,7 +18,7 @@
     },
     {
       "title": "Card",
-      "id": "card",
+      "id": "card-icon-item",
       "plugins": {
         "xwalk": {
           "page": {
@@ -58,7 +58,7 @@
       ]
     },
     {
-      "id": "card",
+      "id": "card-icon-item",
       "fields": [
         {
           "component": "reference",
@@ -99,6 +99,6 @@
     }
   ],
   "filters": [
-    { "id": "cards-icon", "components": ["card"] }
+    { "id": "cards-icon", "components": ["card-icon-item"] }
   ]
 }

--- a/blocks/cards-icon/_cards-icon.json
+++ b/blocks/cards-icon/_cards-icon.json
@@ -25,7 +25,7 @@
             "resourceType": "core/franklin/components/block/v1/block/item",
             "template": {
               "name": "Card",
-              "model": "card"
+              "model": "card-icon-item"
             }
           }
         }

--- a/component-definition.json
+++ b/component-definition.json
@@ -223,7 +223,7 @@
                 "resourceType": "core/franklin/components/block/v1/block/item",
                 "template": {
                   "name": "Card",
-                  "model": "card"
+                  "model": "card-icon-item"
                 }
               }
             }

--- a/component-definition.json
+++ b/component-definition.json
@@ -199,14 +199,14 @@
           }
         },
         {
-          "title": "Cards Icon",
+          "title": "Cards with Icon",
           "id": "cards-icon",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
-                  "name": "Cards Icon",
+                  "name": "Cards with Icon",
                   "model": "cards-icon",
                   "filter": "cards-icon"
                 }
@@ -216,7 +216,7 @@
         },
         {
           "title": "Card",
-          "id": "card",
+          "id": "card-icon-item",
           "plugins": {
             "xwalk": {
               "page": {

--- a/component-filters.json
+++ b/component-filters.json
@@ -83,7 +83,7 @@
   {
     "id": "cards-icon",
     "components": [
-      "card"
+      "card-icon-item"
     ]
   },
   {

--- a/component-models.json
+++ b/component-models.json
@@ -1110,7 +1110,7 @@
     ]
   },
   {
-    "id": "card",
+    "id": "card-icon-item",
     "fields": [
       {
         "component": "reference",


### PR DESCRIPTION
Because AI is bad at naming.

Fix #657 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/cards-icon
- After: https://657-cardsicon--idfc--aemsites.aem.page/library/cards-icon
