### PR TITLE
bad name for cards-icon

### DIFF
--- a/blocks/cards-icon/_cards-icon.json
+++ b/blocks/cards-icon/_cards-icon.json
@@ -8,7 +8,7 @@
           "page": {
             "resourceType": "core/franklin/components/block/v1/block",
             "template": {
-              "name": "Cards with Icon",
+              "name": "cards-icon",
               "model": "cards-icon",
               "filter": "cards-icon"
             }

--- a/component-definition.json
+++ b/component-definition.json
@@ -206,7 +206,7 @@
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block",
                 "template": {
-                  "name": "Cards with Icon",
+                  "name": "cards-icon",
                   "model": "cards-icon",
                   "filter": "cards-icon"
                 }


### PR DESCRIPTION
typo

Fix #657 
Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/cards-icon
- After: https:/657-cardsicon--idfc--aemsites.aem.page/library/cards-icon
