### PR TITLE
add global dompurify functions, update estlintrc

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -21,15 +21,13 @@ module.exports = {
     'xwalk/max-cells': ['error', {
       section: 30, // section is a key-value block and over 4 is OK
       'multi-section': 30,
-      accordion: 4, // the rest of these need adjustments per https://www.aem.live/developer/component-model-definitions#type-inference
-      'banner-item': 4,
-      cards: 4,
-      card: 4,
-      'category-nav-item': 4,
-      'cc-hero-slider-item': 4,
-      steps: 4,
-      table: 4,
-      'tabs-upi-link': 4,
+      accordion: 5, // the rest of these need adjustments per https://www.aem.live/developer/component-model-definitions#type-inference
+      cards: 8,
+      card: 7,
+      'category-nav-item': 10,
+      'section-title': 5,
+      steps: 5,
+      table: 5,
     }],
     'no-restricted-syntax': [
       'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -27,7 +27,7 @@ module.exports = {
       'category-nav-item': 10,
       'section-title': 5,
       steps: 5,
-      table: 5,
+      table: 6,
     }],
     'no-restricted-syntax': [
       'error',

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -12,10 +12,37 @@ import {
   loadSection,
   loadSections,
   loadCSS,
+  loadScript,
   getMetadata,
   // readBlockConfig,
   toCamelCase,
 } from './aem.js';
+
+// DOMPurify loaded once for HTML sanitization (mitigates DOM XSS from contentMap/dataset)
+let domPurifyReady = null;
+
+/**
+ * Ensures DOMPurify is loaded. Resolves with the script load. Safe to call multiple times.
+ * @returns {Promise<void>}
+ */
+export async function ensureDOMPurify() {
+  if (!domPurifyReady) {
+    const base = window.hlx?.codeBasePath ?? '';
+    domPurifyReady = loadScript(`${base}/scripts/dompurify.min.js`);
+  }
+  return domPurifyReady;
+}
+
+/**
+ * Sanitize HTML before assigning to innerHTML. Use for any content from DOM/dataset/contentMap.
+ * @param {string} html - Raw HTML string
+ * @returns {string} Sanitized HTML safe for insertion
+ */
+export function sanitizeHTML(html) {
+  if (!html || typeof html !== 'string') return html;
+  if (!window.DOMPurify) return html;
+  return window.DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
+}
 
 // Cached media query results for Section performance
 const MEDIA_QUERIES = {


### PR DESCRIPTION
adding 2 benign functions to set up individual block tickets to remedy high XSS security problems.
(they are also added to PR 671 but I didn't want to merge that).

Fix #673 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://673-scriptsdompurify--idfc--aemsites.aem.page/

Testing: This code doesn't do anything by itself, it is safe to merge.

Scores look good despite what the API says.
<img width="1009" height="818" alt="image" src="https://github.com/user-attachments/assets/63277c35-a71d-491a-b456-d57ee7737dc8" />
