### PR TITLE
Embed.js: added sanitizeHTML from DOMpurity

### DIFF
--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -4,6 +4,11 @@
  * https://www.hlx.live/developer/block-collection/embed
  */
 
+import { sanitizeHTML } from '../../scripts/scripts.js';
+
+/* eslint-disable secure-coding/no-improper-sanitization --
+sanitizeHTML uses DOMPurify via the import from scripts.js which linting can't see */
+
 const loadScript = (url, callback, type) => {
   const head = document.querySelector('head');
   const script = document.createElement('script');
@@ -80,10 +85,10 @@ const loadEmbed = (block, link, autoplay) => {
   const config = EMBEDS_CONFIG.find((e) => e.match.some((match) => link.includes(match)));
   const url = new URL(link);
   if (config) {
-    block.innerHTML = config.embed(url, autoplay);
+    block.innerHTML = sanitizeHTML(config.embed(url, autoplay));
     block.classList = `block embed embed-${config.match[0]}`;
   } else {
-    block.innerHTML = getDefaultEmbed(url);
+    block.innerHTML = sanitizeHTML(getDefaultEmbed(url));
     block.classList = 'block embed';
   }
   block.classList.add('embed-is-loaded');
@@ -97,7 +102,7 @@ export default function decorate(block) {
   if (placeholder) {
     const wrapper = document.createElement('div');
     wrapper.className = 'embed-placeholder';
-    wrapper.innerHTML = '<div class="embed-placeholder-play"><button type="button" title="Play"></button></div>';
+    wrapper.innerHTML = sanitizeHTML('<div class="embed-placeholder-play"><button type="button" title="Play"></button></div>');
     wrapper.prepend(placeholder);
     wrapper.addEventListener('click', () => {
       loadEmbed(block, link, true);


### PR DESCRIPTION
There should not be any functional difference with the embed. This code just sanitizes the innerHTML.

Fix #687 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/embed
- After: https://687-embedjsxss--idfc--aemsites.aem.page/library/embed