### PR TITLE
Move sanitizeHTML to aem.js, misc fixes

### DIFF
--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -22,6 +22,9 @@ import {
 // Re-export for blocks that import from scripts.js
 export { sanitizeHTML };
 
+// Max collection size before iteration to prevent DoS from excessive loops (CWE-400)
+const MAX_ITERATION_LIMIT = 500;
+
 // DOMPurify loaded once for HTML sanitization (mitigates DOM XSS from contentMap/dataset)
 let domPurifyReady = null;
 

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,9 +14,13 @@ import {
   loadCSS,
   loadScript,
   getMetadata,
+  sanitizeHTML,
   // readBlockConfig,
   toCamelCase,
 } from './aem.js';
+
+// Re-export for blocks that import from scripts.js
+export { sanitizeHTML };
 
 // DOMPurify loaded once for HTML sanitization (mitigates DOM XSS from contentMap/dataset)
 let domPurifyReady = null;
@@ -31,17 +35,6 @@ export async function ensureDOMPurify() {
     domPurifyReady = loadScript(`${base}/scripts/dompurify.min.js`);
   }
   return domPurifyReady;
-}
-
-/**
- * Sanitize HTML before assigning to innerHTML. Use for any content from DOM/dataset/contentMap.
- * @param {string} html - Raw HTML string
- * @returns {string} Sanitized HTML safe for insertion
- */
-export function sanitizeHTML(html) {
-  if (!html || typeof html !== 'string') return html;
-  if (!window.DOMPurify) return html;
-  return window.DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
 }
 
 // Cached media query results for Section performance


### PR DESCRIPTION
1. moved santizeHTML to aem.js so we could apply it
2. added necessary eslint ignore to safe areas
3. added some console.log messages to try/catch blocks per the linting
4. the placeholders related code: Implemented property whitelisting: adding a safe-key check and normalizing the prefix so we don't use dangerous keys. (we don't currently use this placeholders feature for IDFC).
5. fixed this duplicate branches error:

**What was wrong**
ESLint reported “duplicate branches” because two branches did the same thing:
Line 417: if (!hasWrapper) { wrap(blockColumn); }
Lines 418–422: else if (PICTURE condition) { wrap(blockColumn); }
Both branches only called wrap(blockColumn), so the linter treated them as redundant.
**What was changed**
The two conditions were merged into one and a single call to wrap(blockColumn) was kept:
Introduced a needsWrap variable that is true when:
there is no valid wrapper (!hasWrapper), or
the first child is a PICTURE and there’s extra content (more than one child or non-empty text).
Replaced the if / else if with a single if (needsWrap) { wrap(blockColumn); }.
blockColumn.firstElementChild is now accessed with optional chaining (?.) so it’s safe when there is no first element child.
Behavior is unchanged; the duplicate-branch ESLint error should be gone.


Fix #695 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://695-aemjsxss--idfc--aemsites.aem.page/

Testing: No functionality should be changed.