### PR TITLE
Set discover card blog post bg to white

### DIFF
--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -2122,7 +2122,7 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
 
   /* Discover card: flat structure is card > .cards-card-image, .cards-card-body (body needs padding) */
   header nav .nav-sections .nav-discover-section .cards.block .cards-card.blog-post-card {
-    background: var(--color-white-200);
+    background: var(--color-white);
     border: 1px solid var(--color-gray-200);
     margin: var(--spacing-xs);
   }


### PR DESCRIPTION
Fixed BG color of cards, removed extra "bell notification bulletin card" from JCR and republished. 

Fix #701

<img width="1699" height="1516" alt="image" src="https://github.com/user-attachments/assets/e6467b89-1467-4825-bb55-391b3f5f28e5" />


Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://701-cardbg--idfc--aemsites.aem.page/
