### PR TITLE
Updated all the prev JS via browser-security

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,6 +1,6 @@
 module.exports = {
   root: true,
-  plugins: ['secure-coding', 'sonarjs'],
+  plugins: ['secure-coding', 'browser-security', 'sonarjs'],
   extends: [
     'airbnb-base',
     'plugin:json/recommended',
@@ -18,10 +18,15 @@ module.exports = {
   },
   rules: {
     // secure-coding: preset is flat-config only; rules enabled manually for legacy config
+    // see https://eslint.interlace.tools/docs/security/plugin-secure-coding/rules
     'secure-coding/no-hardcoded-credentials': 'error',
     'secure-coding/no-redos-vulnerable-regex': 'error',
     'secure-coding/no-unsafe-deserialization': 'error',
-    'secure-coding/no-improper-sanitization': 'error',
+    'secure-coding/no-improper-sanitization': ['error', {
+      safeSanitizers: [
+        'DOMPurify.sanitize', 'he.encode', 'encodeURIComponent', 'encodeURI', 'escape',
+      ],
+    }],
     'secure-coding/no-format-string-injection': 'error',
     'secure-coding/no-unchecked-loop-condition': 'error',
     'secure-coding/no-unlimited-resource-allocation': 'error',
@@ -34,6 +39,43 @@ module.exports = {
     'secure-coding/no-missing-authentication': 'warn',
     'secure-coding/no-sensitive-data-exposure': 'warn',
     'secure-coding/no-pii-in-logs': 'warn',
+    // browser-security: configs.recommended is flat-config only; rules enabled manually for
+    // legacy config.see https://eslint.interlace.tools/docs/security/plugin-browser-security
+    'browser-security/no-innerhtml': ['error', {
+      trustedSanitizers: [
+        'DOMPurify.sanitize', 'sanitize', 'sanitizeHtml', 'xss', 'purify',
+      ],
+    }],
+    'browser-security/no-eval': 'error',
+    'browser-security/require-postmessage-origin-check': 'error',
+    'browser-security/no-postmessage-wildcard-origin': 'error',
+    'browser-security/no-postmessage-innerhtml': 'error',
+    'browser-security/no-sensitive-localstorage': 'error',
+    'browser-security/no-jwt-in-storage': 'error',
+    'browser-security/no-sensitive-sessionstorage': 'error',
+    'browser-security/no-sensitive-indexeddb': 'error',
+    'browser-security/no-sensitive-cookie-js': 'error',
+    'browser-security/no-cookie-auth-tokens': 'error',
+    'browser-security/require-cookie-secure-attrs': 'error',
+    'browser-security/require-websocket-wss': 'error',
+    'browser-security/no-websocket-innerhtml': 'error',
+    'browser-security/no-websocket-eval': 'error',
+    'browser-security/no-filereader-innerhtml': 'error',
+    'browser-security/require-blob-url-revocation': 'warn',
+    'browser-security/no-dynamic-service-worker-url': 'error',
+    'browser-security/no-worker-message-innerhtml': 'error',
+    'browser-security/no-unsafe-inline-csp': 'error',
+    'browser-security/no-unsafe-eval-csp': 'error',
+    'browser-security/detect-mixed-content': 'error',
+    'browser-security/no-allow-arbitrary-loads': 'error',
+    'browser-security/no-clickjacking': 'error',
+    'browser-security/no-credentials-in-query-params': 'error',
+    'browser-security/no-http-urls': 'error',
+    'browser-security/no-insecure-redirects': 'error',
+    'browser-security/require-https-only': 'error',
+    'browser-security/no-insecure-websocket': 'error',
+    'browser-security/no-unvalidated-deeplinks': 'error',
+    'browser-security/no-client-side-auth-logic': 'error',
     'import/extensions': ['error', { js: 'always' }], // require js file extensions in imports
     'linebreak-style': ['error', 'unix'], // enforce unix linebreaks
     'no-param-reassign': [2, { props: false }], // allow modifying properties of param

--- a/README.md
+++ b/README.md
@@ -28,8 +28,9 @@ npm i
 ```
 
 ## Linting
-This project is using StyleLint and ESLint (including the SonarJS code quality and the Interlace secure-coding security plugins for ESLint).
+This project is using StyleLint and ESLint (including the SonarJS code quality and the Interlace secure-coding security +  browser-security plugins for ESLint).
 https://dev.to/ofri-peretz/sonarjs-has-269-rules-it-still-misses-65-of-security-vulnerabilities-3jh
+https://eslint.interlace.tools/docs/security/plugin-browser-security/rules
 
 ```sh
 npm run lint

--- a/blocks/cards-testimonial/cards-testimonial.js
+++ b/blocks/cards-testimonial/cards-testimonial.js
@@ -1,10 +1,7 @@
 import {
   createOptimizedPicture, loadScript, loadCSS, getMetadata,
 } from '../../scripts/aem.js';
-import { moveInstrumentation, sanitizeHTML } from '../../scripts/scripts.js';
-
-/* eslint-disable secure-coding/no-improper-sanitization --
-sanitizeHTML uses DOMPurify via the import from scripts.js which linting can't see */
+import { moveInstrumentation, DOMPURIFY } from '../../scripts/scripts.js';
 
 function parseReviewDateToISO(dateText) {
   if (!dateText || !String(dateText).trim()) return '';
@@ -40,17 +37,19 @@ function formatDateForDisplay(isoDate) {
 function extractOneTestimonial(card) {
   const cardBody = card.querySelector('.cards-card-body');
   if (!cardBody) return null;
-  let authorName = sanitizeHTML(card.dataset.personName || card.getAttribute('data-person-name') || '');
-  let productName = sanitizeHTML(card.dataset.productName || card.getAttribute('data-product-name') || 'IDFC FIRST Bank Credit Card');
+  const rawName = card.dataset.personName || card.getAttribute('data-person-name') || '';
+  const rawProduct = card.dataset.productName || card.getAttribute('data-product-name') || 'IDFC FIRST Bank Credit Card';
+  let authorName = rawName;
+  let productName = rawProduct;
   let ratingValue = parseInt(card.dataset.authorRating || card.getAttribute('data-author-rating'), 10) || 0;
   let datePublished = parseReviewDateToISO(card.dataset.reviewDate || card.getAttribute('data-review-date') || '');
   if (!authorName) {
-    const authorEl = cardBody.querySelector('.testimonial-person-name') || cardBody.querySelector('h5');
-    authorName = sanitizeHTML(authorEl ? authorEl.textContent : '');
+    const authorEl = cardBody.querySelector('.testimonial-person-name');
+    authorName = authorEl ? authorEl.textContent : '';
   }
   if (!productName || productName === 'IDFC FIRST Bank Credit Card') {
     const productEl = cardBody.querySelector('.testimonial-product-name u') || cardBody.querySelector('p u');
-    productName = sanitizeHTML(productEl ? productEl.textContent : 'IDFC FIRST Bank Credit Card');
+    productName = productEl ? productEl.textContent : 'IDFC FIRST Bank Credit Card';
   }
   if (ratingValue <= 0) {
     const starIcons = cardBody.querySelectorAll('[class*="icon-star"]');
@@ -66,9 +65,8 @@ function extractOneTestimonial(card) {
       reviewText += p.textContent.trim();
     }
   });
-  reviewText = sanitizeHTML(reviewText);
   if (!datePublished) {
-    const dateEl = cardBody.querySelector('.testimonial-date') || cardBody.querySelector('h6');
+    const dateEl = cardBody.querySelector('.testimonial-date');
     const dateText = dateEl ? dateEl.textContent : '';
     const dateParts = dateText.split('|');
     const dateString = dateParts.length > 1 ? dateParts[1].trim() : dateText.trim();
@@ -361,7 +359,7 @@ function applyLegacyNormalization(cardItem, mainBody) {
   }
   const authorEl = mainBody.querySelector('h5');
   if (authorEl) {
-    const name = sanitizeHTML(authorEl.textContent);
+    const name = authorEl.textContent;
     const p = document.createElement('p');
     p.className = 'testimonial-person-name';
     p.textContent = name;
@@ -370,7 +368,7 @@ function applyLegacyNormalization(cardItem, mainBody) {
   }
   const dateEl = mainBody.querySelector('h6');
   if (dateEl) {
-    const dt = sanitizeHTML(dateEl.textContent);
+    const dt = dateEl.textContent;
     const p = document.createElement('p');
     p.className = 'testimonial-date';
     p.textContent = dt;
@@ -379,7 +377,7 @@ function applyLegacyNormalization(cardItem, mainBody) {
   }
   const productEl = mainBody.querySelector('p u');
   if (productEl) {
-    const name = sanitizeHTML(productEl.textContent);
+    const name = productEl.textContent;
     const parentP = productEl.closest('p');
     if (parentP && !parentP.classList.contains('testimonial-product-name')) {
       parentP.classList.add('testimonial-product-name');
@@ -414,8 +412,8 @@ function getDetailsFromLayout(layoutMap, bodyDivsByIndex) {
     const detailsBody = bodyDivsByIndex.get(quotedetailsIdx);
     const detailsParas = detailsBody ? [...detailsBody.querySelectorAll('p')] : [];
     return {
-      personName: sanitizeHTML(detailsParas[0]?.textContent ?? ''),
-      productName: sanitizeHTML(detailsParas[1]?.textContent ?? '') || DEFAULT_PRODUCT,
+      personName: detailsParas[0]?.textContent ?? '',
+      productName: (detailsParas[1]?.textContent ?? '') || DEFAULT_PRODUCT,
       ratingRaw: detailsParas[2]?.textContent?.trim() ?? '',
       dateText: detailsParas[3]?.textContent?.trim() ?? '',
     };
@@ -437,8 +435,8 @@ function getDetailsFromLayout(layoutMap, bodyDivsByIndex) {
   const ratingDiv = bodyDivsByIndex.get(ratingIdx);
   const dateDiv = bodyDivsByIndex.get(dateIdx);
   return {
-    personName: personDiv ? sanitizeHTML(personDiv.textContent) : '',
-    productName: (productDiv ? sanitizeHTML(productDiv.textContent) : '') || DEFAULT_PRODUCT,
+    personName: personDiv ? personDiv.textContent : '',
+    productName: (productDiv ? productDiv.textContent : '') || DEFAULT_PRODUCT,
     ratingRaw: ratingDiv ? ratingDiv.textContent.trim() : '',
     dateText: dateDiv ? dateDiv.textContent.trim() : '',
   };
@@ -478,7 +476,8 @@ function normalizeTestimonialCard(cardItem) {
   cardItem.setAttribute('data-quote-icon', quoteIcon);
   if (reviewHtml.trim()) {
     const reviewWrapper = document.createElement('div');
-    reviewWrapper.innerHTML = reviewHtml;
+    reviewWrapper.innerHTML = (window.DOMPurify?.sanitize(reviewHtml, DOMPURIFY))
+      ?? reviewHtml;
     newBody.append(...reviewWrapper.childNodes);
   }
   const pPerson = document.createElement('p');

--- a/blocks/cc-hero-slider/cc-hero-slider.js
+++ b/blocks/cc-hero-slider/cc-hero-slider.js
@@ -1,5 +1,5 @@
 import { loadScript, loadCSS } from '../../scripts/aem.js';
-import { moveInstrumentation, sanitizeHTML } from '../../scripts/scripts.js';
+import { moveInstrumentation, DOMPURIFY } from '../../scripts/scripts.js';
 
 /**
  * Decorates the CC Hero Slider block
@@ -61,7 +61,9 @@ export default async function decorate(block) {
     if (popupTriggerDiv?.textContent.trim()) {
       const popupTrigger = document.createElement('div');
       popupTrigger.className = 'cc-hero-slider-popup-trigger';
-      popupTrigger.innerHTML = sanitizeHTML(popupTriggerDiv.innerHTML);
+      const popupRaw = popupTriggerDiv.innerHTML;
+      popupTrigger.innerHTML = (window.DOMPurify?.sanitize(popupRaw, DOMPURIFY))
+        ?? popupRaw;
       swiperSlide.appendChild(popupTrigger);
     }
 

--- a/blocks/embed/embed.js
+++ b/blocks/embed/embed.js
@@ -4,10 +4,7 @@
  * https://www.hlx.live/developer/block-collection/embed
  */
 
-import { sanitizeHTML } from '../../scripts/scripts.js';
-
-/* eslint-disable secure-coding/no-improper-sanitization --
-sanitizeHTML uses DOMPurify via the import from scripts.js which linting can't see */
+import { DOMPURIFY } from '../../scripts/scripts.js';
 
 const loadScript = (url, callback, type) => {
   const head = document.querySelector('head');
@@ -85,10 +82,14 @@ const loadEmbed = (block, link, autoplay) => {
   const config = EMBEDS_CONFIG.find((e) => e.match.some((match) => link.includes(match)));
   const url = new URL(link);
   if (config) {
-    block.innerHTML = sanitizeHTML(config.embed(url, autoplay));
+    const embedHtml = config.embed(url, autoplay);
+    block.innerHTML = (window.DOMPurify?.sanitize(embedHtml, DOMPURIFY))
+      ?? embedHtml;
     block.classList = `block embed embed-${config.match[0]}`;
   } else {
-    block.innerHTML = sanitizeHTML(getDefaultEmbed(url));
+    const defaultHtml = getDefaultEmbed(url);
+    block.innerHTML = (window.DOMPurify?.sanitize(defaultHtml, DOMPURIFY))
+      ?? defaultHtml;
     block.classList = 'block embed';
   }
   block.classList.add('embed-is-loaded');
@@ -102,7 +103,9 @@ export default function decorate(block) {
   if (placeholder) {
     const wrapper = document.createElement('div');
     wrapper.className = 'embed-placeholder';
-    wrapper.innerHTML = sanitizeHTML('<div class="embed-placeholder-play"><button type="button" title="Play"></button></div>');
+    const placeholderHtml = '<div class="embed-placeholder-play"><button type="button" title="Play"></button></div>';
+    wrapper.innerHTML = (window.DOMPurify?.sanitize(placeholderHtml, DOMPURIFY))
+      ?? placeholderHtml;
     wrapper.prepend(placeholder);
     wrapper.addEventListener('click', () => {
       loadEmbed(block, link, true);

--- a/blocks/header/header.js
+++ b/blocks/header/header.js
@@ -1,9 +1,6 @@
 import { getMetadata, decorateIcons } from '../../scripts/aem.js';
-import { loadFragment, sanitizeHTML } from '../../scripts/scripts.js';
+import { loadFragment, DOMPURIFY } from '../../scripts/scripts.js';
 import { parseCategoryNavBlock, buildDropdown } from '../category-nav/category-nav.js';
-
-/* eslint-disable secure-coding/no-improper-sanitization --
-sanitizeHTML uses DOMPurify via the import from scripts.js which linting can't see */
 
 // media query matches for different viewport sizes
 const isDesktop = window.matchMedia('(min-width: 990px)');
@@ -134,7 +131,7 @@ function createDropdown(options) {
 
   const closeBtn = document.createElement('button');
   closeBtn.className = `${className.split(' ')[0]}-close-btn`;
-  closeBtn.innerHTML = '&times;';
+  closeBtn.textContent = '\u00D7'; // × (multiplication sign / close icon)
   closeBtn.setAttribute('aria-label', 'Close');
   dropdown.appendChild(closeBtn);
 
@@ -390,14 +387,15 @@ function buildMobileOdometerContainer(odometerItemTexts) {
 
   const spans = odometerItemTexts.map((text) => `<span>${text}</span>`).join('');
   const firstItemText = odometerItemTexts[0];
-  container.innerHTML = sanitizeHTML(`
+  const odometerHtml = `
     <div class="grnt-animation-odometer">
       <div class="grnt-odometer-track">
         ${spans}
         <span>${firstItemText}</span>
       </div>
     </div>
-  `);
+  `;
+  container.innerHTML = (window.DOMPurify?.sanitize(odometerHtml, DOMPURIFY)) ?? odometerHtml;
   return container;
 }
 
@@ -458,10 +456,12 @@ function setupSearchDropdown(navToolsWrapper, navTools) {
   const mobileSearchBox = document.createElement('div');
   mobileSearchBox.className = 'mobile-search-input-wrapper';
   mobileSearchBox.id = 'mobile-search-box';
-  mobileSearchBox.innerHTML = `
+  const mobileSearchHtml = `
     <span class="icon icon-search"></span>
     <input type="text" placeholder="What are you looking for..." class="search-input mobile-search-input" />
   `;
+  mobileSearchBox.innerHTML = (window.DOMPurify?.sanitize(mobileSearchHtml, DOMPURIFY))
+   ?? mobileSearchHtml;
 
   const insertMobileSearchBox = () => {
     const firstSection = search.dropdown.querySelector('.section');
@@ -494,14 +494,19 @@ function setupSearchDropdown(navToolsWrapper, navTools) {
     if (loadingEl) loadingEl.remove();
 
     if (results.length === 0) {
-      /* eslint-disable-next-line secure-coding/no-format-string-injection --
-      HTML, sanitizeHTML; not format string */
-      container.innerHTML += sanitizeHTML(`
-        <div class="search-results-empty">
-          <p>No results found for "${query}"</p>
-          <p>Try searching for something else or press Enter to see all results</p>
-        </div>
-      `);
+      const emptyDiv = document.createElement('div');
+      emptyDiv.className = 'search-results-empty';
+      const p1 = document.createElement('p');
+      p1.append(
+        document.createTextNode('No results found for "'),
+        document.createTextNode(query),
+        document.createTextNode('"'),
+      );
+      emptyDiv.appendChild(p1);
+      const p2 = document.createElement('p');
+      p2.textContent = 'Try searching for something else or press Enter to see all results';
+      emptyDiv.appendChild(p2);
+      container.appendChild(emptyDiv);
       return;
     }
 
@@ -509,25 +514,31 @@ function setupSearchDropdown(navToolsWrapper, navTools) {
     resultsList.classList.add('search-results-list');
     results.forEach((result) => {
       const li = document.createElement('li');
-      li.innerHTML = sanitizeHTML(`
+      const liHtml = `
         <a href="${result.url}">
           <span class="search-result-title">${result.title}</span>
           ${result.type ? `<span class="search-result-type">${result.type}</span>` : ''}
         </a>
-      `);
+      `;
+      li.innerHTML = (window.DOMPurify?.sanitize(liHtml, DOMPURIFY)) ?? liHtml;
       resultsList.appendChild(li);
     });
     container.appendChild(resultsList);
 
     const viewAllLink = document.createElement('div');
     viewAllLink.classList.add('search-results-footer');
-    /* eslint-disable-next-line secure-coding/no-format-string-injection --
-    HTML, sanitizeHTML; not format string. Next time don't use 'query' in the format string. */
-    viewAllLink.innerHTML = sanitizeHTML(`
-      <a href="https://www.idfcfirst.bank.in/search?skey=${encodeURIComponent(query)}" class="view-all-results">
-        View all results for "${query}" <span class="icon icon-arrow-right-alt"></span>
-      </a>
-    `);
+    const viewAllAnchor = document.createElement('a');
+    viewAllAnchor.href = `https://www.idfcfirst.bank.in/search?skey=${encodeURIComponent(query)}`;
+    viewAllAnchor.className = 'view-all-results';
+    viewAllAnchor.append(
+      document.createTextNode('View all results for "'),
+      document.createTextNode(query),
+      document.createTextNode('" '),
+    );
+    const viewAllIcon = document.createElement('span');
+    viewAllIcon.className = 'icon icon-arrow-right-alt';
+    viewAllAnchor.appendChild(viewAllIcon);
+    viewAllLink.appendChild(viewAllAnchor);
     viewAllLink.querySelector('.view-all-results').addEventListener('click', () => {
       sessionStorage.setItem('searchKeySolar', query);
     });
@@ -558,16 +569,22 @@ function setupSearchDropdown(navToolsWrapper, navTools) {
     const resultsContainer = document.createElement('div');
     resultsContainer.classList.add('search-results', 'section');
     resultsContainer.setAttribute('data-search-results', 'true');
-    /* eslint-disable-next-line secure-coding/no-format-string-injection --
-    HTML, sanitizeHTML; not format string.  */
-    resultsContainer.innerHTML = sanitizeHTML(`
-      <div class="search-results-header">
-        <h3>Search results for "${query}"</h3>
-      </div>
-      <div class="search-results-loading">
-        <p>Searching...</p>
-      </div>
-    `);
+    const headerDiv = document.createElement('div');
+    headerDiv.className = 'search-results-header';
+    const headerH3 = document.createElement('h3');
+    headerH3.append(
+      document.createTextNode('Search results for "'),
+      document.createTextNode(query),
+      document.createTextNode('"'),
+    );
+    headerDiv.appendChild(headerH3);
+    resultsContainer.appendChild(headerDiv);
+    const loadingDiv = document.createElement('div');
+    loadingDiv.className = 'search-results-loading';
+    const loadingP = document.createElement('p');
+    loadingP.textContent = 'Searching...';
+    loadingDiv.appendChild(loadingP);
+    resultsContainer.appendChild(loadingDiv);
     firstSection.parentNode.insertBefore(resultsContainer, firstSection);
     setTimeout(() => fetchSearchResults(query, resultsContainer), 300);
   };
@@ -587,8 +604,10 @@ function setupSearchDropdown(navToolsWrapper, navTools) {
   const handleSearchKeydown = (e) => {
     if (e.key === 'Enter') {
       e.preventDefault();
-      const query = e.target.value.trim();
-      if (query) {
+      const { target } = e;
+      if (!target || typeof target.value !== 'string') return;
+      const query = String(target.value).trim();
+      if (typeof query === 'string' && query.length > 0) {
         sessionStorage.setItem('searchKeySolar', query);
         window.location.href = `https://www.idfcfirst.bank.in/search?skey=${encodeURIComponent(query)}`;
       }
@@ -673,9 +692,10 @@ function getLogoFromFragment(fragment) {
  * @param {{ logoImgSrc: string, logoImgAlt: string }} logo Logo data
  */
 function buildNavBrand(navBrand, logo) {
-  navBrand.innerHTML = sanitizeHTML(`<a href="https://www.idfcfirst.bank.in/personal-banking" aria-label="IDFC FIRST Bank Home">
+  const navBrandHtml = `<a href="https://www.idfcfirst.bank.in/personal-banking" aria-label="IDFC FIRST Bank Home">
     <img src="${logo.logoImgSrc}" alt="${logo.logoImgAlt}">
-  </a>`);
+  </a>`;
+  navBrand.innerHTML = (window.DOMPurify?.sanitize(navBrandHtml, DOMPURIFY)) ?? navBrandHtml;
 }
 
 /**
@@ -795,11 +815,14 @@ function buildNavToolsDOM(navToolsWrapper, toolsData) {
     const searchText = searchP.textContent.trim();
     const searchElement = document.createElement('p');
     searchElement.id = 'search-box';
-    /* eslint-disable secure-coding/no-graphql-injection -- HTML, sanitizeHTML; not GraphQL */
-    const searchHtml = '<span class="icon icon-search"></span>'
-      + `<input type="text" placeholder="${searchText}" class="search-input" />`;
-    /* eslint-enable secure-coding/no-graphql-injection */
-    searchElement.innerHTML = sanitizeHTML(searchHtml);
+    const iconSpan = document.createElement('span');
+    iconSpan.className = 'icon icon-search';
+    const searchInput = document.createElement('input');
+    searchInput.type = 'text';
+    searchInput.placeholder = searchText;
+    searchInput.className = 'search-input';
+    searchElement.appendChild(iconSpan);
+    searchElement.appendChild(searchInput);
     navToolsWrapper.appendChild(searchElement);
   }
 
@@ -808,14 +831,16 @@ function buildNavToolsDOM(navToolsWrapper, toolsData) {
     const odometerLi = document.createElement('li');
     const odometerSpans = odometerItemTexts.map((text) => `<span>${text}</span>`).join('');
     const firstItemText = odometerItemTexts[0];
-    odometerLi.innerHTML = sanitizeHTML(`
+    const odometerLiHtml = `
       <div class="grnt-animation-odometer">
         <div class="grnt-odometer-track">
           ${odometerSpans}
           <span>${firstItemText}</span>
         </div>
       </div>
-    `);
+    `;
+    odometerLi.innerHTML = (window.DOMPurify?.sanitize(odometerLiHtml, DOMPURIFY))
+    ?? odometerLiHtml;
     toolsUlClone.appendChild(odometerLi);
     navToolsWrapper.appendChild(toolsUlClone);
   }
@@ -998,7 +1023,10 @@ export default async function decorate(block) {
         const viewAllBtn = document.createElement('a');
         viewAllBtn.href = link.href;
         viewAllBtn.classList.add('nav-view-all-btn');
-        viewAllBtn.innerHTML = 'View All <span class="icon icon-arrow-right-alt"></span>';
+        viewAllBtn.textContent = 'View All';
+        const arrowSpan = document.createElement('span');
+        arrowSpan.className = 'icon icon-arrow-right-alt';
+        viewAllBtn.appendChild(arrowSpan);
         wrapper.appendChild(viewAllBtn);
         decorateIcons(viewAllBtn);
       }
@@ -1381,7 +1409,11 @@ export default async function decorate(block) {
         exploreLink = document.createElement('a');
         exploreLink.classList.add('explore-section-link');
         exploreLink.href = titleUrl;
-        exploreLink.innerHTML = `Explore ${titleText} <span class="arrow">→</span>`;
+        exploreLink.textContent = `Explore ${titleText}`;
+        const arrowSpan = document.createElement('span');
+        arrowSpan.className = 'arrow';
+        arrowSpan.textContent = '→';
+        exploreLink.appendChild(arrowSpan);
 
         // Insert before the fragment content
         const fragmentContent = section.querySelector('.nav-fragment-content');

--- a/blocks/hotspot/hotspot.js
+++ b/blocks/hotspot/hotspot.js
@@ -6,7 +6,7 @@
  * Link hotspots (#id) navigate to other hotspot blocks.
  */
 
-import { ensureDOMPurify, moveInstrumentation, sanitizeHTML } from '../../scripts/scripts.js';
+import { ensureDOMPurify, moveInstrumentation, DOMPURIFY } from '../../scripts/scripts.js';
 
 // Per-section tracking (keyed by section element)
 // Stores: { firstBlockId, firstBlockElement, maxHeight, seenFirst, contentMap }
@@ -122,8 +122,7 @@ function showInitialPanel(container, currentBlockId, skipPaddingCalculation = fa
     return;
   }
 
-  // Show the panel with the content (sanitize in case content came from dataset/cache)
-  tooltipContent.innerHTML = sanitizeHTML(panelHTML);
+  tooltipContent.innerHTML = (window.DOMPurify?.sanitize(panelHTML, DOMPURIFY)) ?? panelHTML;
   tooltipPanel.classList.add('visible');
 
   // Only calculate padding if not skipped (during transitions, fadeTransition handles this)
@@ -220,7 +219,8 @@ function showInitialPanel(container, currentBlockId, skipPaddingCalculation = fa
 
           // eslint-disable-next-line no-use-before-define
           fadeTransition(container, () => {
-            container.innerHTML = sanitizeHTML(targetContent);
+            container.innerHTML = (window.DOMPurify?.sanitize(targetContent, DOMPURIFY))
+              ?? targetContent;
             // eslint-disable-next-line no-use-before-define
             reattachHotspotListeners(container, targetId);
             showInitialPanel(container, targetId, true);
@@ -341,7 +341,7 @@ function handleGoBackLinkClick(evt, sectionData, container, reattachListeners) {
 
   transitioningContainers.add(container);
   fadeTransition(container, () => {
-    container.innerHTML = sanitizeHTML(content);
+    container.innerHTML = (window.DOMPurify?.sanitize(content, DOMPURIFY)) ?? content;
     reattachListeners(container, targetId);
     showInitialPanel(container, targetId, true);
   });
@@ -411,7 +411,7 @@ function navigateToHotspotContent(container, targetId, hotspot, reattachListener
   transitioningContainers.add(container);
   applyClickPadding(container, hotspot);
   fadeTransition(container, () => {
-    container.innerHTML = sanitizeHTML(newContent);
+    container.innerHTML = (window.DOMPurify?.sanitize(newContent, DOMPURIFY)) ?? newContent;
     reattachListeners(container, targetId);
     showInitialPanel(container, targetId, true);
   });
@@ -439,7 +439,7 @@ function setupConnectorLine(container, currentBlockId = null) {
   if (existingSvg) existingSvg.remove();
 
   // Create SVG container
-  const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+  const svg = document.createElementNS('https://www.w3.org/2000/svg', 'svg');
   svg.classList.add('hotspot-connector-svg');
   svg.style.cssText = `
     position: absolute;
@@ -598,7 +598,7 @@ function setupConnectorLine(container, currentBlockId = null) {
     }
 
     // Create line element
-    const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+    const line = document.createElementNS('https://www.w3.org/2000/svg', 'line');
     line.setAttribute('x1', x1);
     line.setAttribute('y1', y1);
     line.setAttribute('x2', x2);
@@ -607,14 +607,14 @@ function setupConnectorLine(container, currentBlockId = null) {
     line.setAttribute('stroke-width', '1');
 
     // Create small circle at the panel item end (text side)
-    const circleStart = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    const circleStart = document.createElementNS('https://www.w3.org/2000/svg', 'circle');
     circleStart.setAttribute('cx', x1);
     circleStart.setAttribute('cy', y1);
     circleStart.setAttribute('r', '3');
     circleStart.setAttribute('fill', lineColor);
 
     // Create small circle at the hotspot end
-    const circleEnd = document.createElementNS('http://www.w3.org/2000/svg', 'circle');
+    const circleEnd = document.createElementNS('https://www.w3.org/2000/svg', 'circle');
     circleEnd.setAttribute('cx', x2);
     circleEnd.setAttribute('cy', y2);
     circleEnd.setAttribute('r', '3');
@@ -669,7 +669,9 @@ function parseBlockMetadata(rows) {
     const textRow = rows[2];
     const firstCell = textRow.children[0];
     const rawHTML = firstCell ? firstCell.innerHTML?.trim() : textRow.innerHTML?.trim();
-    if (rawHTML) hotspotText = sanitizeHTML(rawHTML);
+    if (rawHTML) {
+      hotspotText = (window.DOMPurify?.sanitize(rawHTML, DOMPURIFY)) ?? rawHTML;
+    }
   }
   return { imageElement, blockId, hotspotText };
 }
@@ -693,8 +695,9 @@ function handleStandardHotspotClick(
     return;
   }
   hotspot.classList.add('active');
+  const panelItemHtml = `<div class="hotspot-panel-item">${hotspotText}</div>`;
   tooltipContent.innerHTML = hotspotText
-    ? sanitizeHTML(`<div class="hotspot-panel-item">${hotspotText}</div>`)
+    ? ((window.DOMPurify?.sanitize(panelItemHtml, DOMPURIFY)) ?? panelItemHtml)
     : '';
   tooltipPanel.classList.add('visible');
   attachGoBackHandlers(tooltipContent, container, reattachListeners);
@@ -860,7 +863,9 @@ export default async function decorate(block) {
   // Content is stored per-section to avoid conflicts between sections with same block IDs.
   // Sanitize before storing to keep contentMap safe for later innerHTML use.
   if (blockId) {
-    sectionData.contentMap.set(blockId, sanitizeHTML(container.innerHTML));
+    const stored = (window.DOMPurify?.sanitize(container.innerHTML, DOMPURIFY))
+      ?? container.innerHTML;
+    sectionData.contentMap.set(blockId, stored);
   }
 }
 
@@ -905,7 +910,8 @@ function reattachHotspotListeners(container, blockId) {
 
         if (!isActive && tooltipPanel && tooltipContent) {
           hotspot.classList.add('active');
-          tooltipContent.innerHTML = sanitizeHTML(panelHTML);
+          tooltipContent.innerHTML = (window.DOMPurify?.sanitize(panelHTML, DOMPURIFY))
+          ?? panelHTML;
           tooltipPanel.classList.add('visible');
 
           // Attach go-back handlers to any links with href starting with #

--- a/blocks/link-to-upi/link-to-upi.js
+++ b/blocks/link-to-upi/link-to-upi.js
@@ -1,4 +1,4 @@
-import { sanitizeHTML } from '../../scripts/scripts.js';
+import { DOMPURIFY } from '../../scripts/scripts.js';
 
 /**
  * Extract block-level fields from rows. Each row is a div containing a single div with content.
@@ -21,7 +21,7 @@ function parseBlockFields(rows) {
 
   return {
     title: firstCell?.textContent?.trim() || '',
-    text: sanitizeHTML(secondCell?.innerHTML || ''),
+    text: (window.DOMPurify?.sanitize(secondCell?.innerHTML || '', DOMPURIFY)) ?? (secondCell?.innerHTML || ''),
     image,
     imageAlt: fourthCell?.textContent?.trim() || '',
   };
@@ -57,7 +57,8 @@ function buildContainer(fields) {
   if (fields.text) {
     const textEl = document.createElement('div');
     textEl.className = 'link-to-upi-text';
-    textEl.innerHTML = sanitizeHTML(fields.text);
+    textEl.innerHTML = (window.DOMPurify?.sanitize(fields.text, DOMPURIFY))
+      ?? fields.text;
     container.append(textEl);
   }
 
@@ -67,6 +68,6 @@ function buildContainer(fields) {
 export default function decorate(block) {
   const rows = Array.from(block.children);
   const fields = parseBlockFields(rows);
-  block.innerHTML = sanitizeHTML('');
+  block.innerHTML = (window.DOMPurify?.sanitize('', DOMPURIFY)) ?? '';
   block.append(buildContainer(fields));
 }

--- a/blocks/modal/modal.js
+++ b/blocks/modal/modal.js
@@ -1,7 +1,7 @@
 import {
   buildBlock, decorateBlock, loadBlock, loadCSS,
 } from '../../scripts/aem.js';
-import { loadFragment, sanitizeHTML } from '../../scripts/scripts.js';
+import { loadFragment, DOMPURIFY } from '../../scripts/scripts.js';
 
 /*
   This is not a traditional block, so there is no decorate function.
@@ -260,7 +260,7 @@ function setupMayuraConnectorLines(container) {
     const existingSvg = section.querySelector('.mayura-connector-svg');
     if (existingSvg) existingSvg.remove();
 
-    const svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
+    const svg = document.createElementNS('https://www.w3.org/2000/svg', 'svg');
     svg.classList.add('mayura-connector-svg');
     svg.style.cssText = `
       position: absolute;
@@ -324,7 +324,7 @@ function setupMayuraConnectorLines(container) {
         y2 = buttonRect.top + (buttonRect.height / 2) - sectionRect.top;
       }
 
-      const line = document.createElementNS('http://www.w3.org/2000/svg', 'line');
+      const line = document.createElementNS('https://www.w3.org/2000/svg', 'line');
       line.setAttribute('x1', x1);
       line.setAttribute('y1', y1);
       line.setAttribute('x2', x2);
@@ -399,9 +399,9 @@ export async function createModal(contentNodes, options = {}) {
   closeButton.classList.add('close-button');
   closeButton.setAttribute('aria-label', 'Close');
   closeButton.type = 'button';
-  // CWE-116: sanitizeHTML uses DOMPurify (comprehensive sanitization)
-  // eslint-disable-next-line secure-coding/no-improper-sanitization -- DOMPurify via scripts.js
-  closeButton.innerHTML = sanitizeHTML('<span class="icon icon-close"></span>');
+  const closeIcon = document.createElement('span');
+  closeIcon.className = 'icon icon-close';
+  closeButton.appendChild(closeIcon);
   closeButton.addEventListener('click', () => animatedClose(dialog));
   dialog.prepend(closeButton);
 
@@ -409,7 +409,8 @@ export async function createModal(contentNodes, options = {}) {
   if (options.ctaContent) {
     const ctaWrapper = document.createElement('div');
     ctaWrapper.classList.add('modal-cta');
-    ctaWrapper.innerHTML = sanitizeHTML(options.ctaContent);
+    ctaWrapper.innerHTML = (window.DOMPurify?.sanitize(options.ctaContent, DOMPURIFY))
+      ?? options.ctaContent;
     dialog.prepend(ctaWrapper);
   }
 

--- a/blocks/table/table.js
+++ b/blocks/table/table.js
@@ -10,7 +10,7 @@ import {
   handleBackground,
   normalizeBackgroundColor,
   getColorScheme,
-  sanitizeHTML,
+  DOMPURIFY,
 } from '../../scripts/scripts.js';
 
 /**
@@ -111,6 +111,7 @@ function findDesktopMobileImages(rows, startCount) {
 
 /** Find imageAlt in next single-cell text row that is not color/boolean/px. */
 function findImageAlt(rows, startCount) {
+  // Loop is bounded: max MAX_METADATA_SCAN_ROWS iterations and early return when j >= rows.length
   // eslint-disable-next-line secure-coding/no-unchecked-loop-condition
   for (let step = 0; step < MAX_METADATA_SCAN_ROWS; step += 1) {
     const j = startCount + step;
@@ -209,13 +210,15 @@ function buildTableRows(dataRows, thead, tbody) {
       const cell = document.createElement(isHeaderRow ? 'th' : 'td');
       if (isHeaderRow) cell.setAttribute('scope', 'column');
       cell.setAttribute('colspan', '2');
-      cell.innerHTML = sanitizeHTML(firstCell.innerHTML);
+      cell.innerHTML = (window.DOMPurify?.sanitize(firstCell.innerHTML, DOMPURIFY))
+        ?? firstCell.innerHTML;
       tr.append(cell);
     } else {
       cells.forEach((cell) => {
         const td = document.createElement(isHeaderRow ? 'th' : 'td');
         if (isHeaderRow) td.setAttribute('scope', 'column');
-        td.innerHTML = sanitizeHTML(cell.innerHTML);
+        td.innerHTML = (window.DOMPurify?.sanitize(cell.innerHTML, DOMPURIFY))
+          ?? cell.innerHTML;
         tr.append(td);
       });
     }

--- a/blocks/tabs/tabs.js
+++ b/blocks/tabs/tabs.js
@@ -1,12 +1,13 @@
 // eslint-disable-next-line import/no-unresolved
 import { toClassName } from '../../scripts/aem.js';
-import { getBlockId, moveInstrumentation, sanitizeHTML } from '../../scripts/scripts.js';
+import { getBlockId, moveInstrumentation, DOMPURIFY } from '../../scripts/scripts.js';
 
 function createTabButton(block, tabpanel, tablist, index, buttonContent, buttonId) {
   const button = document.createElement('button');
   button.className = 'tabs-tab';
   button.id = buttonId;
-  button.innerHTML = sanitizeHTML(buttonContent);
+  button.innerHTML = (window.DOMPurify?.sanitize(buttonContent, DOMPURIFY))
+    ?? buttonContent;
   button.setAttribute('aria-controls', tabpanel.id);
   button.setAttribute('aria-selected', !index);
   button.setAttribute('role', 'tab');
@@ -75,7 +76,8 @@ export default async function decorate(block) {
         tabpanel,
         tablist,
         i,
-        sanitizeHTML(tabTextWrapper.innerHTML),
+        (window.DOMPurify?.sanitize(tabTextWrapper.innerHTML, DOMPURIFY))
+          ?? tabTextWrapper.innerHTML,
         `${block.id}_tab_${i}`,
       );
       tablist.append(button);
@@ -93,7 +95,8 @@ export default async function decorate(block) {
 
     tabs.forEach((tab, i) => {
       const id = toClassName(tab.textContent);
-      const buttonContent = sanitizeHTML(tab.innerHTML);
+      const raw = tab.innerHTML;
+      const buttonContent = (window.DOMPurify?.sanitize(raw, DOMPURIFY)) ?? raw;
       const tabpanel = block.children[i];
       tabpanel.className = 'tabs-panel';
       tabpanel.id = `${block.id}_tabPane_${i}`;

--- a/package-lock.json
+++ b/package-lock.json
@@ -15,6 +15,7 @@
         "enhanced-resolve": "^5.19.0",
         "eslint": "8.57.1",
         "eslint-config-airbnb-base": "15.0.0",
+        "eslint-plugin-browser-security": "^1.2.3",
         "eslint-plugin-import": "2.32.0",
         "eslint-plugin-json": "3.1.0",
         "eslint-plugin-secure-coding": "^3.1.3",
@@ -2063,6 +2064,20 @@
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.1"
+      }
+    },
+    "node_modules/eslint-plugin-browser-security": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-browser-security/-/eslint-plugin-browser-security-1.2.3.tgz",
+      "integrity": "sha512-q8fVdC0Sp0N00uMdYwByk3h8xZ+UNWb3pF0CSGka5WomIhk5+wIv9XHJVBQsJ0LWXAeafgYO285mtKDIApYnGQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@interlace/eslint-devkit": "^1.2.1",
+        "tslib": "^2.3.0"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/eslint-plugin-import": {

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "enhanced-resolve": "^5.19.0",
     "eslint": "8.57.1",
     "eslint-config-airbnb-base": "15.0.0",
+    "eslint-plugin-browser-security": "^1.2.3",
     "eslint-plugin-import": "2.32.0",
     "eslint-plugin-json": "3.1.0",
     "eslint-plugin-secure-coding": "^3.1.3",

--- a/scripts/aem.js
+++ b/scripts/aem.js
@@ -577,16 +577,8 @@ async function fetchPlaceholders(prefix = 'default') {
   return cache.get(safePrefix);
 }
 
-/**
- * Sanitize HTML before assigning to innerHTML. Uses DOMPurify when available.
- * @param {string} html - Raw HTML string
- * @returns {string} Sanitized HTML safe for insertion
- */
-export function sanitizeHTML(html) {
-  if (!html || typeof html !== 'string') return html;
-  if (!window.DOMPurify) return html;
-  return window.DOMPurify.sanitize(html, { USE_PROFILES: { html: true } });
-}
+/** DOMPurify options for HTML. Use: DOMPurify.sanitize(html, DOMPURIFY). */
+export const DOMPURIFY = { USE_PROFILES: { html: true } };
 
 /**
  * Builds a block DOM Element from a two dimensional array, string, or object
@@ -606,7 +598,9 @@ function buildBlock(blockName, content) {
       vals.forEach((val) => {
         if (val) {
           if (typeof val === 'string') {
-            colEl.innerHTML += sanitizeHTML(val);
+            colEl.innerHTML += (window.DOMPurify
+              ? window.DOMPurify.sanitize(val, DOMPURIFY)
+              : val);
           } else {
             colEl.appendChild(val);
           }

--- a/scripts/scripts.js
+++ b/scripts/scripts.js
@@ -14,13 +14,12 @@ import {
   loadCSS,
   loadScript,
   getMetadata,
-  sanitizeHTML,
+  DOMPURIFY,
   // readBlockConfig,
   toCamelCase,
 } from './aem.js';
 
-// Re-export for blocks that import from scripts.js
-export { sanitizeHTML };
+export { DOMPURIFY };
 
 // Max collection size before iteration to prevent DoS from excessive loops (CWE-400)
 const MAX_ITERATION_LIMIT = 500;
@@ -205,7 +204,7 @@ export async function loadFragment(path) {
     if (resp.ok) {
       await ensureDOMPurify();
       const main = document.createElement('main');
-      main.innerHTML = sanitizeHTML(await resp.text());
+      main.innerHTML = window.DOMPurify.sanitize(await resp.text(), DOMPURIFY);
 
       // reset base path for media to fragment base (whitelist attr to avoid prototype pollution)
       const resetAttributeBase = (tag, attr) => {

--- a/tools/sidekick/plugins/icons/icons.js
+++ b/tools/sidekick/plugins/icons/icons.js
@@ -93,7 +93,11 @@ export async function decorate(container, inputData, query) {
         const icon = res.icons[iconText];
         const card = createElement('sp-card', '', { variant: 'quiet', heading: icon.label, size: 's' });
         const cardIcon = createElement('div', 'icon', { size: 's', slot: 'preview' });
-        cardIcon.innerHTML = icon.svg;
+        const svgDoc = new DOMParser().parseFromString(icon.svg, 'image/svg+xml');
+        const svgEl = svgDoc.documentElement;
+        if (svgEl?.tagName?.toLowerCase() === 'svg') {
+          cardIcon.append(svgEl);
+        }
         card.append(cardIcon);
         iconGrid.append(card);
 


### PR DESCRIPTION
I learned of another plugin that I should have used all along, and with that I needed to rename "sanitizeHTML" to DOMPurify.sanitize() so it would be deemed a "trusted sanitizer".
In some cases, we only needed to use "textContent" instead of "innerHTML" so I didn't need to sanitize at all.

So there should be no missing functionality, just better security with our new rules in eslintrc.js.

Fix #705 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://705-innerhtml--idfc--aemsites.aem.page/


- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://705-innerhtml--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

New tickets were created for the remaining blocks that didn't get the first pass treatment.
