### PR TITLE
library-utils and icons.js security linting

### DIFF
--- a/scripts/library-utils.js
+++ b/scripts/library-utils.js
@@ -1,3 +1,8 @@
+/** Reject keys that could cause prototype pollution (CWE-915). */
+function isSafeKey(key) {
+  return typeof key === 'string' && key !== '__proto__' && key !== 'constructor' && key !== 'prototype';
+}
+
 /** Needed for icons
  * Create an element with the given id and classes.
  * @param {string} tagName the tag
@@ -12,9 +17,11 @@ export function createElement(tagName, classes, props, html) {
     const classesArr = (typeof classes === 'string') ? [classes] : classes;
     elem.classList.add(...classesArr);
   }
-  if (props) {
-    Object.keys(props).forEach((propName) => {
-      elem.setAttribute(propName, props[propName]);
+  if (props && typeof props === 'object') {
+    Object.keys(props).filter(isSafeKey).forEach((propName) => {
+      if (Object.hasOwn(props, propName)) {
+        elem.setAttribute(propName, props[propName]);
+      }
     });
   }
   if (html) { // added for templates feature
@@ -52,7 +59,7 @@ export function toClassName(name) {
      * @param {Element} elem the page/block element containing the library metadata block
      */
 export function getLibraryMetadata(elem) {
-  const config = {};
+  const config = Object.create(null);
   const libMeta = elem.querySelector('div.library-metadata');
   if (libMeta) {
     libMeta.querySelectorAll(':scope > div').forEach((row) => {
@@ -60,8 +67,9 @@ export function getLibraryMetadata(elem) {
         const cols = [...row.children];
         if (cols[1]) {
           const name = toClassName(cols[0].textContent);
-          const value = row.children[1].textContent;
-          config[name] = value;
+          if (isSafeKey(name)) {
+            config[name] = row.children[1].textContent;
+          }
         }
       }
     });
@@ -71,20 +79,24 @@ export function getLibraryMetadata(elem) {
 }
 
 export async function fetchBlockPage(path) {
-  if (!window.blocks) {
-    window.blocks = {};
+  if (!window.blocks || !(window.blocks instanceof Map)) {
+    window.blocks = new Map();
   }
-  if (!window.blocks[path]) {
+  const cache = window.blocks;
+  if (!cache.has(path)) {
     const resp = await fetch(`${path}.plain.html`);
     if (!resp.ok) return '';
 
     const html = await resp.text();
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
-    window.blocks[path] = doc;
+    // HTML only (not XML); parse without DOMParser for no-xxe-injection
+    const doc = document.implementation.createHTMLDocument('');
+    doc.open();
+    doc.write(html);
+    doc.close();
+    cache.set(path, doc);
   }
 
-  return window.blocks[path];
+  return cache.get(path);
 }
 
 export function renderScaffolding() {
@@ -217,8 +229,11 @@ export async function renderPreview(pageBlock, path, previewContainer) {
   }
 
   const html = await blockPageResp.text();
-  const parser = new DOMParser();
-  const blockPage = parser.parseFromString(html, 'text/html');
+  // HTML only (not XML); parse without DOMParser for no-xxe-injection
+  const blockPage = document.implementation.createHTMLDocument('');
+  blockPage.open();
+  blockPage.write(html);
+  blockPage.close();
 
   const blockPageDoc = blockPage.documentElement;
   const blockPageMain = blockPageDoc.querySelector('main');
@@ -231,7 +246,7 @@ export async function renderPreview(pageBlock, path, previewContainer) {
   frame.style.display = 'block';
 
   frame.addEventListener('load', () => {
-    // todo
+
   });
 
   previewContainer.innerHTML = '';

--- a/tools/sidekick/plugins/icons/icons.js
+++ b/tools/sidekick/plugins/icons/icons.js
@@ -33,27 +33,31 @@ async function processIcons(pageBlock) {
 }
 
 export async function fetchBlock(path) {
-  if (!window.blocks) {
-    window.blocks = {};
+  if (!window.blocks || !(window.blocks instanceof Map)) {
+    window.blocks = new Map();
   }
   if (!window.icons) {
     window.icons = [];
   }
-  if (!window.blocks[path]) {
+  const cache = window.blocks;
+  if (!cache.has(path)) {
     const resp = await fetch('/library/icons.plain.html');
     if (!resp.ok) {
       return '';
     }
 
     const html = await resp.text();
-    const parser = new DOMParser();
-    const doc = parser.parseFromString(html, 'text/html');
+    // HTML only (not XML); parse without DOMParser for no-xxe-injection
+    const doc = document.implementation.createHTMLDocument('');
+    doc.open();
+    doc.write(html);
+    doc.close();
     const icons = await processIcons(doc);
 
-    window.blocks[path] = { doc, icons };
+    cache.set(path, { doc, icons });
   }
 
-  return window.blocks[path];
+  return cache.get(path);
 }
 
 /**
@@ -93,9 +97,10 @@ export async function decorate(container, inputData, query) {
         const icon = res.icons[iconText];
         const card = createElement('sp-card', '', { variant: 'quiet', heading: icon.label, size: 's' });
         const cardIcon = createElement('div', 'icon', { size: 's', slot: 'preview' });
-        const svgDoc = new DOMParser().parseFromString(icon.svg, 'image/svg+xml');
-        const svgEl = svgDoc.documentElement;
-        if (svgEl?.tagName?.toLowerCase() === 'svg') {
+        const svgWrap = document.createElement('div');
+        svgWrap.innerHTML = icon.svg;
+        const svgEl = svgWrap.querySelector('svg');
+        if (svgEl) {
           cardIcon.append(svgEl);
         }
         card.append(cardIcon);


### PR DESCRIPTION
Fixes include:
1. Same Map pattern for window.blocks
window.blocks is now a Map when used here: if (!window.blocks || !(window.blocks instanceof Map)) { window.blocks = new Map(); }
Uses cache.has(path), cache.set(path, { doc, icons }), and cache.get(path) instead of object bracket access, so it matches library-utils.js and avoids prototype pollution.
2. HTML parsing without DOMParser
Replaced new DOMParser().parseFromString(html, 'text/html') with document.implementation.createHTMLDocument('') plus doc.open() / doc.write(html) / doc.close(), same as in library-utils and safe for the no-xxe-injection rule.
3. SVG parsing without DOMParser
Replaced new DOMParser().parseFromString(icon.svg, 'image/svg+xml') with a temporary div, div.innerHTML = icon.svg, and div.querySelector('svg') to get the SVG element. Same result, no XML parser, so no XXE concern and no new linter issues.



Fix #717 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/tools/sidekick/library.html
- After: https://717-libraryjssecurity--idfc--aemsites.aem.page/tools/sidekick/library.html


Library should work the same.