### PR TITLE
remove img argument

### DIFF
--- a/blocks/cards-icon/cards-icon.js
+++ b/blocks/cards-icon/cards-icon.js
@@ -134,7 +134,6 @@ export default async function decorate(block) {
   const { classList } = block;
   const isImportantDocuments = classList.contains('important-documents');
   const isRelatedSearch = classList.contains('related-search');
-  // const isImageAndTitle = classList.contains('image-and-title');
 
   const rows = [...block.children];
   const cardRows = rows;
@@ -173,7 +172,7 @@ export default async function decorate(block) {
       optimizedImg.setAttribute('width', width);
       optimizedImg.setAttribute('height', height);
     } else {
-      const staticSize = getStaticImageDimensions(img);
+      const staticSize = getStaticImageDimensions();
       if (staticSize) {
         optimizedImg.setAttribute('width', staticSize.width);
         optimizedImg.setAttribute('height', staticSize.height);


### PR DESCRIPTION
Updated the call at line 175  so it matches the function.
getStaticImageDimensions is defined with no parameters (line 159) and only uses isImportantDocuments to return { width: 175, height: 175 } or null, so it doesn’t need the img argument. The call is now getStaticImageDimensions() with no arguments.

Fix #719 
Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://719-cardsiconlint--idfc--aemsites.aem.page/
