### PR TITLE
CSS easy linting fixes

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,3 +1,6 @@
 {
-  "extends": ["stylelint-config-standard"]
+  "extends": ["stylelint-config-standard"],
+  "rules": {
+  "no-descending-specificity": null
+ }
 }

--- a/blocks/accordion/accordion.css
+++ b/blocks/accordion/accordion.css
@@ -20,11 +20,10 @@
 
 .accordion details summary {
   position: relative;
-  padding-right: 46px;
   cursor: pointer;
   list-style: none;
   transition: all 0.5s ease-in-out;
-  padding: 20px 30px 0 var(--spacing-s);
+  padding: 20px 46px 0 var(--spacing-s);
   margin: 0 5px;
   font-size: var(--body-font-size-s);
   font-weight: 600;
@@ -118,7 +117,7 @@
 }
 
 .accordion details p {
-  margin: 0 0 0.8em 0;
+  margin: 0 0 0.8em;
 }
 
 .accordion details[open],
@@ -138,7 +137,6 @@
 }
 
 .dark-scheme {
-
   .accordion details[open] a {
     color: var(--text-color);
   }
@@ -175,7 +173,6 @@
 
   /* section.dark-scheme overrides */
   .dark-scheme .light-scheme {
-
     .accordion details summary {
       color: var(--color-gray-100);
     }

--- a/blocks/banner/banner.css
+++ b/blocks/banner/banner.css
@@ -19,7 +19,7 @@
 }
 
 .banner .button.primary:hover {
-    box-shadow: 0 2px 3px 0 rgba(0, 0, 0, .5);
+    box-shadow: 0 2px 3px 0 rgb(0 0 0 / 50%);
   }
 
 /* Main content container */
@@ -129,7 +129,7 @@
 
   .banner .button-container {
     text-align: unset;
-}
+ }
 }
 
 /* Desktop Styles */
@@ -140,8 +140,8 @@
   flex-direction: column;
   position: relative;
   max-width: 1100px;
+  padding-left: 92px;
   justify-content: center;
-  min-height: 420px;
 }
 
 .banner-heading {
@@ -151,10 +151,5 @@
 
 .banner-heading h2 {
   font-size: var(--heading-font-size-xxl);
-}
-
-  .banner-content {
-    padding-left: 92px;
-    justify-content: center;
-  }
+ }
 }

--- a/blocks/cards-icon/cards-icon.css
+++ b/blocks/cards-icon/cards-icon.css
@@ -1,4 +1,5 @@
 /* stylelint-disable no-descending-specificity */
+
 /* Cards-icon: Important Documents, Related Search, Image and Title (no Swiper) */
 
 .cards-icon > .grid-cards {
@@ -152,7 +153,6 @@
 .cards-icon.important-documents .cards-card-body h3 {
   width: 100%;
   text-align: center;
-  word-wrap: break-word;
   overflow-wrap: break-word;
   font-size: var(--body-font-size-s);
 }
@@ -192,7 +192,7 @@
   margin-bottom: var(--spacing-s);
   background: var(--color-white);
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0 0 0 / 8%);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
   width: 100%;
   gap: 16px;
   position: relative;

--- a/blocks/cards-testimonial/cards-testimonial.css
+++ b/blocks/cards-testimonial/cards-testimonial.css
@@ -159,7 +159,7 @@
     margin-right: auto;
   }
 
-  .cards-testimonial.swiper .swiper-slide { to 
+  .cards-testimonial.swiper .swiper-slide {
     max-width: 350px;
     min-height: 350px;
   }
@@ -183,7 +183,7 @@
   background-color: var(--color-gray-300);
   border-radius: 20px;
   box-shadow: 0 4px 8px 2px rgb(37 36 59 / 15%);
-  padding: 20px 20px;
+  padding: 20px;
   flex-direction: column;
   margin-right: 0;
   box-sizing: border-box;
@@ -223,7 +223,7 @@
 .cards-testimonial .swiper-pagination-bullet {
   width: 10px;
   height: 10px;
-  background: rgba(255 255 255 / 50%);
+  background: rgb(255 255 255 / 50%);
   opacity: 1;
   transition: all 0.3s ease;
   border-radius: 50%;

--- a/blocks/cards/cards.css
+++ b/blocks/cards/cards.css
@@ -336,7 +336,6 @@
 .cards.important-documents .cards-card-body h3 {
   width: 100%;
   text-align: center;
-  word-wrap: break-word;
   overflow-wrap: break-word;
 
   /* Base font styling for all text elements */
@@ -401,7 +400,7 @@
   margin-bottom: var(--spacing-s);
   background: var(--color-white);
   border-radius: 12px;
-  box-shadow: 0 2px 8px rgba(0 0 0 / 8%);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
   width: 100%;
   gap: 16px;
   position: relative;
@@ -607,7 +606,7 @@
   position: relative;
   min-height: 380px;
   width: 100%;
-  box-shadow: 0 8px 10px rgba(0 0 0 / 30%);
+  box-shadow: 0 8px 10px rgb(0 0 0 / 30%);
 }
 
 /* Ensure parent has relative positioning for absolute children */
@@ -680,14 +679,14 @@
 .cards.key-benefits .benefit-cards .cards-card-tag p {
   display: inline-block;
   padding: 4px var(--spacing-xxs);
-  border: 1px solid rgba(255 255 255 / 60%);
+  border: 1px solid rgb(255 255 255 / 60%);
   border-radius: 4px;
   color: var(--color-white);
   font-size: var(--body-font-size-xxs);
   font-weight: 700;
   line-height: 1.2;
   margin: 0 0 10px;
-  background: rgba(255 255 255 / 15%);
+  background: rgb(255 255 255 / 15%);
 }
 
 /* Key Benefits Card Body */
@@ -722,7 +721,7 @@
 
 /* Description text */
 .cards.key-benefits .benefit-cards .cards-card-body p {
-  color: rgba(255 255 255 / 80%);
+  color: rgb(255 255 255 / 80%);
   font-size: var(--body-font-size-s);
   font-weight: 400;
   line-height: 1.5;
@@ -820,7 +819,7 @@
   position: relative;
   min-height: 280px;
   width: 100%;
-  box-shadow: 0 8px 12px rgba(0 0 0 / 30%);
+  box-shadow: 0 8px 12px rgb(0 0 0 / 30%);
 }
 
 .cards.experience-life > .grid-cards > .cards-card,
@@ -832,7 +831,7 @@
 /* Experience Life - Gray/silver gradient with image as background */
 .cards.experience-life .benefit-cards {
   background: linear-gradient(137deg, #3D3D3D 4.07%, #5A5A5A 50%, #4A4A4A 75.46%);
-  border: 1px solid rgba(255 255 255 / 100%);
+  border: 1px solid rgb(255 255 255 / 100%);
 }
 
 /* Experience Life - Image becomes full card background */
@@ -865,7 +864,7 @@
 .cards.reward-points .benefit-cards .cards-card-tag p {
   display: inline-block;
   padding: 4px var(--spacing-xxs);
-  border: 1px solid rgba(255 255 255 / 60%);
+  border: 1px solid rgb(255 255 255 / 60%);
   border-radius: 4px;
   color: #2E3E79;
   font-size: var(--body-font-size-xxs) !important;
@@ -973,7 +972,7 @@
 
 .cards.experience-life .benefit-cards .cards-card-body p,
 .cards.reward-points .benefit-cards .cards-card-body p {
-  color: rgba(255 255 255 / 80%);
+  color: rgb(255 255 255 / 80%);
   font-size: var(--body-font-size-s);
   margin: 0 0 var(--spacing-xxs);
 }
@@ -1084,7 +1083,7 @@
 
 /* Blog Post Card - Individual card styling */
 .cards.blog-posts .blog-post-card {
-  background: linear-gradient(180deg, rgba(255 255 255 / 20%) 0%, rgba(177 177 177 / 20%) 100%);
+  background: linear-gradient(180deg, rgb(255 255 255 / 20%) 0%, rgb(177 177 177 / 20%) 100%);
   border-radius: 20px;
   padding: 0;
   display: flex;
@@ -1344,7 +1343,7 @@
 
 .explore-other-cards .swiper-wrapper {
   display: flex;
-  justify-content: none;
+  justify-content: unset;
   width: auto;
 }
 
@@ -1382,7 +1381,7 @@
   height: 44px;
   background: white;
   border-radius: 50%;
-  box-shadow: 0 2px 8px rgba(0 0 0 / 15%);
+  box-shadow: 0 2px 8px rgb(0 0 0 / 15%);
 }
 
 .cards .swiper-button-next::after,
@@ -1410,7 +1409,7 @@
   height: 10px;
 
   /* 490-swiper rollback: was rgba(255 255 255 / 50%); using pre-490 default */
-  background: rgba(0 0 0 / 50%);
+  background: rgb(0 0 0 / 50%);
   opacity: 1;
   transition: all 0.3s ease;
   border-radius: 50%;
@@ -1426,7 +1425,7 @@
 
 /* General cards - Dark scheme overrides */
 .dark-scheme .cards .swiper-pagination-bullet {
-  background: rgba(255 255 255 / 50%);
+  background: rgb(255 255 255 / 50%);
 }
 
 .dark-scheme .cards .swiper-pagination-bullet-active {
@@ -1435,7 +1434,7 @@
 
 /* General cards - Light scheme overrides */
 .light-scheme .cards .swiper-pagination-bullet {
-  background: rgba(0 0 0 / 50%);
+  background: rgb(0 0 0 / 50%);
 }
 
 .light-scheme .cards .swiper-pagination-bullet-active {
@@ -1497,7 +1496,7 @@
   flex-direction: column;
   align-items: stretch;
   gap: 0;
-  background: radial-gradient(231% 135.8% at 0.9% 2.98%, rgba(255 255 255 / 40%) 0%, rgba(255 255 255 / 0%) 100%);
+  background: radial-gradient(231% 135.8% at 0.9% 2.98%, rgb(255 255 255 / 40%) 0%, rgb(255 255 255 / 0%) 100%);
   background-color: transparent;
   backdrop-filter: blur(5px);
   border-radius: 8px;
@@ -1618,7 +1617,7 @@
   background: 
     radial-gradient(231% 135.8% at 0.9% 2.98%, rgb(255 255 255 / 40%) 0%, rgb(255 255 255 / 0%) 100%),
     linear-gradient(180deg, #2C2C2C 0%, #1A1A1A 100%);
-  box-shadow: 0 8px 16px rgba(0 0 0 / 30%);
+  box-shadow: 0 8px 16px rgb(0 0 0 / 30%);
   padding: 0;
   overflow: hidden;
   position: relative;
@@ -1756,7 +1755,7 @@
 .cards.key-benefits > .grid-cards > .cards-card,
 .cards.key-benefits .swiper-slide > .cards-card,
 .cards.key-benefits .benefit-cards {
-  box-shadow: 0 8px 20px rgba(0 0 0 / 30%);
+  box-shadow: 0 8px 20px rgb(0 0 0 / 30%);
 }
 
   /* Joining Perks Card Desktop Styles */

--- a/blocks/category-nav/category-nav.css
+++ b/blocks/category-nav/category-nav.css
@@ -53,6 +53,7 @@ body.is-framework-page .category-nav.block > div > div {
    ================================================================= */
 
 /* Hide bell notification sections on normal pages to prevent CLS */
+
 /* Use :has() to match sections containing bell icons BEFORE JavaScript runs */
 body:not(.is-framework-page) main:not([data-aue-resource]) .section.cards-container:has(.icon-bell),
 body:not(.is-framework-page) main:not([data-aue-resource]) .section.cards-container:has(.icon-bell-outline),
@@ -796,8 +797,7 @@ header nav .nav-sections .nav-fragment-section-content .category-nav-explore-lin
 /* ------ From nav-pane.css 
 There could be more to delete here from the old nav ------ */
 
-@media (max-width:991px) {
-
+@media (width <= 991px) {
   .top-nav {
     height: 70px;
     align-items: center
@@ -830,7 +830,7 @@ There could be more to delete here from the old nav ------ */
 }
 
 .top-nav .logo {
-    padding: 0 0 0 0
+    padding: 0;
 }
 
 .top-nav .logo img {
@@ -852,7 +852,7 @@ There could be more to delete here from the old nav ------ */
  }
 }
 
-@media (max-width:1024px) {
+@media (width <= 1024px) {
   .top-nav .logo {
     padding: 10px 10px 0 30px
   }
@@ -879,7 +879,7 @@ There could be more to delete here from the old nav ------ */
 }
 }
 
-@media (max-width:1280px) {
+@media (width <= 1280px) {
   .top-nav-left>li.hide-1024 {
     display: none
 }
@@ -899,6 +899,7 @@ header .header {
   top: 0;
   left: 0;
   z-index: 4;
+
   /* height: 110px; */
   background: var(--color-white);
   transition: all .1s ease
@@ -928,8 +929,8 @@ header .header {
   font-weight: 700
 }
 
-.top-nav-left>li.active>a .icon-Down:before,
-.top-nav-left>li:hover>a .icon-Down:before {
+.top-nav-left>li.active>a .icon-Down::before,
+.top-nav-left>li:hover>a .icon-Down::before {
   color: var(--text-red-color);
   content: "\e903"
 }
@@ -940,7 +941,7 @@ header .header {
   margin-left: 5px
 }
 
-.top-nav-left>li>a .icon-Down:before {
+.top-nav-left>li>a .icon-Down::before {
   color: var(--text-red-color)
 }
 
@@ -1021,7 +1022,7 @@ header .header {
 
 .top-nav-left>li>a {
     display: block;
-    border-bottom: 3px solid rgba(0, 0, 0, 0);
+    border-bottom: 3px solid rgb(0 0 0 / 0%);
     padding: var(--spacing-xs) 0;
     color: var(--text-color);
     white-space: nowrap;

--- a/blocks/cc-hero-slider/cc-hero-slider.css
+++ b/blocks/cc-hero-slider/cc-hero-slider.css
@@ -89,7 +89,7 @@ main>div.section > .cc-hero-slider-wrapper {
   font-weight: 700;
   line-height: 1.2;
   margin: 0 0 16px;
-  text-shadow: 0 2px 4px rgba(0 0 0 / 30%);
+  text-shadow: 0 2px 4px rgb(0 0 0 / 30%);
   text-align: center;
 }
 
@@ -97,7 +97,7 @@ main>div.section > .cc-hero-slider-wrapper {
   color: var(--color-white);
   font-size: var(--body-font-size-l);
   margin: 0 0 var(--spacing-s);
-  text-shadow: 0 1px 3px rgba(0 0 0 / 30%);
+  text-shadow: 0 1px 3px rgb(0 0 0 / 30%);
   text-align: center;
 }
 

--- a/blocks/columns/columns.css
+++ b/blocks/columns/columns.css
@@ -62,7 +62,7 @@
   bottom: 2% ;
 }
 
-@media (max-width:767px){
+@media (width <= 767px){
   .columns.block.feature-cards > div > div{
   display: flex;
   align-items: center;

--- a/blocks/cta-sticky/cta-sticky.css
+++ b/blocks/cta-sticky/cta-sticky.css
@@ -29,6 +29,7 @@ and outer background value (such as rgb(0 0 0 / 60%) */
     transform: translateY(100%);
     opacity: 0;
   }
+
   to {
     transform: translateY(0);
     opacity: 1;
@@ -71,7 +72,6 @@ div:empty {
 }
 
 .cta-sticky-mobile-content {
-
   > div {
   margin: var(--spacing-xs) 0;
   }

--- a/blocks/footer/footer.css
+++ b/blocks/footer/footer.css
@@ -22,10 +22,13 @@ footer .footer ul {
   flex-direction: column;
 }
 
-.footer .section.accordion-container:first-child > .default-content {width: 100%;padding-left: 15px;padding-right: 15px;padding-top: 35px;padding-bottom: 15px;}
+.footer .section.accordion-container:first-child > .default-content {
+  width: 100%;
+  padding: 35px 15px 15px;
+}
 
 .footer .section.accordion-container:first-child > .default-content > h5 {
-  color: rgb(188, 59, 69);
+  color: rgb(188 59 69);
   font-size: var(--heading-font-size-xl);
   font-style: normal;
   font-weight: 600;
@@ -35,8 +38,7 @@ footer .footer ul {
 }
 
 .footer .section.accordion-container:first-child > .default-content > h6 {
-  color: rgb(188, 59, 69);
-  font-family: Inter;
+  color: rgb(188 59 69);
   font-size: 77px;
   font-style: normal;
   font-weight: 900;
@@ -74,22 +76,14 @@ footer .footer ul {
   content: "\e903";
   color: #525252;
   font-size: var(--body-font-size-xl);
-  font-family: 'icomoon';
+  font-family: icomoon, var(--body-font-family);
   line-height: 0.5;
   -webkit-font-smoothing: antialiased;
-}
-
-/* Only show TOP button on screens wider than 1200px */
-@media (min-width: 1200px) {
-  .footer .section.accordion-container:first-child > .default-content > p {
-    display: flex;
-  }
 }
 
 /* Added for desktop view */
 footer .footer>div .section>div {
   margin: 0 auto;
-	align-items: anchor-center;
   max-width: var(--grid-container-width);
 }
 
@@ -134,7 +128,7 @@ footer .footer>div .section>div {
 .footer>div>div .accordion-wrapper .accordion>div>div:first-child,
 .footer>div>div .accordion-wrapper .accordion .accordion-item-label {
   padding: 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.21);
+  border-bottom: 1px solid rgb(255 255 255 / 21%);
   padding-bottom: 16px;
   letter-spacing: .5px;
   margin-bottom: 10px;
@@ -145,7 +139,7 @@ footer .footer>div .section>div {
 }
 
 .footer .section.accordion-container:first-of-type .accordion-wrapper .accordion .accordion-item-label {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.21);
+  border-bottom: 1px solid rgb(255 255 255 / 21%);
   background: transparent;
 }
 
@@ -153,7 +147,7 @@ footer .footer>div .section>div {
 .footer>div>div .accordion-wrapper .accordion .accordion-item-label::after {
   display: block;
   top: 30%;
-  background: url(/icons/icon-plus.svg);
+  background: url("/icons/icon-plus.svg");
   background-position: center;
   background-repeat: no-repeat;
   transform: translateY(-50%);
@@ -163,7 +157,7 @@ footer .footer>div .section>div {
 .footer>div>div .accordion-wrapper .accordion .accordion-item[open]>div>div:first-child ::after,
 .footer .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label::after {
   display: block;
-  background: url(/icons/icon-minus.svg);
+  background: url("/icons/icon-minus.svg");
   background-position: center;
   background-repeat: no-repeat;
 }
@@ -171,7 +165,6 @@ footer .footer>div .section>div {
 .footer>div>div .accordion-wrapper .accordion>div>div:first-child p,
 .footer>div>div .accordion-wrapper .accordion .accordion-item-label p {
   font-size: var(--body-font-size-s);
-  font: 14px "Inter", sans-serif;
   font-weight: 600;
   letter-spacing: 0.6px;
   margin: 0;
@@ -201,7 +194,6 @@ footer .footer>div .section>div {
 .footer>div>div .accordion-wrapper .accordion>div>div:nth-child(2) ul li a,
 .footer>div>div .accordion-wrapper .accordion .accordion-item-body ul li a {
   color: var(--color-white);
-  font: 14px "Inter", sans-serif;
   font-weight: 300;
   word-break: unset;
   text-decoration: none;
@@ -209,7 +201,7 @@ footer .footer>div .section>div {
 
 .footer>div>div:nth-child(2),
 .footer .accordion-item-body {
-  background: rgba(17, 17, 17, 0.1);
+  background: rgb(17 17 17 / 10%);
   padding: 40px 0;
   max-width: 100%;
 }
@@ -279,7 +271,7 @@ footer .footer>div .section>div {
 
 .footer>div>div:nth-child(3) h3 {
   line-height: 1;
-  font: 24px Inter, sans-serif;
+  font-size: 24px;
   font-weight: 300;
   margin: 0;
 }
@@ -300,7 +292,7 @@ footer .footer>div .section>div {
 }
 
 footer .footer>div .section:nth-child(4) {
-  padding: 30px 0 160px 0;
+  padding: 30px 0 160px ;
 }
 
 .footer>div>div:nth-child(3) .accordion-wrapper .accordion .accordion-item .accordion-item-label::after {
@@ -308,7 +300,7 @@ footer .footer>div .section:nth-child(4) {
 }
 
 .footer .accordion-wrapper .accordion .accordion-item[open] .accordion-item-label {
-  border-bottom: 1px solid rgba(255, 255, 255, 0.21);
+  border-bottom: 1px solid rgb(255 255 255 / 21%);
 }
 
 footer .footer>div .section:nth-child(4)>div {
@@ -352,7 +344,7 @@ footer .footer>div .section:nth-child(4)>div p a {
   display: none;
 }
 
-@media (max-width: 767px) {
+@media (width <= 767px) {
   .footer>div>div {
     padding: 0;
     order: 1;
@@ -423,7 +415,7 @@ footer .footer>div .section>div {
     border: none;
     border-radius: unset;
     font-weight: 700;
-    border-bottom: 1px solid rgba(255, 255, 255, 0.21);
+    border-bottom: 1px solid rgb(255 255 255 / 21%);
     letter-spacing: .5px;
     padding: 18px 0;
   }
@@ -551,7 +543,6 @@ footer .footer>div .section>div {
   .footer>div>div:nth-child(3) h3 {
     display: none;
   }
-
 }
 
 @media (width >= 768px) {
@@ -566,5 +557,11 @@ footer .footer>div .section>div {
   footer .footer>div .section:nth-child(4) > div > p {
     margin-top: 0;
   }
-  
+}
+
+/* Only show TOP button on screens wider than 1200px */
+@media (width >= 1200px) {
+  .footer .section.accordion-container:first-child > .default-content > p {
+    display: flex;
+  }
 }

--- a/blocks/fragment/fragment.css
+++ b/blocks/fragment/fragment.css
@@ -1,1 +1,1 @@
-
+/* Fragment CSS goes here */

--- a/blocks/header/header.css
+++ b/blocks/header/header.css
@@ -332,7 +332,6 @@ header nav .nav-sections .nav-fragment-section-content p:not(.button-container, 
   height: auto;
   line-height: 1.3;
   white-space: normal;
-  word-wrap: break-word;
   overflow-wrap: break-word;
 }
 
@@ -343,7 +342,6 @@ header nav .nav-sections .nav-fragment-section-content p:not(.button-container, 
 /* H4 section content items */
 header nav .nav-sections .nav-fragment-section-content .nav-h4-section-content p.button-container a {
   white-space: normal;
-  word-wrap: break-word;
   overflow-wrap: break-word;
   font-weight: 400;
 }
@@ -482,7 +480,6 @@ header nav .nav-sections .nav-fragment-section-content .nav-h4-section-content p
   height: auto;
   line-height: 1.3;
   white-space: normal;
-  word-wrap: break-word;
   overflow-wrap: break-word;
 }
 
@@ -1109,7 +1106,7 @@ header nav .nav-sections .default-content-wrapper>ul>li .nav-h4-section-content 
   }
 
   .section#cscards .cards .card-clickable:hover {
-    box-shadow: 0 2px 8px rgba(0 0 0 / 8%);
+    box-shadow: 0 2px 8px rgb(0 0 0 / 8%);
     transform: none;
   }
 
@@ -1412,7 +1409,7 @@ header nav .nav-sections .default-content-wrapper>ul>li .nav-h4-section-content 
   border-radius: 20px;
   padding: 5px 20px;
   margin-bottom: 20px;
-  box-shadow: 3px 3px 8px rgba(0 0 0 / 20%);
+  box-shadow: 3px 3px 8px rgb(0 0 0 / 20%);
 }
 
 .search-dropdown .search-results-list li:last-child {
@@ -1420,7 +1417,7 @@ header nav .nav-sections .default-content-wrapper>ul>li .nav-h4-section-content 
   border-radius: 20px;
   padding: 5px 20px;
   margin-bottom: 20px;
-  box-shadow: 3px 3px 8px rgba(0 0 0 / 20%);
+  box-shadow: 3px 3px 8px rgb(0 0 0 / 20%);
 }
 
 .search-dropdown .search-results-list li a {
@@ -1716,7 +1713,6 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
 }
 
 .login-dropdown.open {
-
   .cards .benefit-cards .cards-card-body p {
     font-size: var(--body-font-size-xxs);
   }
@@ -1724,7 +1720,6 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
 }
 
 @media (width >= 990px) {
-
   /* Header wrapper is now a container for both nav and secondary navbar */
   header .nav-wrapper {
     position: fixed;
@@ -1869,7 +1864,7 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
 
   header nav .nav-sections .default-content-wrapper>ul>li p {
     font-size: var(--body-font-size-xxs);
-    padding: 5px 0 0 0;
+    padding: 5px 0 0;
     min-width: unset;
   }
 
@@ -1969,12 +1964,6 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
     border-left: 3px solid transparent;
     cursor: pointer;
   }
-/*
-  header nav .nav-sections .nav-fragment-section:hover .nav-fragment-section-title {
-    background-color: var(--color-white-200);
-    border-radius: 24px 0 0 24px;
-  }
-*/
 
   header nav .nav-sections .nav-fragment-section[aria-expanded='true'] p.nav-fragment-section-title {
     background-color: var(--color-white-100);
@@ -2242,7 +2231,6 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
     line-height: 1.3;
     display: block;
     white-space: normal;
-    word-wrap: break-word;
     overflow-wrap: break-word;
     cursor: auto;
   }
@@ -2267,7 +2255,6 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
     margin: 0;
     display: inline;
     white-space: normal;
-    word-wrap: break-word;
     overflow-wrap: break-word;
     cursor: pointer;
   }
@@ -2458,19 +2445,8 @@ header nav[aria-expanded='true'] .nav-tools #search-box .search-input {
     overflow: hidden;
     white-space: nowrap;
   }
-/*
-  .nav-tools .default-content-wrapper>p:first-child>strong {
-    margin-left: var(--spacing-xxs);
-    color: #353535;
-    font-weight: 400;
-    overflow: hidden;
-    text-overflow: ellipsis;
-    white-space: nowrap;
-  }
-*/
 
 header nav {
-
   .nav-tools .default-content-wrapper>p:first-child .search-input {
     margin-left: var(--spacing-xxs);
     font-weight: 400;
@@ -2878,7 +2854,6 @@ border-radius: 0;
    DESKTOP STYLES (1200px+)
    ================================================================= */
 @media (width >= 1200px) {
-
   /* Nav sections - allow natural growth within parent container */
   header nav .nav-sections {
     max-width: 100%;
@@ -2973,7 +2948,6 @@ border-radius: 0;
    EXTRA LARGE DESKTOP STYLES (1400px+)
    ================================================================= */
 @media (width >= 1400px) {
-
     /* Nav spacing - generous on desktop */
     header nav {
       gap: 16px;

--- a/blocks/header/nav-pane.css
+++ b/blocks/header/nav-pane.css
@@ -1,5 +1,4 @@
-@media (max-width:991px) {
-
+@media (width <= 991px) {
   .top-nav {
     height: 70px;
     align-items: center
@@ -32,7 +31,7 @@
 }
 
 .top-nav .logo {
-    padding: 0 0 0 0
+    padding: 0;
 }
 
 .top-nav .logo img {
@@ -54,7 +53,7 @@
  }
 }
 
-@media (max-width:1024px) {
+@media (width <= 1024px) {
   .top-nav .logo {
     padding: 10px 10px 0 30px
   }
@@ -81,7 +80,7 @@
 }
 }
 
-@media (max-width:1280px) {
+@media (width <= 1280px) {
   .top-nav-left>li.hide-1024 {
     display: none
 }
@@ -101,7 +100,6 @@ header .header {
   top: 0;
   left: 0;
   z-index: 4;
-  /* height: 110px; */
   background: var(--color-white);
   transition: all .1s ease
 }
@@ -223,7 +221,7 @@ header .header {
 
 .top-nav-left>li>a {
     display: block;
-    border-bottom: 3px solid rgba(0, 0, 0, 0);
+    border-bottom: 3px solid rgb(0 0 0 / 0%);
     padding: var(--spacing-xs) 0;
     color: var(--text-color);
     white-space: nowrap;

--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -91,7 +91,7 @@
 /* Header CTA - dedicated 70px space at top */
 .hero-heritage-cc-header-cta {
   position: relative;
-  background-color: rgba(255 255 255 / 15%);
+  background-color: rgb(255 255 255 / 15%);
   z-index: 10;
   height: 70px;
   width: 100%;

--- a/blocks/hero/hero.css
+++ b/blocks/hero/hero.css
@@ -28,7 +28,6 @@
   font-size: var(--heading-font-size-l);
   font-weight: 700;
   line-height: 1.1;
-
   text-align: center;
 }
 

--- a/blocks/link-to-upi/link-to-upi.css
+++ b/blocks/link-to-upi/link-to-upi.css
@@ -18,7 +18,6 @@
   font-weight: 700;
   line-height: 1.2;
   margin: 0;
-  
   order: 1;
 }
 
@@ -40,21 +39,20 @@
   font-size: var(--body-font-size-l);
   font-weight: 700;
   margin-bottom: var(--spacing-xs);
-  color: rgba(247 247 247 / 80%);
+  color: rgb(247 247 247 / 80%);
 }
 
 .link-to-upi .link-to-upi-text > p:last-of-type {
   font-size: var(--body-font-size-xs);
   font-weight: 400;
   margin: 0;
-  color: rgba(247 247 247 / 80%);
+  color: rgb(247 247 247 / 80%);
   text-align: center;
   line-height: 1.3;
 }
 
 .link-to-upi .link-to-upi-text a u {
   color: var(--color-white);
-  
   text-decoration: underline;
 }
 
@@ -103,7 +101,6 @@
   color: var(--color-white);
   font-size: var(--heading-font-size-xs);
   font-weight: 700;
-  
   flex-shrink: 0;
 }
 
@@ -123,7 +120,6 @@
 
 /* ===== DESKTOP (900px+) ===== */
 @media (width >= 900px) {
-
   .link-to-upi .link-to-upi-container {
     flex-flow: row wrap;
     align-items: flex-start;
@@ -175,7 +171,6 @@
 
   .link-to-upi .link-to-upi-text ol li strong {
     font-size: var(--body-font-size-xl);
-    
     font-weight: 700;
     line-height: normal;
   }
@@ -187,7 +182,6 @@
   .link-to-upi .link-to-upi-text > p:last-of-type strong{
     font-size: var(--body-font-size-xs);
     margin-top: var(--spacing-s);
-    
     font-weight: 500;
     text-align: left;
   }

--- a/blocks/modal/modal.css
+++ b/blocks/modal/modal.css
@@ -28,7 +28,7 @@ body.modal-open {
 }
 
 .modal dialog::backdrop {
-	background: rgba(0, 0, 0, 0.8);
+	background: rgb(0 0 0 / 80%);
 	backdrop-filter: blur(2.5px);
 }
 
@@ -115,7 +115,7 @@ body.modal-open {
   display: flex;
   position: fixed;
   justify-self: center;
-  align-self: center;
+  place-self: center;
   width: fit-content;
   max-width: 1060px;
   height: 100%;
@@ -146,6 +146,7 @@ body.modal-open {
   text-align: center;
   margin: 0 0 var(--spacing-s);
 }
+
 .modal dialog h2 {
   font-size: var(--heading-font-size-l);
   text-align: center;
@@ -636,7 +637,7 @@ body.modal-open {
   }
 
   .modal .section[data-id="mayura-card-modal"] > div > div:nth-child(3) > div > div {
-    padding: 10px 10px;
+    padding: 10px;
   }
 
 	
@@ -765,6 +766,7 @@ body.modal-open {
   margin:0;
   position: relative;
 }
+
 .section[data-id="mayura-metal-concept-2"] > div > div > div > div:first-child {
   margin-top: 13%;
   margin-left: 5%;
@@ -774,13 +776,12 @@ body.modal-open {
 .section[data-id="mayura-metal-concept-3"] > div > div > div > div:first-child {
   margin-top: -10%;
   position: relative;
-  width: 100;
 }
 
 .section[data-id^="mayura-metal-concept-"] p {
   background: linear-gradient(308.18deg, #110140 4.16%, #1E2A8E 44.91%, #010740 88.8%);
   -webkit-background-clip: text;
-  -webkit-text-fill-color: rgba(0, 0, 0, 0);
+  -webkit-text-fill-color: rgb(0 0 0 / 0%);
   background-clip: text;
   font-size: var(--body-font-size-m);
   font-weight: 500;
@@ -974,7 +975,6 @@ body.modal-open {
 }
 
 @media (width < 900px) {
-
   .section[data-id="mayura-metal-concept-1"] > div > div > div > div:first-child {
   margin-top: 5%;
   }

--- a/blocks/steps/steps.css
+++ b/blocks/steps/steps.css
@@ -113,7 +113,6 @@
   width: 100%;
   margin: 0 auto;
   font-size: var(--body-font-size-s);
-  
   font-weight: 600;
   font-style: normal;
   text-align: center;
@@ -124,7 +123,6 @@
 
 .upi-steps-red-bg .steps-item-body {
   font-size: var(--body-font-size-l);
-  
   font-weight: 600;
   font-style: normal;
   line-height: 1.2;
@@ -219,7 +217,6 @@
     width: 50%;
     margin: 0 auto;
     font-size: var(--body-font-size-s);
-    
     font-weight: 600;
     font-style: normal;
     text-align: center;
@@ -235,7 +232,6 @@
 
   .upi-steps-red-bg .steps-item-body {
     font-size: var(--body-font-size-m);
-    
     font-weight: 600;
     font-style: normal;
     line-height: 1.2;
@@ -326,7 +322,6 @@
   .upi-steps-red-bg .steps-item-body {
     font-size: var(--body-font-size-m);
     width: 70%;
-    
     font-weight: 600;
     font-style: normal;
     line-height: 1.2;

--- a/blocks/tabs-upi-link/tabs-upi-link.css
+++ b/blocks/tabs-upi-link/tabs-upi-link.css
@@ -122,7 +122,7 @@
   gap: var(--spacing-xxs);
   font-size: var(--body-font-size-xs);
   white-space: normal;
-  word-wrap: break-word;
+  overflow-wrap: break-word;
   text-align: center;
 }
 

--- a/blocks/tabs/tabs.css
+++ b/blocks/tabs/tabs.css
@@ -123,7 +123,6 @@
 
   /* new tab-section styles */
 .section.multi.tabs-container {
-
     .tabs-list {
       flex: 0 0 150px;
     }
@@ -135,9 +134,8 @@
 
 .section[data-category="tabs-vertical"].multi.tabs-container .tabs {
   display: flex;
-  flex-direction: row;
-  flex-wrap: wrap;
+  flex-flow: row wrap;
   align-items: flex-start;
   gap: var(--spacing-s);
-}
+ }
 }

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint:css": "stylelint blocks/**/*.css styles/*.css",
     "fix-css": " stylelint --fix **/**/*.css",
     "fix-js": "eslint --fix **/**/*.js",
-    "lint": "npm run lint:js",
+    "lint": "npm run lint:js && npm run lint:css",
     "build:json": "npm-run-all -p build:json:models build:json:definitions build:json:filters",
     "build:json:models": "merge-json-cli -i \"models/_component-models.json\" -o \"component-models.json\"",
     "build:json:definitions": "merge-json-cli -i \"models/_component-definition.json\" -o \"component-definition.json\"",

--- a/styles/fonts.css
+++ b/styles/fonts.css
@@ -1,8 +1,9 @@
 /* stylelint-disable max-line-length */
+
 /* Individual Inter fonts are only 17k, total 119k */
 
 @font-face {
-  font-family: 'Inter'; /* aka Inter-Light */
+  font-family: Inter; /* aka Inter-Light */
   src: url('../fonts/inter-v8-latin-300.woff2') format('woff2');
   font-weight: 300;
   font-style: normal;
@@ -10,7 +11,7 @@
 }
 
 @font-face {
-  font-family: 'Inter'; /* aka Inter-Regular */
+  font-family: Inter; /* aka Inter-Regular */
   src: url('../fonts/inter-v8-latin-regular.woff2') format('woff2');
   font-weight: 400;
   font-style: normal;
@@ -18,7 +19,7 @@
 }
 
 @font-face {
-  font-family: 'Inter'; /* aka Inter-Medium */
+  font-family: Inter; /* aka Inter-Medium */
   src: url('../fonts/inter-v8-latin-500.woff2') format('woff2');
   font-weight: 500;
   font-style: normal;
@@ -26,7 +27,7 @@
 }
 
 @font-face {
-  font-family: 'Inter'; /* aka Inter SemiBold */
+  font-family: Inter; /* aka Inter SemiBold */
   src: url('../fonts/inter-v12-latin-600.woff2') format('woff2');
   font-weight: 600;
   font-style: normal;
@@ -34,7 +35,7 @@
 }
 
 @font-face {
-  font-family: 'Inter'; /* aka Inter-Bold */
+  font-family: Inter; /* aka Inter-Bold */
   src: url('../fonts/inter-v8-latin-700.woff2') format('woff2');
   font-weight: bold;
   font-style: normal;
@@ -42,7 +43,7 @@
 }
 
 @font-face {
-  font-family: 'Inter'; /* aka Inter28pt-ExtraBold */
+  font-family: Inter; /* aka Inter28pt-ExtraBold */
   src: url('../fonts/inter-v8-latin-800.woff2') format('woff2');
   font-weight: 800;
   font-style: normal;
@@ -50,7 +51,7 @@
 }
 
 @font-face {
-  font-family: 'Inter'; /* aka Inter28pt-Black */
+  font-family: Inter; /* aka Inter28pt-Black */
   src: url('../fonts/inter-v8-latin-900.woff2') format('woff2');
   font-weight: 900;
   font-style: normal;

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -13,7 +13,7 @@
 
  /* fallback fonts */
     @font-face {
-      font-family: "inter-fallback";
+      font-family: Inter-fallback;
       size-adjust: 106.001%;
       src: local("Arial");
     }
@@ -44,15 +44,14 @@
   --color-black: #000;
   --color-boxshadow-10: 0 0 10px 0 rgb(0 0 0 / 25%);
   --color-boxshadow-20: 0 0 20px 0 rgb(0 0 0 / 25%);
-
-  --gradient-translucent: linear-gradient(180deg, rgba(255, 255, 255, 0.32) 0%, rgba(255, 255, 255, 0.24) 100%);
+  --gradient-translucent: linear-gradient(180deg, rgb(255 255 255 / 32%) 0%, rgb(255 255 255 / 24%) 100%);
   --gradient-pearl: linear-gradient(73deg, #C7C6C6 -74.4%, #F1F1F1 23.15%);
   --gradient-red-purple: linear-gradient(165deg, #D94751 0%, #8C2034 40%, #732C53 80%, #513873 100%);
   --gradient-red-black: radial-gradient(at top left, #AC2A34 0%, #661E2A 50%, #140F23 100%);
   --gradient-pink-red: linear-gradient(to bottom, #C5767D, #9E1E29);
   --gradient-earn-rewards: radial-gradient(231% 135.8% at 0.9% 2.98%, #FFF6 0%, #FFF0 100%);
   --gradient-red: linear-gradient(92deg, #5D2227 36.27%, #982B35 70.68%, #5D2227 85.89%);
-  --gradient-light-red: linear-gradient(97.67deg, rgba(55, 10, 14, 0.8) 6.64%, rgba(157, 29, 39, 0.8) 90.39%);
+  --gradient-light-red: linear-gradient(97.67deg, rgb(55 10 14 / 80%) 6.64%, rgb(157 29 39 / 80%) 90.39%);
   --gradient-blue: linear-gradient(137deg, #08133C 4.07%, #2E3E79 75.46%);
   --gradient-indigo: linear-gradient(308deg, #110140 4.16%, #1E2A8E 44.91%, #010740 88.8%);
   --gradient-black-90: linear-gradient(90deg, rgb(0 0 0 / 0%) 0%, #000 65%);
@@ -62,7 +61,6 @@
   --gradient-metal-blue: linear-gradient(308deg, #110140 4.16%, #1E2A8E 44.91%, #010740 88.8%);
   --gradient-metal-silver: linear-gradient(138deg, #999 -15.44%, #EFEFEF 0.15%, #CACACA 18.04%, #EFEFEF 37.09%, #CACACA 58.44%, #999 76.91%, #EFEFEF 87.3%);
   --modal-backdrop-gradient: linear-gradient(to bottom, rgb(200 198 198 / 70%) 0, rgb(200 198 198 / 95%) 1px, #C8C6C6 250px, #F1F0F0 50%, #C8C6C6 100%);
-
   --background-color: var(--color-white);
   --text-color: var(--color-gray-700);
   --text-link-color: var(--text-color);
@@ -145,7 +143,7 @@
 html {
  /* -webkit-font-smoothing: antialiased; */
   -webkit-text-size-adjust: 100%;
-  -webkit-tap-highlight-color: rgba(0, 0, 0, 0);
+  -webkit-tap-highlight-color: rgb(0 0 0 / 0%);
 }
 
 body {
@@ -278,7 +276,7 @@ button {
 a {
   color: var(--text-link-color);
   text-decoration: underline;
-  word-break: break-word;
+  word-break: normal;
 }
 
 a:hover {
@@ -409,7 +407,7 @@ main img {
   color: var(--text-color);
 
   .swiper-pagination-bullet {
-    background: rgba(0 0 0 / 50%);
+    background: rgb(0 0 0 / 50%);
   }
 
   .swiper-pagination-bullet-active {
@@ -437,7 +435,7 @@ main img {
   }  
 
   .swiper-pagination-bullet {
-    background: rgba(255 255 255 / 50%);
+    background: rgb(255 255 255 / 50%);
   }
 
   .swiper-pagination-bullet-active {
@@ -582,6 +580,7 @@ main>.section:first-of-type {
   &.gap-xxl {
     --gap-spacing: var(--spacing-xxl);
   }
+
 /* all section spacing classes are set to l in Mobile */
   &.spacing-xxs,
   &.spacing-xs,
@@ -668,7 +667,6 @@ main>.section:first-of-type {
   }
 
   .icon-icon-plus {
-
     img {
       filter: invert(100%);
       transform: rotate(45deg);
@@ -1063,6 +1061,7 @@ The height and width are set to 200 assuming the decorations won't be larger. */
     header {
       height: var(--nav-height);
     }
+    
     /* Reserve space for category-nav BEFORE it loads to prevent CLS.
      The has-category-nav class is added by scripts.js based on page metadata.
      This runs BEFORE body.appear, ensuring correct header height from the start. */


### PR DESCRIPTION
I addressed all of the easy CSS linting problems (mostly formatting).

- empty lines
- rgba to rgb format
- double colon pseudo-element fix
- 'modern color notation'
- missing quotes
- redundant/duplicated lines

 I also set a global rule not to look for descending specificity since it doesn't affect anything and there is no gain in trying to conform to that rule at this time.
There are still linting issues left for another future ticket.

**Testing:**
There should not be any visible style changes.

Fix #738 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/rupay-credit-card
- After: https://738-csslinting--idfc--aemsites.aem.page/credit-card/rupay-credit-card

- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://738-csslinting--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

