### PR TITLE
new library source file

### DIFF
--- a/tools/sidekick/library-utils.js
+++ b/tools/sidekick/library-utils.js
@@ -181,7 +181,7 @@ export function createElement(tagName, classes, props, html) {
       createElement('div', 'details-container', {}, [
         createElement('div', 'action-bar', {}, [
           createElement('h3', 'block-title'),
-          createElement('div', 'actions', {}),
+          createElement('div', 'actions', {}, createElement('sp-button', 'copy-button', {}, 'Copy Block')),
         ]),
         createElement('sp-divider', '', { size: 's' }),
         createElement('div', 'details'),

--- a/tools/sidekick/library.html
+++ b/tools/sidekick/library.html
@@ -28,7 +28,8 @@
 <body>
 <script
         type="module"
-        src="/scripts/sidekick-library.js"
+        src="https://www.aem.live/tools/sidekick/library/index.js"
+
 ></script>
 <script type="module">
   const library = document.createElement('sidekick-library')


### PR DESCRIPTION
When going to a direct library page link, once you clicked on a new block page, the preview wouldn't update.
<img width="776" height="720" alt="image" src="https://github.com/user-attachments/assets/be231ea7-a6e4-4a8a-81b9-9a83b4065711" />


Fix #743 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/tools/sidekick/library.html?plugin=blocks&path=/library/buttons&index=0
- After: https://743-librarycopy--idfc--aemsites.aem.page/tools/sidekick/library.html?plugin=blocks&path=/library/buttons&index=0

To test: Click on another block page from the test link and the new page contents should be showing now.
