### PR TITLE
replacing cards-icon with updated json

### DIFF
--- a/blocks/cards-icon/_cards-icon.json
+++ b/blocks/cards-icon/_cards-icon.json
@@ -1,104 +1,94 @@
 {
-  "definitions": [
-    {
-      "title": "Cards with Icon",
-      "id": "cards-icon",
-      "plugins": {
-        "xwalk": {
-          "page": {
-            "resourceType": "core/franklin/components/block/v1/block",
-            "template": {
-              "name": "cards-icon",
-              "model": "cards-icon",
-              "filter": "cards-icon"
+    "definitions": [
+      {
+        "title": "Cards with Icon",
+        "id": "cards-icon",
+        "plugins": {
+          "xwalk": {
+            "page": {
+              "resourceType": "core/franklin/components/block/v1/block",
+              "template": {
+                "name": "cards-icon",
+                "model": "cards-icon",
+                "filter": "cards-icon"
+              }
+            }
+          }
+        }
+      },
+      {
+        "title": "Card Icon",
+        "id": "card-icon",
+        "plugins": {
+          "xwalk": {
+            "page": {
+              "resourceType": "core/franklin/components/block/v1/block/item",
+              "template": {
+                "name": "Card Icon",
+                "model": "card-icon"
+              }
             }
           }
         }
       }
-    },
-    {
-      "title": "Card",
-      "id": "card-icon-item",
-      "plugins": {
-        "xwalk": {
-          "page": {
-            "resourceType": "core/franklin/components/block/v1/block/item",
-            "template": {
-              "name": "Card",
-              "model": "card-icon-item"
-            }
+    ],
+    "models": [
+      {
+        "id": "cards-icon",
+        "fields": [
+          {
+            "component": "select",
+            "name": "classes",
+            "label": "Style",
+            "options": [
+             {
+                "name": "Image on left, no border/bg",
+                "value": "image-left"
+              },
+              {
+                "name": "Image on top (Imp. Docs)",
+                "value": "important-documents"
+              },
+              {
+                "name": "Image on left w/ arrow (Related Search)",
+                "value": "related-search"
+              }
+            ]
           }
-        }
+        ]
+      },
+      {
+        "id": "card-icon",
+        "fields": [
+          {
+            "component": "reference",
+            "valueType": "string",
+            "name": "image",
+            "label": "Image",
+            "multi": false
+          },
+          {
+            "component": "text",
+            "name": "imageAlt",
+            "label": "Alt Text"
+          },
+          {
+            "component": "richtext",
+            "name": "text",
+            "value": "",
+            "label": "Text",
+            "valueType": "string"
+          },
+          {
+            "component": "aem-content",
+            "name": "cardlink",
+            "label": "Card Link",
+            "valueType": "string"
+          }
+        ]
       }
-    }
-  ],
-  "models": [
-    {
-      "id": "cards-icon",
-      "fields": [
-        {
-          "component": "select",
-          "name": "classes",
-          "label": "Style",
-          "options": [
-            {
-              "name": "Important Documents",
-              "value": "important-documents"
-            },
-            {
-              "name": "Related Search",
-              "value": "related-search"
-            },
-            {
-              "name": "Image and Title",
-              "value": "image-and-title"
-            }
-          ]
-        }
-      ]
-    },
-    {
-      "id": "card-icon-item",
-      "fields": [
-        {
-          "component": "reference",
-          "valueType": "string",
-          "name": "image",
-          "label": "Image",
-          "multi": false
-        },
-        {
-          "component": "text",
-          "name": "imageAlt",
-          "label": "Alt Text"
-        },
-        {
-          "component": "text",
-          "name": "card-tag",
-          "label": "Card Tag (optional)"
-        },
-        {
-          "component": "richtext",
-          "name": "card_text",
-          "value": "",
-          "label": "Text",
-          "valueType": "string"
-        },
-        {
-          "component": "aem-content",
-          "name": "card_link",
-          "label": "Card Link (optional)",
-          "valueType": "string"
-        },
-        {
-          "component": "text",
-          "name": "card_linkText",
-          "label": "Card Link Text (optional)"
-        }
-      ]
-    }
-  ],
-  "filters": [
-    { "id": "cards-icon", "components": ["card-icon-item"] }
-  ]
-}
+    ],
+    "filters": [
+      { "id": "cards-icon", "components": ["card-icon"] }
+    ]
+  }

--- a/blocks/cards-icon/cards-icon.css
+++ b/blocks/cards-icon/cards-icon.css
@@ -1,80 +1,13 @@
-/* Cards-icon: Important Documents, Related Search, Image and Title (no Swiper) */
+/* =================================================================
+   CARDS-ICON BLOCK
+   Simpler icon-card block for three layout variants:
+     - image-left        : icon on left, no border/background
+     - important-documents : icon on top, grid of white-bg cards
+     - related-search    : icon on left with right-arrow indicator
+   Mobile-first.
+   ================================================================= */
 
-.cards-icon > .grid-cards {
-  list-style: none;
-  margin: 0;
-  padding: 0;
-}
-
-.cards-icon .grid-cards {
-  display: flex;
-  flex-wrap: wrap;
-  gap: 2rem;
-  list-style: none;
-  padding: 0;
-  margin: 0;
-}
-
-.cards-icon .grid-cards > .cards-card {
-  background-color: transparent;
-}
-
-.cards-icon .cards-card-image {
-  line-height: 0;
-}
-
-.cards-icon .grid-cards > .cards-card img {
-  width: 100%;
-  object-fit: cover;
-  border-radius: 6px;
-}
-
-/* Benefit cards (used by related-search) */
-.cards-icon .benefit-cards {
-  display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: var(--spacing-xxs);
-  margin-bottom: 0;
-  width: 100%;
-  border-radius: 8px;
-  background: var(--color-white);
-  box-shadow: 0 0 8px 0 rgb(37 36 59 / 15%);
-  box-sizing: border-box;
-  transition: all 0.3s ease;
-}
-
-.cards-icon .benefit-cards .cards-card-image img {
-  width: 120px;
-  height: auto;
-  vertical-align: middle;
-  border-radius: 4px;
-  object-fit: cover;
-}
-
-.cards-icon .benefit-cards .cards-card-body {
-  flex: 1;
-  margin: var(--spacing-xs) 0;
-}
-
-.cards-icon .benefit-cards .cards-card-body h3 {
-  color: var(--text-color);
-  font-size: var(--body-font-size-s);
-  font-weight: 600;
-  margin: 0 0 var(--spacing-xxs);
-}
-
-.cards-icon .benefit-cards .cards-card-body p {
-  color: var(--text-color);
-  font-size: var(--body-font-size-xs);
-  font-weight: 300;
-  margin: 0;
-}
-
-.cards-icon .card-clickable {
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
-}
+/* --- Shared utilities --- */
 
 .cards-icon .sr-only {
   position: absolute;
@@ -88,23 +21,121 @@
   border: 0;
 }
 
-/* === IMPORTANT DOCUMENTS === */
+/* --- Base grid reset --- */
+
+.cards-icon .cards-icon-grid {
+  margin: 0;
+  padding: 0;
+}
+
+/* --- Shared image defaults --- */
+
+.cards-icon .cards-icon-image {
+  line-height: 0;
+  flex-shrink: 0;
+}
+
+.cards-icon .cards-icon-image img {
+  object-fit: contain;
+  border-radius: 0;
+}
+
+/* --- Clickable card interaction --- */
+
+.cards-icon .cards-icon-clickable {
+  cursor: pointer;
+  transition: transform 0.2s ease, box-shadow 0.2s ease;
+}
+
+.cards-icon .cards-icon-clickable:hover {
+  transform: translateY(-2px);
+}
+
+/* =================================================================
+   IMAGE-LEFT VARIANT
+   Icon on left, text on right, no card border or background.
+   ================================================================= */
+
+.cards-icon.image-left .cards-icon-grid {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.cards-icon.image-left .cards-icon-card {
+  display: flex;
+  flex-direction: row;
+  align-items: flex-start;
+  gap: 0.75rem;
+  width: 100%;
+  background: transparent;
+  border: none;
+  box-sizing: border-box;
+}
+
+.cards-icon.image-left .cards-icon-image {
+  width: 48px;
+  height: 48px;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cards-icon.image-left .cards-icon-image img {
+  width: 48px;
+  height: 48px;
+}
+
+.cards-icon.image-left .cards-icon-body {
+  flex: 1;
+  min-width: 0;
+}
+
+.cards-icon.image-left .cards-icon-body h3 {
+  color: var(--text-color);
+  font-size: var(--body-font-size-s);
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0 0 4px;
+}
+
+.cards-icon.image-left .cards-icon-body p {
+  color: var(--text-color);
+  font-size: var(--body-font-size-xs);
+  font-weight: 400;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.cards-icon.image-left .cards-icon-body a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.cards-icon.image-left .cards-icon-clickable:hover {
+  box-shadow: none;
+  transform: none;
+  opacity: 0.85;
+}
+
+/* =================================================================
+   IMPORTANT-DOCUMENTS VARIANT
+   Icon on top, centered text, white card with shadow, grid layout.
+   ================================================================= */
+
 .cards-icon.important-documents {
   margin: var(--spacing-s) 0;
 }
 
-.cards-icon.important-documents .grid-cards {
+.cards-icon.important-documents .cards-icon-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 16px;
   padding: 0;
   margin-bottom: var(--spacing-m);
-  margin-left: auto;
-  margin-right: auto;
 }
 
-.cards-icon.important-documents .cards-card,
-.cards-icon.important-documents .important-documents-card {
+.cards-icon.important-documents .cards-icon-card {
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -117,17 +148,10 @@
   min-height: 140px;
   justify-content: flex-start;
   position: relative;
+  box-sizing: border-box;
 }
 
-.cards-icon.important-documents .important-documents-card-link {
-  align-items: center;
-  width: 100%;
-  height: 100%;
-  text-decoration: none;
-  color: inherit;
-}
-
-.cards-icon.important-documents .cards-card-image {
+.cards-icon.important-documents .cards-icon-image {
   width: 100%;
   display: flex;
   justify-content: center;
@@ -135,30 +159,45 @@
   margin-bottom: 4px;
 }
 
-.cards-icon.important-documents .cards-card-image img {
+.cards-icon.important-documents .cards-icon-image img {
   width: 64px;
   height: 64px;
   object-fit: contain;
-  border-radius: 0;
 }
 
-.cards-icon.important-documents .cards-card-body p,
-.cards-icon.important-documents .cards-card-body h3 {
+.cards-icon.important-documents .cards-icon-body {
+  width: 100%;
+  text-align: center;
+}
+
+.cards-icon.important-documents .cards-icon-body p,
+.cards-icon.important-documents .cards-icon-body h3 {
   width: 100%;
   text-align: center;
   overflow-wrap: break-word;
   font-size: var(--body-font-size-s);
-}
-
-.cards-icon.important-documents p {
   margin: 0;
 }
 
-.dark-scheme .cards-icon .important-documents-card {
-  color: var(--text-color);
+.cards-icon.important-documents .cards-icon-body h3 {
+  font-weight: 600;
 }
 
-/* === RELATED SEARCH === */
+.cards-icon.important-documents .cards-icon-body a {
+  color: inherit;
+  text-decoration: none;
+}
+
+.cards-icon.important-documents .cards-icon-clickable:hover {
+  box-shadow: 0 4px 12px rgb(37 36 59 / 25%);
+  transform: translateY(-2px);
+}
+
+/* =================================================================
+   RELATED-SEARCH VARIANT
+   Row cards: icon left, text middle, arrow-circle on right.
+   ================================================================= */
+
 .section:has(.cards-icon.related-search) .default-content-wrapper h2 {
   color: #54565b;
   font-size: 21px;
@@ -166,17 +205,13 @@
   margin: 0 0 var(--spacing-s);
 }
 
-.section:has(.cards-icon.related-search) .cards-icon-wrapper {
-  padding: 0 var(--spacing-xs);
-}
-
-.cards-icon.related-search .grid-cards {
+.cards-icon.related-search .cards-icon-grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 0;
 }
 
-.cards-icon.related-search .benefit-cards {
+.cards-icon.related-search .cards-icon-card {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -189,10 +224,11 @@
   width: 100%;
   gap: 16px;
   position: relative;
+  box-sizing: border-box;
   transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-.cards-icon.related-search .benefit-cards .cards-card-image {
+.cards-icon.related-search .cards-icon-image {
   flex-shrink: 0;
   width: 70px;
   height: 70px;
@@ -201,32 +237,42 @@
   justify-content: center;
 }
 
-.cards-icon.related-search .benefit-cards .cards-card-image img {
+.cards-icon.related-search .cards-icon-image img {
   width: 100%;
   height: 100%;
   object-fit: contain;
   border-radius: 4px;
 }
 
-.cards-icon.related-search .benefit-cards .cards-card-body {
+.cards-icon.related-search .cards-icon-body {
   flex: 1;
   margin: 0;
   padding-right: 40px;
+  min-width: 0;
 }
 
-.cards-icon.related-search .benefit-cards .cards-card-body h3 {
+.cards-icon.related-search .cards-icon-body h3 {
   font-size: var(--body-font-size-s);
   font-weight: 600;
   line-height: 1.4;
   margin: 0;
 }
 
-.cards-icon.related-search .benefit-cards .cards-card-body h3 a {
+.cards-icon.related-search .cards-icon-body p {
+  font-size: var(--body-font-size-xs);
+  font-weight: 400;
+  line-height: 1.5;
+  margin: 2px 0 0;
+  color: var(--text-color);
+}
+
+.cards-icon.related-search .cards-icon-body a {
   color: inherit;
   text-decoration: none;
 }
 
-.cards-icon.related-search .benefit-cards::after {
+/* Arrow circle indicator (CSS only, no JS) */
+.cards-icon.related-search .cards-icon-card::after {
   content: '';
   position: absolute;
   right: 16px;
@@ -240,227 +286,149 @@
   background-repeat: no-repeat;
   background-position: center;
   background-size: 24px 24px;
-}
-
-/* === IMAGE AND TITLE === */
-.cards-icon.image-and-title .grid-cards {
-  display: flex;
-  flex-flow: row nowrap;
-  justify-content: space-between;
-  align-items: flex-start;
-  padding: 20px 0;
-  margin: 0;
-  gap: 0;
-}
-
-.cards-icon.image-and-title .cards-card {
-  display: flex;
-  flex-direction: column;
-  align-items: center;
-  text-align: center;
-  padding: 16px 8px;
-  cursor: pointer;
-  gap: 8px;
-  flex: 1 1 0;
-  min-width: 0;
-}
-
-.cards-icon.image-and-title .cards-card:hover {
-  box-shadow: none;
-  background: transparent;
-}
-
-.cards-icon.image-and-title .cards-card-image {
-  width: 80px;
-  height: 80px;
-  display: flex;
-  align-items: center;
-  justify-content: center;
+  pointer-events: none;
   flex-shrink: 0;
 }
 
-.cards-icon.image-and-title .cards-card-image img {
-  width: 54px;
-  height: 54px;
-  object-fit: contain;
+.cards-icon.related-search .cards-icon-clickable:hover {
+  box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
+  transform: translateY(-2px);
 }
 
-.cards-icon.image-and-title .cards-card-body {
-  margin: 0;
-  padding: 0;
-  flex: 1 1 auto;
-  min-width: 0;
-}
+/* =================================================================
+   TABLET (600px+)
+   ================================================================= */
 
-.cards-icon.image-and-title .cards-card-body h3,
-.cards-icon.image-and-title .cards-card-body p {
-  font-size: 14px;
-  font-weight: 700;
-  line-height: 130%;
-  margin: 0;
-  color: var(--color-blue-800);
-}
-
-.cards-icon.image-and-title .cards-card a {
-  display: flex;
-  flex-direction: row;
-  align-items: center;
-  text-decoration: none;
-  color: inherit;
-  gap: 16px;
-}
-
-.cards-icon.image-and-title .cards-card a:hover {
-  text-decoration: none;
-}
-
-.cards-icon.image-and-title .button-container {
-  display: none;
-}
-
-.cards-icon.image-and-title .card-clickable {
-  box-shadow: none;
-  background: transparent;
-  transition: none;
-}
-
-.cards-icon.image-and-title .card-clickable:hover {
-  box-shadow: none;
-  background: transparent;
-  transform: none;
-}
-
-/* === BREAKPOINTS === */
 @media (width >= 600px) {
-  .cards-icon .benefit-cards {
-    gap: 16px;
-    width: calc(50% - 1rem);
-    box-shadow: 0 4px 8px 2px rgb(37 36 59 / 15%);
+  /* Image-left: 2-column grid */
+  .cards-icon.image-left .cards-icon-grid {
+    display: grid;
+    flex-direction: unset;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
   }
 
-  .cards-icon .benefit-cards .cards-card-image img {
-    width: 150px;
-    height: 156px;
-  }
-
-  .cards-icon.important-documents .grid-cards {
+  /* Important Documents: tighter grid, constrained width */
+  .cards-icon.important-documents .cards-icon-grid {
     gap: 10px;
-    padding: 0;
     max-width: 80%;
+    margin-left: auto;
+    margin-right: auto;
   }
 
-  .cards-icon.important-documents .cards-card,
-  .cards-icon.important-documents .important-documents-card {
+  .cards-icon.important-documents .cards-icon-card {
     padding: 20px var(--spacing-xs);
     gap: 6px;
   }
 
-  .cards-icon.important-documents .cards-card-image img {
+  .cards-icon.important-documents .cards-icon-image {
+    margin-bottom: 3px;
+  }
+
+  .cards-icon.important-documents .cards-icon-image img {
     width: 56px;
     height: 56px;
   }
 
-  .cards-icon.important-documents .cards-card-image {
-    margin-bottom: 3px;
+  /* Related Search: 2-column grid */
+  .cards-icon.related-search .cards-icon-grid {
+    grid-template-columns: repeat(2, 1fr);
+    gap: 20px 30px;
+  }
+
+  .cards-icon.related-search .cards-icon-card {
+    margin-bottom: 0;
+  }
+
+  .cards-icon.related-search .cards-icon-image {
+    width: 80px;
+    height: 70px;
   }
 
   .section:has(.cards-icon.related-search) .default-content-wrapper h2 {
     font-size: var(--heading-font-size-s);
     margin-bottom: 32px;
   }
-
-  .cards-icon.related-search .grid-cards {
-    grid-template-columns: repeat(2, 1fr);
-    gap: 20px 30px;
-  }
-
-  .cards-icon.related-search .benefit-cards {
-    margin-bottom: 0;
-  }
-
-  .cards-icon.related-search .benefit-cards .cards-card-image {
-    width: 80px;
-    height: 70px;
-  }
-
-  .cards-icon.image-and-title .cards-card {
-    gap: 12px;
-    padding: 16px 12px;
-  }
 }
 
-@media (width >= 768px) {
-  .cards-icon.image-and-title .cards-card {
-    flex-direction: row;
-    text-align: left;
-    gap: 16px;
-    padding: 16px;
-    align-items: center;
-  }
-
-  .cards-icon.image-and-title .cards-card-image img {
-    width: 80px;
-    height: 80px;
-  }
-
-  .cards-icon.image-and-title .cards-card-body h3,
-  .cards-icon.image-and-title .cards-card-body p {
-    font-size: 16px;
-  }
-}
+/* =================================================================
+   DESKTOP (900px+)
+   ================================================================= */
 
 @media (width >= 900px) {
-  .cards-icon.important-documents .grid-cards {
+  /* Image-left: 3-column grid */
+  .cards-icon.image-left .cards-icon-grid {
+    grid-template-columns: repeat(3, 1fr);
+    gap: 1.5rem;
+  }
+
+  .cards-icon.image-left .cards-icon-image {
+    width: 56px;
+    height: 56px;
+  }
+
+  .cards-icon.image-left .cards-icon-image img {
+    width: 56px;
+    height: 56px;
+  }
+
+  .cards-icon.image-left .cards-icon-body h3 {
+    font-size: var(--body-font-size-m);
+  }
+
+  /* Important Documents: 4-column fixed-size grid */
+  .cards-icon.important-documents .cards-icon-grid {
     grid-template-columns: repeat(4, 175px);
     grid-auto-rows: 175px;
     gap: 40px;
-    padding: 0;
+    max-width: unset;
     justify-content: center;
     margin-left: auto;
     margin-right: auto;
   }
 
-  .cards-icon.important-documents .cards-card,
-  .cards-icon.important-documents .important-documents-card {
+  .cards-icon.important-documents .cards-icon-card {
     width: 175px;
     height: 175px;
     padding: var(--spacing-s) 26px;
   }
 
-  .cards-icon.important-documents .cards-card-image img {
+  .cards-icon.important-documents .cards-icon-image img {
     width: 64px;
     height: 64px;
   }
 
-  .cards-icon.important-documents .cards-card-body {
+  .cards-icon.important-documents .cards-icon-body {
     flex: 1;
+    display: flex;
+    flex-direction: column;
     align-items: center;
     justify-content: center;
   }
 
+  /* Related Search: 3-column grid, constrained max-width */
   .section:has(.cards-icon.related-search) .default-content-wrapper h2 {
     font-size: var(--heading-font-size-m);
     margin-bottom: 40px;
   }
 
-  .cards-icon.related-search .grid-cards {
+  .cards-icon.related-search .cards-icon-grid {
     grid-template-columns: repeat(3, 1fr);
     gap: 20px 30px;
     max-width: 1120px;
     margin: 0 auto;
   }
 
-  .cards-icon.related-search .benefit-cards {
+  .cards-icon.related-search .cards-icon-card {
     padding: 0 20px;
-    margin-bottom: 0;
   }
 
-  .cards-icon.related-search .benefit-cards .cards-card-image {
+  .cards-icon.related-search .cards-icon-image {
     width: 90px;
     height: 75px;
   }
 
-  .cards-icon.related-search .benefit-cards .cards-card-body h3 {
-    font-size: var(--body-font-size-s);
+  .cards-icon.related-search .cards-icon-body h3 {
+    font-size: var(--body-font-size-m);
   }
 }

--- a/blocks/cards-icon/cards-icon.js
+++ b/blocks/cards-icon/cards-icon.js
@@ -2,201 +2,200 @@ import { createOptimizedPicture } from '../../scripts/aem.js';
 import { moveInstrumentation } from '../../scripts/scripts.js';
 
 /**
- * Cards-icon block: Important Documents, Related Search, and Image and Title variants only.
- * No Swiper carousel; grid layout only.
- * Card row: 6 cells - image, imageAlt, card-tag, card_text, card_link, card_linkText.
+ * Returns the first picture or img element from a cell's inner content.
+ * @param {HTMLElement} cell
+ * @returns {HTMLPictureElement|HTMLImageElement|null}
  */
-
-function getCellValue(cell) {
-  if (!cell) return '';
-  const inner = cell.querySelector('div') || cell;
-  const img = inner.querySelector?.('img') || (inner.tagName === 'IMG' ? inner : null);
-  if (img?.src) return img.src;
-  const a = inner.querySelector?.('a[href]');
-  if (a?.href) return a.href;
-  const t = inner.textContent?.trim();
-  return t || '';
-}
-
-function getCellPictureOrImg(cell) {
+function getCellPicture(cell) {
   if (!cell) return null;
   const inner = cell.querySelector('div') || cell;
-  return inner.querySelector?.('picture') || inner.querySelector?.('img') || null;
-}
-
-function appendCellContentAs(cardItem, cell, wrapperClass) {
-  const inner = cell?.querySelector('div') || cell;
-  if (!inner || !inner.children.length) return;
-  const wrap = document.createElement('div');
-  wrap.className = wrapperClass;
-  [...inner.children].forEach((child) => wrap.appendChild(child.cloneNode(true)));
-  cardItem.appendChild(wrap);
-}
-
-function appendArrowIcon(cardBody) {
-  if (cardBody.querySelector('.icon-arrow-right-white')) return;
-  const arrowP = document.createElement('p');
-  const arrowSpan = document.createElement('span');
-  arrowSpan.className = 'icon icon-arrow-right-white';
-  const arrowImg = document.createElement('img');
-  arrowImg.setAttribute('data-icon-name', 'arrow-right-white');
-  arrowImg.src = '/icons/arrow-right-white.svg';
-  arrowImg.alt = 'arrow-right-white';
-  arrowImg.loading = 'lazy';
-  arrowSpan.appendChild(arrowImg);
-  arrowP.appendChild(arrowSpan);
-  cardBody.appendChild(arrowP);
-}
-
-function setupCardInteractivity(cardItem, shouldAddArrow = false) {
-  const cardBodies = cardItem.querySelectorAll('.cards-card-body');
-  if (cardBodies.length === 0) return;
-
-  const mainBody = cardBodies[0];
-  const cardLink = cardItem.querySelector('a[href]');
-  if (!cardLink) return;
-
-  cardItem.classList.add('card-clickable');
-  cardItem.setAttribute('role', 'link');
-  cardItem.setAttribute('tabindex', '0');
-
-  const handleClick = (e) => {
-    if (e.target.closest('a')) return;
-    e.preventDefault();
-    cardLink.click();
-  };
-
-  cardItem.addEventListener('click', handleClick);
-  cardItem.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      cardLink.click();
-    }
-  });
-
-  let buttonContainer = cardLink.closest('.button-container');
-  if (!buttonContainer) {
-    buttonContainer = document.createElement('div');
-    buttonContainer.className = 'button-container';
-    cardLink.parentNode.insertBefore(buttonContainer, cardLink);
-    buttonContainer.appendChild(cardLink);
-  }
-  buttonContainer.classList.add('sr-only');
-
-  if (shouldAddArrow) appendArrowIcon(mainBody);
+  return inner.querySelector('picture') || inner.querySelector('img') || null;
 }
 
 /**
- * Builds a card from 6 cells (image, imageAlt, card-tag, card_text, card_link, card_linkText).
+ * Returns trimmed text content of a cell.
+ * @param {HTMLElement} cell
+ * @returns {string}
  */
-function buildCardFromSixCells(row) {
-  const cardItem = document.createElement('div');
-  cardItem.classList.add('cards-card');
-  moveInstrumentation(row, cardItem);
+function getCellText(cell) {
+  if (!cell) return '';
+  return (cell.querySelector('div') || cell).textContent?.trim() || '';
+}
 
-  const cells = [...row.children];
-  if (cells.length < 6) return cardItem;
+/**
+ * Returns the first anchor element from a cell.
+ * @param {HTMLElement} cell
+ * @returns {HTMLAnchorElement|null}
+ */
+function getCellLink(cell) {
+  if (!cell) return null;
+  return (cell.querySelector('div') || cell).querySelector('a[href]') || null;
+}
 
-  // cells[0]: image
-  const pic = getCellPictureOrImg(cells[0]);
-  if (pic) {
-    const imageWrap = document.createElement('div');
-    imageWrap.className = 'cards-card-image';
-    const cloned = pic.cloneNode(true);
-    const alt = (cells[1] && getCellValue(cells[1])) || '';
-    if (alt && cloned.tagName === 'IMG') cloned.alt = alt;
-    if (cloned.tagName === 'PICTURE' && cloned.querySelector('img')) {
-      cloned.querySelector('img').alt = alt;
+/**
+ * Appends a cloned picture/img into a .cards-icon-image wrapper on the card.
+ * @param {HTMLElement} cardItem
+ * @param {HTMLPictureElement|HTMLImageElement|null} pic
+ * @param {string} altText
+ */
+function appendImage(cardItem, pic, altText) {
+  if (!pic) return;
+  const wrap = document.createElement('div');
+  wrap.className = 'cards-icon-image';
+  const cloned = pic.cloneNode(true);
+  const img = cloned.tagName === 'IMG' ? cloned : cloned.querySelector('img');
+  if (img && altText) img.alt = altText;
+  wrap.appendChild(cloned);
+  cardItem.appendChild(wrap);
+}
+
+/**
+ * Appends cloned child elements from a cell into a .cards-icon-body wrapper on the card.
+ * @param {HTMLElement} cardItem
+ * @param {HTMLElement} cell
+ */
+function appendBody(cardItem, cell) {
+  if (!cell) return;
+  const inner = cell.querySelector('div') || cell;
+  if (!inner.children.length && !inner.textContent.trim()) return;
+  const wrap = document.createElement('div');
+  wrap.className = 'cards-icon-body';
+  if (inner.children.length) {
+    [...inner.children].forEach((child) => wrap.appendChild(child.cloneNode(true)));
+  } else {
+    const p = document.createElement('p');
+    p.textContent = inner.textContent.trim();
+    wrap.appendChild(p);
+  }
+  cardItem.appendChild(wrap);
+}
+
+/**
+ * Makes a card fully clickable and navigable by keyboard.
+ * Hides the original anchor visually while preserving accessibility.
+ * @param {HTMLElement} cardItem
+ * @param {HTMLAnchorElement} link
+ */
+function makeClickable(cardItem, link) {
+  if (!link?.href) return;
+  cardItem.classList.add('cards-icon-clickable');
+  cardItem.setAttribute('role', 'link');
+  cardItem.setAttribute('tabindex', '0');
+
+  // Keep the link accessible but visually hidden so the card surface is the click target
+  const btnContainer = link.closest('.button-container');
+  (btnContainer || link).classList.add('sr-only');
+
+  cardItem.addEventListener('click', (e) => {
+    if (e.target.closest('a')) return;
+    e.preventDefault();
+    window.location.href = link.href;
+  });
+  cardItem.addEventListener('keydown', (e) => {
+    if (e.key === 'Enter' || e.key === ' ') {
+      e.preventDefault();
+      window.location.href = link.href;
     }
-    imageWrap.appendChild(cloned);
-    cardItem.appendChild(imageWrap);
+  });
+}
+
+/**
+ * Builds a single card element from a table row.
+ *
+ * Supported row formats (from authoring):
+ *   4-cell (UE): image | imageAlt | text | cardlink
+ *   2-cell (doc): image | text  (link embedded in text cell)
+ *   1-cell: text only (link embedded)
+ *
+ * @param {HTMLElement} row
+ * @returns {HTMLElement|null}
+ */
+function buildCard(row) {
+  const cells = [...row.children];
+  if (!cells.length) return null;
+
+  const cardItem = document.createElement('div');
+  cardItem.classList.add('cards-icon-card');
+  moveInstrumentation(row, cardItem);
+  cardItem.removeAttribute('data-aue-prop');
+  cardItem.setAttribute('data-aue-type', 'container');
+  cardItem.setAttribute('data-aue-label', 'Card');
+
+  let link;
+  if (cells.length >= 4) {
+    // UE format: image | imageAlt | text | cardlink
+    appendImage(cardItem, getCellPicture(cells[0]), getCellText(cells[1]));
+    appendBody(cardItem, cells[2]);
+    link = getCellLink(cells[3]) || cardItem.querySelector('a[href]');
+  } else if (cells.length >= 2) {
+    // Document format: image | content (link may be embedded in content)
+    appendImage(cardItem, getCellPicture(cells[0]), '');
+    appendBody(cardItem, cells[1]);
+    link = cardItem.querySelector('a[href]');
+  } else {
+    // Single cell: all content together
+    appendBody(cardItem, cells[0]);
+    link = cardItem.querySelector('a[href]');
   }
-  // cells[2]: card-tag
-  appendCellContentAs(cardItem, cells[2], 'cards-card-tag');
-  // cells[3]: card_text (main body)
-  appendCellContentAs(cardItem, cells[3], 'cards-card-body');
-  // cells[4]: card_link, cells[5]: card_linkText (optional override)
-  const linkEl = (cells[4]?.querySelector('div') || cells[4])?.querySelector?.('a[href]');
-  const linkTextOverride = cells[5] ? getCellValue(cells[5]) : '';
-  if (linkEl && linkEl.href) {
-    const btnWrap = document.createElement('p');
-    btnWrap.className = 'button-container';
-    const a = linkEl.cloneNode(true);
-    if (linkTextOverride) a.textContent = linkTextOverride;
-    btnWrap.appendChild(a);
-    const body = cardItem.querySelector('.cards-card-body');
-    (body || cardItem).appendChild(btnWrap);
-  }
+
+  makeClickable(cardItem, link);
   return cardItem;
 }
 
-export default async function decorate(block) {
-  const { classList } = block;
-  const isImportantDocuments = classList.contains('important-documents');
-  const isRelatedSearch = classList.contains('related-search');
-
-  const rows = [...block.children];
-  const cardRows = rows;
-
-  const cardsContainer = document.createElement('div');
-  cardsContainer.classList.add('grid-cards');
-
-  cardRows.forEach((row, rowIndex) => {
-    const numCells = row.querySelectorAll(':scope > div').length || row.children.length;
-    if (numCells === 6) {
-      const cardItem = buildCardFromSixCells(row);
-      cardsContainer.append(cardItem);
-    } else {
-      // eslint-disable-next-line no-console
-      console.error(
-        'Cards-icon block: card row has unexpected number of cells (expected 6, got %d). Row index: %d.',
-        numCells,
-        rowIndex,
-      );
-    }
-  });
-
-  const getStaticImageDimensions = () => {
-    if (isImportantDocuments) return { width: 175, height: 175 };
-    return null;
-  };
-
-  cardsContainer.querySelectorAll('picture > img').forEach((img) => {
+/**
+ * Replaces raw <picture> elements with optimized variants via createOptimizedPicture.
+ * @param {HTMLElement} container
+ */
+function optimizeImages(container) {
+  container.querySelectorAll('picture > img').forEach((img) => {
     const optimizedPic = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
     const optimizedImg = optimizedPic.querySelector('img');
     moveInstrumentation(img, optimizedImg);
-
-    const width = img.getAttribute('width');
-    const height = img.getAttribute('height');
-    if (width && height) {
-      optimizedImg.setAttribute('width', width);
-      optimizedImg.setAttribute('height', height);
-    } else {
-      const staticSize = getStaticImageDimensions();
-      if (staticSize) {
-        optimizedImg.setAttribute('width', staticSize.width);
-        optimizedImg.setAttribute('height', staticSize.height);
-      }
+    const w = img.getAttribute('width');
+    const h = img.getAttribute('height');
+    if (w && h) {
+      optimizedImg.setAttribute('width', w);
+      optimizedImg.setAttribute('height', h);
     }
-
     img.closest('picture').replaceWith(optimizedPic);
   });
+}
 
-  block.replaceChildren(cardsContainer);
+/**
+ * Decorates the cards-icon block.
+ *
+ * Variants (applied as CSS classes on the block element):
+ *   image-left        – icon on left, no card border/background (default)
+ *   important-documents – icon on top, centered grid cards
+ *   related-search    – icon on left with right-side arrow indicator
+ *
+ * @param {HTMLElement} block
+ */
+export default function decorate(block) {
+  let rows = [...block.children];
 
-  const allCards = cardsContainer.querySelectorAll('.cards-card');
-
-  allCards.forEach((cardItem) => {
-    if (isImportantDocuments) {
-      cardItem.classList.add('important-documents-card');
-    } else if (isRelatedSearch) {
-      cardItem.classList.add('benefit-cards');
+  // Unwrap a single container div injected by UE (block-content / default-content wrapper)
+  if (rows.length === 1) {
+    const single = rows[0];
+    if (
+      single.classList.contains('default-content')
+      || single.classList.contains('block-content')
+    ) {
+      rows = [...single.children];
     }
-    // image-and-title: no extra card class
+  }
 
-    const shouldAddArrow = false;
-    setupCardInteractivity(cardItem, shouldAddArrow);
+  block.setAttribute('data-aue-type', 'container');
+  block.setAttribute('data-aue-label', 'Cards Icon');
+
+  const grid = document.createElement('div');
+  grid.classList.add('cards-icon-grid');
+
+  rows.forEach((row) => {
+    const card = buildCard(row);
+    if (card) grid.appendChild(card);
   });
 
-  block.append(cardsContainer);
+  optimizeImages(grid);
+  block.replaceChildren(grid);
 }

--- a/component-definition.json
+++ b/component-definition.json
@@ -215,15 +215,15 @@
           }
         },
         {
-          "title": "Card",
-          "id": "card-icon-item",
+          "title": "Card Icon",
+          "id": "card-icon",
           "plugins": {
             "xwalk": {
               "page": {
                 "resourceType": "core/franklin/components/block/v1/block/item",
                 "template": {
-                  "name": "Card",
-                  "model": "card-icon-item"
+                  "name": "Card Icon",
+                  "model": "card-icon"
                 }
               }
             }

--- a/component-filters.json
+++ b/component-filters.json
@@ -82,7 +82,7 @@
   {
     "id": "cards-icon",
     "components": [
-      "card-icon-item"
+      "card-icon"
     ]
   },
   {

--- a/component-models.json
+++ b/component-models.json
@@ -1094,23 +1094,23 @@
         "label": "Style",
         "options": [
           {
-            "name": "Important Documents",
+            "name": "Image on left, no border/bg",
+            "value": "image-left"
+          },
+          {
+            "name": "Image on top (Imp. Docs)",
             "value": "important-documents"
           },
           {
-            "name": "Related Search",
+            "name": "Image on left w/ arrow (Related Search)",
             "value": "related-search"
-          },
-          {
-            "name": "Image and Title",
-            "value": "image-and-title"
           }
         ]
       }
     ]
   },
   {
-    "id": "card-icon-item",
+    "id": "card-icon",
     "fields": [
       {
         "component": "reference",
@@ -1125,27 +1125,17 @@
         "label": "Alt Text"
       },
       {
-        "component": "text",
-        "name": "card-tag",
-        "label": "Card Tag (optional)"
-      },
-      {
         "component": "richtext",
-        "name": "card_text",
+        "name": "text",
         "value": "",
         "label": "Text",
         "valueType": "string"
       },
       {
         "component": "aem-content",
-        "name": "card_link",
-        "label": "Card Link (optional)",
+        "name": "cardlink",
+        "label": "Card Link",
         "valueType": "string"
-      },
-      {
-        "component": "text",
-        "name": "card_linkText",
-        "label": "Card Link Text (optional)"
       }
     ]
   },


### PR DESCRIPTION
I scrapped the earlier attempt at a new cards-icon block, this is a new version. I have to merge this in order to publish content for showing before/after.

#746 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/cards-icon
- After: https://746-cardsicon--idfc--aemsites.aem.page/cards-icon
