### PR TITLE
new cards-icon block

### DIFF
--- a/blocks/cards-icon/_cards-icon.json
+++ b/blocks/cards-icon/_cards-icon.json
@@ -46,11 +46,11 @@
                 "value": "image-left"
               },
               {
-                "name": "Image on top (Imp. Docs)",
+                "name": "Image on top (square)",
                 "value": "image-top"
               },
               {
-                "name": "Image on left w/ arrow (Related Search)",
+                "name": "Image on left w/ arrow",
                 "value": "image-left-arrow"
               }
             ]

--- a/blocks/cards-icon/_cards-icon.json
+++ b/blocks/cards-icon/_cards-icon.json
@@ -47,11 +47,11 @@
               },
               {
                 "name": "Image on top (Imp. Docs)",
-                "value": "important-documents"
+                "value": "image-top"
               },
               {
                 "name": "Image on left w/ arrow (Related Search)",
-                "value": "related-search"
+                "value": "image-left-arrow"
               }
             ]
           }

--- a/blocks/cards-icon/cards-icon.css
+++ b/blocks/cards-icon/cards-icon.css
@@ -2,33 +2,20 @@
    CARDS-ICON BLOCK
    Simpler icon-card block for three layout variants:
      - image-left        : icon on left, no border/background
-     - important-documents : icon on top, grid of white-bg cards
-     - related-search    : icon on left with right-arrow indicator
+     - image-top          : icon on top, grid of white-bg cards
+     - image-left-arrow   : icon on left with right-arrow indicator
    Mobile-first.
    ================================================================= */
-
-/* --- Shared utilities --- */
-
-.cards-icon .sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip-path: rect(0 0 0 0);
-  white-space: nowrap;
-  border: 0;
-}
-
-/* --- Base grid reset --- */
 
 .cards-icon .cards-icon-grid {
   margin: 0;
   padding: 0;
 }
 
-/* --- Shared image defaults --- */
+.cards-icon .cards-icon-card-link {
+  display: block;
+  text-decoration: none;
+}
 
 .cards-icon .cards-icon-image {
   line-height: 0;
@@ -40,15 +27,23 @@
   border-radius: 0;
 }
 
-/* --- Clickable card interaction --- */
-
-.cards-icon .cards-icon-clickable {
-  cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+.cards-icon .cards-icon-body h3 {
+  font-size: var(--body-font-size-s);
+  font-weight: 600;
+  line-height: 1.4;
+  margin: 0;
 }
 
-.cards-icon .cards-icon-clickable:hover {
-  transform: translateY(-2px);
+.cards-icon .cards-icon-body p {
+  font-size: var(--body-font-size-xs);
+  font-weight: 400;
+  line-height: 1.5;
+  margin: 0;
+}
+
+.cards-icon .cards-icon-card:focus-visible {
+  outline: 1px solid var(--text-color);
+  outline-offset: 1px;
 }
 
 /* =================================================================
@@ -57,33 +52,33 @@
    ================================================================= */
 
 .cards-icon.image-left .cards-icon-grid {
-  display: flex;
-  flex-direction: column;
-  gap: 0.75rem;
+  display: grid;
+  grid-template-columns: repeat(3, 1fr);
+  gap: 4px;
 }
 
 .cards-icon.image-left .cards-icon-card {
   display: flex;
-  flex-direction: row;
-  align-items: flex-start;
-  gap: 0.75rem;
-  width: 100%;
-  background: transparent;
-  border: none;
-  box-sizing: border-box;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  text-align: center;
+  margin-top: var(--spacing-s);
 }
 
 .cards-icon.image-left .cards-icon-image {
-  width: 48px;
-  height: 48px;
+  flex-shrink: 0;
+  width: 70px;
+  height: 70px;
   display: flex;
   align-items: center;
   justify-content: center;
 }
 
 .cards-icon.image-left .cards-icon-image img {
-  width: 48px;
-  height: 48px;
+  width: 100%;
+  height: 100%;
+  object-fit: contain;
 }
 
 .cards-icon.image-left .cards-icon-body {
@@ -92,30 +87,17 @@
 }
 
 .cards-icon.image-left .cards-icon-body h3 {
-  color: var(--text-color);
-  font-size: var(--body-font-size-s);
   font-weight: 600;
   line-height: 1.4;
-  margin: 0 0 4px;
 }
 
-.cards-icon.image-left .cards-icon-body p {
-  color: var(--text-color);
-  font-size: var(--body-font-size-xs);
-  font-weight: 400;
-  line-height: 1.5;
-  margin: 0;
-}
-
-.cards-icon.image-left .cards-icon-body a {
-  color: inherit;
+.cards-icon.image-left a h3 {
+  color: var(--color-purple-800);
   text-decoration: none;
 }
 
-.cards-icon.image-left .cards-icon-clickable:hover {
-  box-shadow: none;
-  transform: none;
-  opacity: 0.85;
+.dark-scheme .cards-icon.image-left a.cards-icon-link {
+  color: var(--color-white);
 }
 
 /* =================================================================
@@ -123,11 +105,11 @@
    Icon on top, centered text, white card with shadow, grid layout.
    ================================================================= */
 
-.cards-icon.important-documents {
+.cards-icon.image-top {
   margin: var(--spacing-s) 0;
 }
 
-.cards-icon.important-documents .cards-icon-grid {
+.cards-icon.image-top .cards-icon-grid {
   display: grid;
   grid-template-columns: repeat(2, 1fr);
   gap: 16px;
@@ -135,14 +117,15 @@
   margin-bottom: var(--spacing-m);
 }
 
-.cards-icon.important-documents .cards-icon-card {
+.cards-icon.image-top .cards-icon-card {
   display: flex;
   flex-direction: column;
   align-items: center;
   padding: 16px 10px;
-  background: var(--color-white);
-  border-radius: 8px;
-  box-shadow: 0 0 8px 0 rgb(37 36 59 / 15%);
+  background: var(--gradient-earn-rewards);
+  box-shadow: none;
+  border: 1px var(--text-color) solid;
+  border-radius: 12px;
   width: 100%;
   gap: 10px;
   min-height: 140px;
@@ -151,7 +134,7 @@
   box-sizing: border-box;
 }
 
-.cards-icon.important-documents .cards-icon-image {
+.cards-icon.image-top .cards-icon-image {
   width: 100%;
   display: flex;
   justify-content: center;
@@ -159,38 +142,32 @@
   margin-bottom: 4px;
 }
 
-.cards-icon.important-documents .cards-icon-image img {
+.cards-icon.image-top .cards-icon-image img {
   width: 64px;
   height: 64px;
   object-fit: contain;
 }
 
-.cards-icon.important-documents .cards-icon-body {
+.cards-icon.image-top .cards-icon-body {
   width: 100%;
   text-align: center;
 }
 
-.cards-icon.important-documents .cards-icon-body p,
-.cards-icon.important-documents .cards-icon-body h3 {
+.cards-icon.image-top .cards-icon-body p,
+.cards-icon.image-top .cards-icon-body h3 {
   width: 100%;
   text-align: center;
   overflow-wrap: break-word;
-  font-size: var(--body-font-size-s);
   margin: 0;
 }
 
-.cards-icon.important-documents .cards-icon-body h3 {
+.cards-icon.image-top .cards-icon-body h3 {
   font-weight: 600;
 }
 
-.cards-icon.important-documents .cards-icon-body a {
+.cards-icon.image-top .cards-icon-body a {
   color: inherit;
   text-decoration: none;
-}
-
-.cards-icon.important-documents .cards-icon-clickable:hover {
-  box-shadow: 0 4px 12px rgb(37 36 59 / 25%);
-  transform: translateY(-2px);
 }
 
 /* =================================================================
@@ -198,20 +175,13 @@
    Row cards: icon left, text middle, arrow-circle on right.
    ================================================================= */
 
-.section:has(.cards-icon.related-search) .default-content-wrapper h2 {
-  color: #54565b;
-  font-size: 21px;
-  font-weight: 600;
-  margin: 0 0 var(--spacing-s);
-}
-
-.cards-icon.related-search .cards-icon-grid {
+.cards-icon.image-left-arrow .cards-icon-grid {
   display: grid;
   grid-template-columns: 1fr;
   gap: 0;
 }
 
-.cards-icon.related-search .cards-icon-card {
+.cards-icon.image-left-arrow .cards-icon-card {
   display: flex;
   flex-direction: row;
   align-items: center;
@@ -228,7 +198,7 @@
   transition: box-shadow 0.2s ease, transform 0.2s ease;
 }
 
-.cards-icon.related-search .cards-icon-image {
+.cards-icon.image-left-arrow .cards-icon-image {
   flex-shrink: 0;
   width: 70px;
   height: 70px;
@@ -237,28 +207,21 @@
   justify-content: center;
 }
 
-.cards-icon.related-search .cards-icon-image img {
+.cards-icon.image-left-arrow .cards-icon-image img {
   width: 100%;
   height: 100%;
   object-fit: contain;
   border-radius: 4px;
 }
 
-.cards-icon.related-search .cards-icon-body {
+.cards-icon.image-left-arrow .cards-icon-body {
   flex: 1;
   margin: 0;
   padding-right: 40px;
   min-width: 0;
 }
 
-.cards-icon.related-search .cards-icon-body h3 {
-  font-size: var(--body-font-size-s);
-  font-weight: 600;
-  line-height: 1.4;
-  margin: 0;
-}
-
-.cards-icon.related-search .cards-icon-body p {
+.cards-icon.image-left-arrow .cards-icon-body p {
   font-size: var(--body-font-size-xs);
   font-weight: 400;
   line-height: 1.5;
@@ -266,13 +229,18 @@
   color: var(--text-color);
 }
 
-.cards-icon.related-search .cards-icon-body a {
+.cards-icon.image-left-arrow .cards-icon-body a {
   color: inherit;
   text-decoration: none;
 }
 
+.cards-icon.image-left-arrow a h3:hover {
+  color: var(--color-red-400);
+  text-decoration: none;
+}
+
 /* Arrow circle indicator (CSS only, no JS) */
-.cards-icon.related-search .cards-icon-card::after {
+.cards-icon.image-left-arrow .cards-icon-card::after {
   content: '';
   position: absolute;
   right: 16px;
@@ -290,7 +258,7 @@
   flex-shrink: 0;
 }
 
-.cards-icon.related-search .cards-icon-clickable:hover {
+.cards-icon.image-left-arrow .cards-icon-clickable:hover {
   box-shadow: 0 4px 12px rgb(0 0 0 / 15%);
   transform: translateY(-2px);
 }
@@ -300,105 +268,82 @@
    ================================================================= */
 
 @media (width >= 600px) {
-  /* Image-left: 2-column grid */
-  .cards-icon.image-left .cards-icon-grid {
-    display: grid;
-    flex-direction: unset;
-    grid-template-columns: repeat(2, 1fr);
-    gap: 1rem;
+  .cards-icon.image-left .cards-icon-card {
+    flex-direction: row;
+    text-align: left;
+    gap: var(--spacing-s); 
   }
 
   /* Important Documents: tighter grid, constrained width */
-  .cards-icon.important-documents .cards-icon-grid {
-    gap: 10px;
+  .cards-icon.image-top .cards-icon-grid {
+    gap: var(--spacing-xs) var(--spacing-s);
     max-width: 80%;
     margin-left: auto;
     margin-right: auto;
   }
 
-  .cards-icon.important-documents .cards-icon-card {
+  .cards-icon.image-top .cards-icon-card {
     padding: 20px var(--spacing-xs);
     gap: 6px;
   }
 
-  .cards-icon.important-documents .cards-icon-image {
+  .cards-icon.image-top .cards-icon-image {
     margin-bottom: 3px;
   }
 
-  .cards-icon.important-documents .cards-icon-image img {
+  .cards-icon.image-top .cards-icon-image img {
     width: 56px;
     height: 56px;
   }
 
   /* Related Search: 2-column grid */
-  .cards-icon.related-search .cards-icon-grid {
+  .cards-icon.image-left-arrow .cards-icon-grid {
     grid-template-columns: repeat(2, 1fr);
     gap: 20px 30px;
   }
 
-  .cards-icon.related-search .cards-icon-card {
+  .cards-icon.image-left-arrow .cards-icon-card {
     margin-bottom: 0;
   }
 
-  .cards-icon.related-search .cards-icon-image {
+  .cards-icon.image-left-arrow .cards-icon-image {
     width: 80px;
     height: 70px;
   }
-
-  .section:has(.cards-icon.related-search) .default-content-wrapper h2 {
-    font-size: var(--heading-font-size-s);
-    margin-bottom: 32px;
-  }
 }
 
-/* =================================================================
-   DESKTOP (900px+)
-   ================================================================= */
-
 @media (width >= 900px) {
-  /* Image-left: 3-column grid */
+  .cards-icon.image-top .cards-icon-body h3 {
+    font-size: var(--body-font-size-xs);
+  }
+
   .cards-icon.image-left .cards-icon-grid {
     grid-template-columns: repeat(3, 1fr);
     gap: 1.5rem;
   }
 
-  .cards-icon.image-left .cards-icon-image {
-    width: 56px;
-    height: 56px;
-  }
-
-  .cards-icon.image-left .cards-icon-image img {
-    width: 56px;
-    height: 56px;
-  }
-
-  .cards-icon.image-left .cards-icon-body h3 {
-    font-size: var(--body-font-size-m);
-  }
-
   /* Important Documents: 4-column fixed-size grid */
-  .cards-icon.important-documents .cards-icon-grid {
+  .cards-icon.image-top .cards-icon-grid {
     grid-template-columns: repeat(4, 175px);
     grid-auto-rows: 175px;
-    gap: 40px;
-    max-width: unset;
-    justify-content: center;
+    max-width: 900px;
+    justify-content: space-between;
     margin-left: auto;
     margin-right: auto;
   }
 
-  .cards-icon.important-documents .cards-icon-card {
+  .cards-icon.image-top .cards-icon-card {
     width: 175px;
     height: 175px;
     padding: var(--spacing-s) 26px;
   }
 
-  .cards-icon.important-documents .cards-icon-image img {
+  .cards-icon.image-top .cards-icon-image img {
     width: 64px;
     height: 64px;
   }
 
-  .cards-icon.important-documents .cards-icon-body {
+  .cards-icon.image-top .cards-icon-body {
     flex: 1;
     display: flex;
     flex-direction: column;
@@ -407,28 +352,15 @@
   }
 
   /* Related Search: 3-column grid, constrained max-width */
-  .section:has(.cards-icon.related-search) .default-content-wrapper h2 {
+  .section:has(.cards-icon.image-left-arrow) .default-content-wrapper h2 {
     font-size: var(--heading-font-size-m);
     margin-bottom: 40px;
   }
 
-  .cards-icon.related-search .cards-icon-grid {
+  .cards-icon.image-left-arrow .cards-icon-grid {
     grid-template-columns: repeat(3, 1fr);
-    gap: 20px 30px;
+    gap: 20px;
     max-width: 1120px;
     margin: 0 auto;
-  }
-
-  .cards-icon.related-search .cards-icon-card {
-    padding: 0 20px;
-  }
-
-  .cards-icon.related-search .cards-icon-image {
-    width: 90px;
-    height: 75px;
-  }
-
-  .cards-icon.related-search .cards-icon-body h3 {
-    font-size: var(--body-font-size-m);
   }
 }

--- a/blocks/cards-icon/cards-icon.css
+++ b/blocks/cards-icon/cards-icon.css
@@ -20,6 +20,7 @@
 .cards-icon .cards-icon-image {
   line-height: 0;
   flex-shrink: 0;
+  height: 70px;
 }
 
 .cards-icon .cards-icon-image img {
@@ -69,7 +70,6 @@
 .cards-icon.image-left .cards-icon-image {
   flex-shrink: 0;
   width: 70px;
-  height: 70px;
   display: flex;
   align-items: center;
   justify-content: center;
@@ -84,11 +84,6 @@
 .cards-icon.image-left .cards-icon-body {
   flex: 1;
   min-width: 0;
-}
-
-.cards-icon.image-left .cards-icon-body h3 {
-  font-weight: 600;
-  line-height: 1.4;
 }
 
 .cards-icon.image-left a h3 {
@@ -107,6 +102,7 @@
 
 .cards-icon.image-top {
   margin: var(--spacing-s) 0;
+  min-height: 175px;
 }
 
 .cards-icon.image-top .cards-icon-grid {
@@ -201,7 +197,6 @@
 .cards-icon.image-left-arrow .cards-icon-image {
   flex-shrink: 0;
   width: 70px;
-  height: 70px;
   display: flex;
   align-items: center;
   justify-content: center;

--- a/blocks/cards-icon/cards-icon.js
+++ b/blocks/cards-icon/cards-icon.js
@@ -2,200 +2,52 @@ import { createOptimizedPicture } from '../../scripts/aem.js';
 import { moveInstrumentation } from '../../scripts/scripts.js';
 
 /**
- * Returns the first picture or img element from a cell's inner content.
- * @param {HTMLElement} cell
- * @returns {HTMLPictureElement|HTMLImageElement|null}
- */
-function getCellPicture(cell) {
-  if (!cell) return null;
-  const inner = cell.querySelector('div') || cell;
-  return inner.querySelector('picture') || inner.querySelector('img') || null;
-}
-
-/**
- * Returns trimmed text content of a cell.
- * @param {HTMLElement} cell
- * @returns {string}
- */
-function getCellText(cell) {
-  if (!cell) return '';
-  return (cell.querySelector('div') || cell).textContent?.trim() || '';
-}
-
-/**
- * Returns the first anchor element from a cell.
- * @param {HTMLElement} cell
- * @returns {HTMLAnchorElement|null}
- */
-function getCellLink(cell) {
-  if (!cell) return null;
-  return (cell.querySelector('div') || cell).querySelector('a[href]') || null;
-}
-
-/**
- * Appends a cloned picture/img into a .cards-icon-image wrapper on the card.
- * @param {HTMLElement} cardItem
- * @param {HTMLPictureElement|HTMLImageElement|null} pic
- * @param {string} altText
- */
-function appendImage(cardItem, pic, altText) {
-  if (!pic) return;
-  const wrap = document.createElement('div');
-  wrap.className = 'cards-icon-image';
-  const cloned = pic.cloneNode(true);
-  const img = cloned.tagName === 'IMG' ? cloned : cloned.querySelector('img');
-  if (img && altText) img.alt = altText;
-  wrap.appendChild(cloned);
-  cardItem.appendChild(wrap);
-}
-
-/**
- * Appends cloned child elements from a cell into a .cards-icon-body wrapper on the card.
- * @param {HTMLElement} cardItem
- * @param {HTMLElement} cell
- */
-function appendBody(cardItem, cell) {
-  if (!cell) return;
-  const inner = cell.querySelector('div') || cell;
-  if (!inner.children.length && !inner.textContent.trim()) return;
-  const wrap = document.createElement('div');
-  wrap.className = 'cards-icon-body';
-  if (inner.children.length) {
-    [...inner.children].forEach((child) => wrap.appendChild(child.cloneNode(true)));
-  } else {
-    const p = document.createElement('p');
-    p.textContent = inner.textContent.trim();
-    wrap.appendChild(p);
-  }
-  cardItem.appendChild(wrap);
-}
-
-/**
- * Makes a card fully clickable and navigable by keyboard.
- * Hides the original anchor visually while preserving accessibility.
- * @param {HTMLElement} cardItem
- * @param {HTMLAnchorElement} link
- */
-function makeClickable(cardItem, link) {
-  if (!link?.href) return;
-  cardItem.classList.add('cards-icon-clickable');
-  cardItem.setAttribute('role', 'link');
-  cardItem.setAttribute('tabindex', '0');
-
-  // Keep the link accessible but visually hidden so the card surface is the click target
-  const btnContainer = link.closest('.button-container');
-  (btnContainer || link).classList.add('sr-only');
-
-  cardItem.addEventListener('click', (e) => {
-    if (e.target.closest('a')) return;
-    e.preventDefault();
-    window.location.href = link.href;
-  });
-  cardItem.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter' || e.key === ' ') {
-      e.preventDefault();
-      window.location.href = link.href;
-    }
-  });
-}
-
-/**
- * Builds a single card element from a table row.
- *
- * Supported row formats (from authoring):
- *   4-cell (UE): image | imageAlt | text | cardlink
- *   2-cell (doc): image | text  (link embedded in text cell)
- *   1-cell: text only (link embedded)
- *
- * @param {HTMLElement} row
- * @returns {HTMLElement|null}
- */
-function buildCard(row) {
-  const cells = [...row.children];
-  if (!cells.length) return null;
-
-  const cardItem = document.createElement('div');
-  cardItem.classList.add('cards-icon-card');
-  moveInstrumentation(row, cardItem);
-  cardItem.removeAttribute('data-aue-prop');
-  cardItem.setAttribute('data-aue-type', 'container');
-  cardItem.setAttribute('data-aue-label', 'Card');
-
-  let link;
-  if (cells.length >= 4) {
-    // UE format: image | imageAlt | text | cardlink
-    appendImage(cardItem, getCellPicture(cells[0]), getCellText(cells[1]));
-    appendBody(cardItem, cells[2]);
-    link = getCellLink(cells[3]) || cardItem.querySelector('a[href]');
-  } else if (cells.length >= 2) {
-    // Document format: image | content (link may be embedded in content)
-    appendImage(cardItem, getCellPicture(cells[0]), '');
-    appendBody(cardItem, cells[1]);
-    link = cardItem.querySelector('a[href]');
-  } else {
-    // Single cell: all content together
-    appendBody(cardItem, cells[0]);
-    link = cardItem.querySelector('a[href]');
-  }
-
-  makeClickable(cardItem, link);
-  return cardItem;
-}
-
-/**
- * Replaces raw <picture> elements with optimized variants via createOptimizedPicture.
- * @param {HTMLElement} container
- */
-function optimizeImages(container) {
-  container.querySelectorAll('picture > img').forEach((img) => {
-    const optimizedPic = createOptimizedPicture(img.src, img.alt, false, [{ width: '750' }]);
-    const optimizedImg = optimizedPic.querySelector('img');
-    moveInstrumentation(img, optimizedImg);
-    const w = img.getAttribute('width');
-    const h = img.getAttribute('height');
-    if (w && h) {
-      optimizedImg.setAttribute('width', w);
-      optimizedImg.setAttribute('height', h);
-    }
-    img.closest('picture').replaceWith(optimizedPic);
-  });
-}
-
-/**
  * Decorates the cards-icon block.
- *
- * Variants (applied as CSS classes on the block element):
- *   image-left        – icon on left, no card border/background (default)
- *   important-documents – icon on top, centered grid cards
- *   related-search    – icon on left with right-side arrow indicator
+ * Expects 3 children per row: image, body, link (optional).
+ * If the third child has a URL, the card is wrapped in an <a>; the link cell is not shown.
  *
  * @param {HTMLElement} block
  */
 export default function decorate(block) {
-  let rows = [...block.children];
+  const outer = document.createElement('div');
+  outer.classList.add('cards-icon-grid');
+  [...block.children].forEach((row) => {
+    const inner = document.createElement('div');
+    inner.classList.add('cards-icon-card');
+    moveInstrumentation(row, inner);
+    while (row.firstElementChild) inner.append(row.firstElementChild);
 
-  // Unwrap a single container div injected by UE (block-content / default-content wrapper)
-  if (rows.length === 1) {
-    const single = rows[0];
-    if (
-      single.classList.contains('default-content')
-      || single.classList.contains('block-content')
-    ) {
-      rows = [...single.children];
+    // Expect 3 children: image, body, link (optional)
+    const [imageCell, bodyCell, linkCell] = inner.children;
+    if (imageCell) imageCell.className = 'cards-icon-image';
+    if (bodyCell) bodyCell.className = 'cards-icon-body';
+
+    let url = null;
+    if (linkCell) {
+      const a = linkCell.querySelector('a[href]');
+      if (a?.href) url = a.href;
+      else {
+        const text = linkCell.textContent?.trim();
+        if (text && (text.startsWith('http') || text.startsWith('/'))) url = text;
+      }
+      linkCell.remove();
     }
-  }
 
-  block.setAttribute('data-aue-type', 'container');
-  block.setAttribute('data-aue-label', 'Cards Icon');
-
-  const grid = document.createElement('div');
-  grid.classList.add('cards-icon-grid');
-
-  rows.forEach((row) => {
-    const card = buildCard(row);
-    if (card) grid.appendChild(card);
+    if (url) {
+      const anchor = document.createElement('a');
+      anchor.href = url;
+      anchor.classList.add('cards-icon-card-link');
+      anchor.appendChild(inner);
+      outer.append(anchor);
+    } else {
+      outer.append(inner);
+    }
   });
-
-  optimizeImages(grid);
-  block.replaceChildren(grid);
+  outer.querySelectorAll('picture > img').forEach((img) => {
+    const optimizedPic = createOptimizedPicture(img.src, img.alt, false, [{ width: '400' }]);
+    moveInstrumentation(img, optimizedPic.querySelector('img'));
+    img.closest('picture').replaceWith(optimizedPic);
+  });
+  block.textContent = '';
+  block.append(outer);
 }

--- a/component-models.json
+++ b/component-models.json
@@ -1099,11 +1099,11 @@
           },
           {
             "name": "Image on top (Imp. Docs)",
-            "value": "important-documents"
+            "value": "image-top"
           },
           {
             "name": "Image on left w/ arrow (Related Search)",
-            "value": "related-search"
+            "value": "image-left-arrow"
           }
         ]
       }

--- a/component-models.json
+++ b/component-models.json
@@ -1098,11 +1098,11 @@
             "value": "image-left"
           },
           {
-            "name": "Image on top (Imp. Docs)",
+            "name": "Image on top (square)",
             "value": "image-top"
           },
           {
-            "name": "Image on left w/ arrow (Related Search)",
+            "name": "Image on left w/ arrow",
             "value": "image-left-arrow"
           }
         ]

--- a/styles/styles.css
+++ b/styles/styles.css
@@ -30,6 +30,7 @@
   --color-blue-800: #2d3679;
   --color-blue-900: #182659;
   --color-purple-400: #563b80;
+  --color-purple-800: #293871;
   --color-white: #fff;
   --color-white-100: #f5f5f5;
   --color-white-200: #eee; /* #e9e9e9 */


### PR DESCRIPTION
Went back to the OOTB cards code to for these since they are much simpler that our other cards.
- They are now using generic names for the style classes:  image-left, image-top, and image-left-arrow 
- I created a new library page with the new block, but after merging I will need to author the Mayura page and then remove the redundant code that I copied from Cards.

<img width="1200" height="1087" alt="image" src="https://github.com/user-attachments/assets/e1c9c8ba-c883-4b7b-9c98-e9f6ef77fc60" />


Fix #746
Test URLs:
- Before: https://main--idfc--aemsites.aem.page/library/cards-icon
- After: https://746-cardsicon--idfc--aemsites.aem.page/library/cards-icon
