### PR TITLE
add css background instead of img

### DIFF
--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -63,7 +63,7 @@
 }
 
 /* Fees and Charges Table Specific Styles */
-.table.block#fees-and-charges {
+.section:not(.grid) .table.block#fees-and-charges {
   border-radius: var(--border-radius);
   overflow: hidden;
   filter: contrast(120%) brightness(90%);
@@ -71,12 +71,15 @@
 	linear-gradient(173deg, rgb(17 1 64 / 82%), rgb(30 42 142 / 59%)),
 	linear-gradient(189deg, rgb(113 53 113 / 52%) 20%, rgb(139 0 255 / 21%) 25%),
 	url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.19' numOctaves='6' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+
+.table-background-image {
+  mix-blend-mode: color;
+}
 }
 
 .table.block#fees-and-charges .table-background-image {
   border-radius: var(--border-radius);
   overflow: hidden;
-  mix-blend-mode: color;
 }
 
 .table.block#fees-and-charges .table-background-image picture {

--- a/blocks/table/table.css
+++ b/blocks/table/table.css
@@ -63,9 +63,20 @@
 }
 
 /* Fees and Charges Table Specific Styles */
+.table.block#fees-and-charges {
+  border-radius: var(--border-radius);
+  overflow: hidden;
+  filter: contrast(120%) brightness(90%);
+  background: 
+	linear-gradient(173deg, rgb(17 1 64 / 82%), rgb(30 42 142 / 59%)),
+	linear-gradient(189deg, rgb(113 53 113 / 52%) 20%, rgb(139 0 255 / 21%) 25%),
+	url("data:image/svg+xml,%3Csvg viewBox='0 0 300 300' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noiseFilter'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.19' numOctaves='6' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noiseFilter)'/%3E%3C/svg%3E");
+}
+
 .table.block#fees-and-charges .table-background-image {
   border-radius: var(--border-radius);
   overflow: hidden;
+  mix-blend-mode: color;
 }
 
 .table.block#fees-and-charges .table-background-image picture {
@@ -151,3 +162,8 @@
     right: 0;
   }
 }
+  
+  
+  
+  
+  


### PR DESCRIPTION
I already removed the png texture background from the table in both pages.
Compare to the live pages. 
https://www.idfcfirst.bank.in/credit-card/metal-credit-card/mayura
https://www.idfcfirst.bank.in/credit-card/metal-credit-card/ashva

<img width="1143" height="333" alt="image" src="https://github.com/user-attachments/assets/c273d6cc-9c88-4c94-9e3b-bc2bdd6742f0" />

<img width="1123" height="314" alt="image" src="https://github.com/user-attachments/assets/48df8b3a-b954-49cd-a09c-5f5ccd39b42d" />

Fix #769 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://769-svgtexture--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura

- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/ashva
- After: https://769-svgtexture--idfc--aemsites.aem.page/credit-card/metal-credit-card/ashva
