### PR TITLE
testing bg

### DIFF
--- a/blocks/hero-heritage-cc/hero-heritage-cc.css
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.css
@@ -9,6 +9,31 @@
   overflow: hidden;
 }
 
+/* LCP background layer: real img for better load priority than CSS background-image */
+.hero-heritage-cc-bg-layer {
+  position: fixed;
+  inset: 0;
+  z-index: -1;
+  overflow: hidden;
+  max-width: 100vw !important;
+}
+
+.hero-heritage-cc-bg-layer picture,
+.hero-heritage-cc-bg-layer p {
+  position: absolute;
+  inset: 0;
+  margin: 0;
+  width: 100%;
+  height: 100%;
+}
+
+.hero-heritage-cc-bg-layer img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  object-position: center center;
+}
+
 /* Decoration image - top right */
 .hero-heritage-cc-container::before {
   display: none;

--- a/blocks/hero-heritage-cc/hero-heritage-cc.js
+++ b/blocks/hero-heritage-cc/hero-heritage-cc.js
@@ -107,7 +107,7 @@ function decorateHeaderCta(block, row) {
   decorateButtons(row);
 }
 
-/** Apply background image from first picture to section (or UE preview). */
+/** Apply background image from first picture to section (or UE preview). Uses an img for LCP. */
 function applyIntroBackground(block, introContent, pictures) {
   const bgPicture = pictures[0];
   if (!bgPicture) return;
@@ -128,26 +128,36 @@ function applyIntroBackground(block, introContent, pictures) {
     bgUrl = bgUrl.replace('optimize=medium', 'optimize=large');
   }
 
-  if (bgUrl) {
-    const sectionContainer = block.closest('.section');
-    if (sectionContainer) {
-      sectionContainer.style.backgroundImage = `url(${bgUrl})`;
-      sectionContainer.style.backgroundSize = 'cover';
-      sectionContainer.style.backgroundRepeat = 'repeat';
-      sectionContainer.style.backgroundPosition = 'center center';
-      sectionContainer.style.backgroundAttachment = 'fixed';
-      const preloadLink = document.createElement('link');
-      preloadLink.rel = 'preload';
-      preloadLink.as = 'image';
-      preloadLink.href = bgUrl;
-      preloadLink.fetchPriority = 'high';
-      if (webpSource) preloadLink.type = 'image/webp';
-      document.head.appendChild(preloadLink);
-    }
+  const sectionContainer = block.closest('.section');
+  if (!sectionContainer || !bgUrl) {
+    bgPicture.remove();
+    if (bgPictureWrapper) bgPictureWrapper.remove();
+    return;
   }
 
-  bgPicture.remove();
-  if (bgPictureWrapper) bgPictureWrapper.remove();
+  /* Preload LCP image as early as possible: insert at start of head for higher priority */
+  const preloadLink = document.createElement('link');
+  preloadLink.rel = 'preload';
+  preloadLink.as = 'image';
+  preloadLink.href = bgUrl;
+  preloadLink.fetchPriority = 'high';
+  if (webpSource) preloadLink.type = 'image/webp';
+  document.head.insertBefore(preloadLink, document.head.firstChild);
+
+  /* Keep an img in the DOM as the LCP element (better than CSS background for PageSpeed) */
+  const layer = document.createElement('div');
+  layer.className = 'hero-heritage-cc-bg-layer';
+  layer.setAttribute('aria-hidden', 'true');
+  sectionContainer.insertBefore(layer, sectionContainer.firstChild);
+  if (bgPictureWrapper) {
+    layer.appendChild(bgPictureWrapper);
+  } else {
+    layer.appendChild(bgPicture);
+  }
+  if (bgImg) {
+    bgImg.setAttribute('fetchpriority', 'high');
+    bgImg.setAttribute('loading', 'eager');
+  }
 }
 
 /** Apply decoration images from pictures[1] and pictures[2] to section. */


### PR DESCRIPTION
With this change, I am seeing much better mobile scores.

Before:
<img width="857" height="848" alt="image" src="https://github.com/user-attachments/assets/8f32774b-8e04-4df1-aed2-b400cbcbc5c0" />



After:
<img width="938" height="841" alt="image" src="https://github.com/user-attachments/assets/9896443c-240c-4214-b15c-7f95edf631fb" />


Summary of changes for LCP and resource load delay:

1. Preload at the start of `<head>`
The preload link is now inserted with document.head.insertBefore(preloadLink, document.head.firstChild) instead of appendChild. The browser sees the LCP image preload earlier, which can reduce load delay.

2. Use a real `<img>` for the LCP image
The background is no longer applied only via background-image on the section. The first picture is moved into a dedicated background layer and kept in the DOM as a real `<img>` with:

fetchpriority="high" – asks the browser to prioritize this image
loading="eager" – avoids lazy-loading so it starts loading immediately
PageSpeed and other tools treat visible `<img>` elements as LCP candidates and prioritize them; CSS background images are often discovered and prioritized later. Keeping the hero image as a`n <img>` in a full-bleed layer improves the chance it’s treated as LCP and loads earlier.

3. New background layer and CSS
A div with class hero-heritage-cc-bg-layer is inserted as the first child of the section.
The first picture (and its wrapper) is moved into this layer instead of being removed.
CSS makes the layer full-viewport with position: fixed; inset: 0; z-index: -1 and the image object-fit: cover so the look matches the previous fixed, cover background.

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura
- After: https://769-svgtexture--idfc--aemsites.aem.page/credit-card/metal-credit-card/mayura


- Before: https://main--idfc--aemsites.aem.page/credit-card/metal-credit-card/ashva
- After: https://769-svgtexture--idfc--aemsites.aem.page/credit-card/metal-credit-card/ashva


<img width="1427" height="1424" alt="image" src="https://github.com/user-attachments/assets/66a56777-9449-4c34-b377-86845e808600" />
