### PR TITLE
strict-dynamic for CSP

### DIFF
--- a/404.html
+++ b/404.html
@@ -2,15 +2,20 @@
 <html>
 
 <head>
+  <meta
+  http-equiv="Content-Security-Policy"
+  content="script-src 'nonce-aem' 'strict-dynamic' 'unsafe-inline' http: https:; base-uri 'self'; object-src 'none';"
+  move-to-http-header="true"
+>
   <title>Error | IDFC FIRST Bank</title>
-  <script type="text/javascript">
+  <script nonce="aem" type="text/javascript">
     window.isErrorPage = true;
     window.errorCode = '404';
   </script>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <meta property="og:title" content="Page not found">
-  <script src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
-  <script type="module">
+  <script nonce="aem" src="/scripts/scripts.js" type="module" crossorigin="use-credentials"></script>
+  <script nonce="aem" type="module">
     import { sampleRUM } from '/scripts/aem.js';
     sampleRUM('404', { source: document.referrer });
   </script>

--- a/head.html
+++ b/head.html
@@ -1,8 +1,13 @@
+<!-- https://www.aem.live/docs/csp-strict-dynamic-cached-nonce -->
+<meta
+  http-equiv="Content-Security-Policy"
+  content="script-src 'nonce-aem' 'strict-dynamic' 'unsafe-inline' http: https:; base-uri 'self'; object-src 'none';"
+  move-to-http-header="true"
+>
 <meta name="viewport" content="width=device-width, initial-scale=1"/>
 <link rel="stylesheet" href="/scripts/swiperjs/swiper-bundle.min.css"/>
-<script src="/scripts/swiperjs/swiper-bundle.min.js"></script>
-<script src="/scripts/aem.js" type="module"></script>
-<script src="/scripts/scripts.js" type="module"></script>
+<script nonce="aem" src="/scripts/swiperjs/swiper-bundle.min.js"></script>
+<script nonce="aem" src="/scripts/aem.js" type="module"></script>
+<script nonce="aem" src="/scripts/scripts.js" type="module"></script>
 <link rel="stylesheet" href="/styles/styles.css"/>
 <meta name="urn:adobe:aue:config:preview" content="main--idfc-edge--aemsites.aem.page"/>
-<meta name="urn:adobe:aue:config:disable" content="aem-dev-login" />


### PR DESCRIPTION
Need to check in Safari
https://www.aem.live/docs/csp-strict-dynamic-cached-nonce

Fix #779 

Test URLs:
- Before: https://main--idfc--aemsites.aem.page/
- After: https://779-csp--idfc--aemsites.aem.page/
